### PR TITLE
fix: selecting account from global menu account should also send user to inbox

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.13.2",
+    "@altinn/altinn-components": "^0.13.3",
     "@digdir/designsystemet-css": "0.11.0-next.10",
     "@digdir/designsystemet-react": "1.0.0-next.15",
     "@digdir/designsystemet-theme": "1.0.0-next.14",

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -9,11 +9,12 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { type ChangeEvent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, Outlet, useSearchParams } from 'react-router-dom';
+import { Link, Outlet, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useDialogs } from '../../api/useDialogs.tsx';
 import { useParties } from '../../api/useParties.ts';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
 import { useSavedSearches } from '../../pages/SavedSearches/useSavedSearches.ts';
+import { PageRoutes } from '../../pages/routes.ts';
 import { useProfile } from '../../profile';
 import { BetaBanner } from '../BetaBanner/BetaBanner';
 import { useAuth } from '../Login/AuthContext.tsx';
@@ -36,6 +37,8 @@ export const PageLayout: React.FC = () => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { searchValue, setSearchValue, onClear } = useSearchString();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { selectedProfile, selectedParties, parties, selectedPartyIds, setSelectedPartyIds, allOrganizationsSelected } =
     useParties();
   const { dialogsByView } = useDialogs(parties);
@@ -98,10 +101,17 @@ export const PageLayout: React.FC = () => {
       accountGroups,
       accounts,
       onSelectAccount: (account: string) => {
-        if (account === 'ALL') {
-          setSelectedPartyIds([], true);
+        const allAccountsSelected = account === 'ALL';
+        const search = new URLSearchParams();
+
+        if (location.pathname === PageRoutes.inbox) {
+          setSelectedPartyIds(allAccountsSelected ? [] : [account], allAccountsSelected);
         } else {
-          setSelectedPartyIds([account], false);
+          search.append(
+            allAccountsSelected ? 'allParties' : 'party',
+            allAccountsSelected ? 'true' : encodeURIComponent(account),
+          );
+          navigate(PageRoutes.inbox + `?${search.toString()}`);
         }
       },
       changeLabel: t('layout.menu.change_account'),

--- a/packages/frontend/src/pages/Inbox/queryParams.ts
+++ b/packages/frontend/src/pages/Inbox/queryParams.ts
@@ -17,7 +17,16 @@ export const getSelectedAllPartiesFromQueryParams = (searchParams: URLSearchPara
   return searchParams.get(GlobalQueryParams.allParties) === 'true';
 };
 
-/* except current location.search and returns location.search only with GlobalQueryParams if provided in location.search  */
+/**
+ * Extracts the global search query parameters from the given search string.
+ *
+ * This function takes the current location.search string and returns a new search string
+ * containing only the global query parameters defined in GlobalQueryParams, if they are present
+ * in the original location.search string.
+ *
+ * @param {string} search - The current location.search string.
+ * @returns {string} - A new search string containing only the global query parameters, or an empty string if none are present.
+ */
 export const getGlobalSearchQueryParams = (search: string): string => {
   const searchParams = new URLSearchParams(search);
   const globalQueryParams = new URLSearchParams();

--- a/packages/frontend/tests/accessibility/axe.test.ts
+++ b/packages/frontend/tests/accessibility/axe.test.ts
@@ -1,10 +1,10 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
-import { appURL } from '..';
+import { defaultAppURL } from '..';
 
 test.describe('Axe test', () => {
   test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
 
     const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
 

--- a/packages/frontend/tests/index.ts
+++ b/packages/frontend/tests/index.ts
@@ -1,1 +1,16 @@
-export const appURL = (process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173/') + '?mock=true';
+import { PageRoutes } from '../src/pages/routes';
+
+const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173';
+const baseQueryParams = '?mock=true';
+
+export const appURLInbox = baseURL + PageRoutes.inbox + baseQueryParams;
+export const appURLDrafts = baseURL + PageRoutes.drafts + baseQueryParams;
+export const appURLBin = baseURL + PageRoutes.bin + baseQueryParams;
+export const appURLSent = baseURL + PageRoutes.sent + baseQueryParams;
+export const appURLSavedSearches = baseURL + PageRoutes.savedSearches + baseQueryParams;
+
+export const matchPathName = (currentURL: string, expectedRoute: string): boolean => {
+  return new URL(currentURL).pathname === new URL(expectedRoute).pathname;
+};
+
+export const defaultAppURL = appURLInbox;

--- a/packages/frontend/tests/stories/dateInput2024.spec.ts
+++ b/packages/frontend/tests/stories/dateInput2024.spec.ts
@@ -1,10 +1,10 @@
 import { type Page, expect, test } from '@playwright/test';
-import { appURL } from '..';
+import { defaultAppURL } from '..';
 import { MOCKED_SYS_DATE } from '../../src/mocks/data/stories/date-2024/dialogs';
 
 test.describe('Date filter, system date set 2024', () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    const dateScenarioPage = `${appURL}&playwrightId=date-2024`;
+    const dateScenarioPage = `${defaultAppURL}&playwrightId=date-2024`;
     //mock system date to keep tests consistent
     await page.clock.setFixedTime(MOCKED_SYS_DATE);
     await page.goto(dateScenarioPage);

--- a/packages/frontend/tests/stories/dialogDetails.spec.ts
+++ b/packages/frontend/tests/stories/dialogDetails.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('Dialog details', () => {
   test('Checking that opening a dialog details page shows the correct number of messages', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
     await expect(page.getByRole('menuitem', { name: 'Innboks' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: 'Innboks' }).locator('[data-color="alert"]')).toContainText('2');
 

--- a/packages/frontend/tests/stories/filter.spec.ts
+++ b/packages/frontend/tests/stories/filter.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('Testing filter bar', () => {
   test('should filter when selecting sender filter and status filter', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
 
     /* Choose Skatteetaten as sender */
     await page.getByRole('button', { name: 'Legg til filter' }).click();
@@ -41,7 +41,7 @@ test.describe('Testing filter bar', () => {
   });
 
   test('should remove filters when changing view types', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
 
     /* Choose Skatteetaten as sender */
     await page.getByRole('button', { name: 'Legg til filter' }).click();
@@ -59,7 +59,7 @@ test.describe('Testing filter bar', () => {
   });
 
   test('should keep filters when returning to a filtered inbox from ', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
 
     /* Choose Skatteetaten as sender */
     await page.getByRole('button', { name: 'Legg til filter' }).click();

--- a/packages/frontend/tests/stories/flatPartySubParty.spec.ts
+++ b/packages/frontend/tests/stories/flatPartySubParty.spec.ts
@@ -1,9 +1,9 @@
 import { type Page, expect, test } from '@playwright/test';
-import { appURL } from '..';
+import { defaultAppURL } from '..';
 
 test.describe('Flattened parties and subparties', () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    const flattenedPartiesPage = `${appURL}&playwrightId=subparty-merged-with-party`;
+    const flattenedPartiesPage = `${defaultAppURL}&playwrightId=subparty-merged-with-party`;
     await page.goto(flattenedPartiesPage);
   });
 

--- a/packages/frontend/tests/stories/inboxItemPage.spec.ts
+++ b/packages/frontend/tests/stories/inboxItemPage.spec.ts
@@ -1,5 +1,5 @@
 import { type Page, expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('InboxItemPage', () => {
   test('Check message opening, archiving and deleting', async ({ page }: { page: Page }) => {
@@ -9,7 +9,7 @@ test.describe('InboxItemPage', () => {
     const papirkurvLink = page.getByRole('menuitem', { name: 'Papirkurv' });
     const papirkurvLinkCount = papirkurvLink.locator('span:text("1")');
 
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
     await expect(page.locator('h2').filter({ hasText: /^Skatten din for 2022$/ })).toBeVisible();
     await page.getByRole('link', { name: 'Skatten din for 2022' }).click();
 

--- a/packages/frontend/tests/stories/loginPartyContext.spec.ts
+++ b/packages/frontend/tests/stories/loginPartyContext.spec.ts
@@ -1,9 +1,9 @@
 import { type Page, expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('LoginPartyContext', () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
-    const dateScenarioPage = `${appURL}&playwrightId=login-party-context`;
+    const dateScenarioPage = `${defaultAppURL}&playwrightId=login-party-context`;
     await page.goto(dateScenarioPage);
   });
 

--- a/packages/frontend/tests/stories/messageNavigation.spec.ts
+++ b/packages/frontend/tests/stories/messageNavigation.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('Message navigation', () => {
-  const pageWithMockOrganizations = `${appURL}&playwrightId=login-party-context`;
+  const pageWithMockOrganizations = `${defaultAppURL}&playwrightId=login-party-context`;
 
   test('Back button navigates correctly and saves party', async ({ page }) => {
     await page.goto(pageWithMockOrganizations);

--- a/packages/frontend/tests/stories/savedSearch.spec.ts
+++ b/packages/frontend/tests/stories/savedSearch.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('Saved search', () => {
   test('Create and deletesaved search', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
     await page.getByRole('button', { name: 'Legg til filter' }).click();
     await page.getByText('Avsender').click();
     await page.getByLabel('Fra Oslo kommune').check();
@@ -24,7 +24,7 @@ test.describe('Saved search', () => {
   });
 
   test('Saved search based on searchbar value', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
     await page.getByPlaceholder('Søk').click();
     await expect(page.getByPlaceholder('Søk')).toBeVisible();
     await page.getByPlaceholder('Søk').fill('skatten');
@@ -44,7 +44,7 @@ test.describe('Saved search', () => {
   });
 
   test('Saved search link shows correct result', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
 
     await page.getByRole('button', { name: 'Test Testesen' }).click();
     await page.getByText('Testbedrift AS Avd Oslo').click();

--- a/packages/frontend/tests/stories/select-account.spec.ts
+++ b/packages/frontend/tests/stories/select-account.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+import { appURLDrafts, appURLInbox, defaultAppURL, matchPathName } from '../index';
+
+test('should navigate to inbox when account is chosen from global menu', async ({ page }) => {
+  await page.goto(defaultAppURL);
+  /* click navigate to draft page */
+  await page.getByRole('menuitem', { name: 'Utkast' }).click();
+  expect(page.url()).toEqual(appURLDrafts);
+  /* chose all organizations from the global menu */
+  await page.getByRole('button', { name: 'Meny' }).click();
+  await page.getByRole('menuitem', { name: 'Test Testesen Bytt konto' }).click();
+  await page.getByRole('menuitem', { name: 'Alle virksomheter' }).click();
+
+  expect(new URL(page.url()).searchParams.get('allParties')).toBe('true');
+  expect(matchPathName(page.url(), appURLInbox)).toBe(true);
+});

--- a/packages/frontend/tests/stories/sidebar.spec.ts
+++ b/packages/frontend/tests/stories/sidebar.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { appURL } from '../';
+import { defaultAppURL } from '../';
 
 test.describe('Sidebar menu', () => {
   test('Checking all items in sidebar', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
     await page.getByRole('menuitem', { name: 'Utkast' }).click();
     await expect(page.getByRole('heading', { name: 'utkast' })).toBeVisible();
     await page.getByRole('menuitem', { name: 'Sendt' }).click();

--- a/packages/frontend/tests/stories/smoke.spec.ts
+++ b/packages/frontend/tests/stories/smoke.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { appURL } from '..';
+import { defaultAppURL } from '..';
 
 test.describe('Smoke test', () => {
   test('should show header, aside, main and footer', async ({ page }) => {
-    await page.goto(appURL);
+    await page.goto(defaultAppURL);
     const aside = page.getByRole('complementary');
     const footer = page.getByRole('contentinfo');
     const header = page.getByRole('button', { name: 'Meny' }).locator('xpath=ancestor::header');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,8 +386,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: ^0.13.2
-        version: 0.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.13.3
+        version: 0.13.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@digdir/designsystemet-css':
         specifier: 0.11.0-next.10
         version: 0.11.0-next.10
@@ -606,8 +606,8 @@ packages:
     resolution: {integrity: sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.13.2':
-    resolution: {integrity: sha512-p+fF2BTzIik9uhO95CnbOm5E11XK43sh4LlBGTQUz1TxEqPVF3KSQhGgD9vWVEcv96ptmHLgdC6awVj9mzedhw==}
+  '@altinn/altinn-components@0.13.3':
+    resolution: {integrity: sha512-EpxaGoSVtkWv5jbW5AMFZeYpF5xdY8bdDOpyRuD0XWFCkSl8G/0W3N82+ZJWtqVxW6CuDCS29nGWrSS7NSVG6A==}
     peerDependencies:
       react: '>=18.3.1'
       react-dom: '>=18.3.1'
@@ -10296,7 +10296,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.19.0
 
-  '@altinn/altinn-components@0.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@altinn/altinn-components@0.13.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@navikt/aksel-icons': 7.9.1
       classnames: 2.5.1


### PR DESCRIPTION
Selecting a party from account menu in the global menu should, in addition to select party, also navigate the user to the inbox route, if not already there. 

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1675 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
