### PR TITLE
chore: revert node-logger as workspace dependency and run cmd in Dockerfile for BFF

### DIFF
--- a/packages/bff/Dockerfile
+++ b/packages/bff/Dockerfile
@@ -8,8 +8,7 @@ COPY . .
 
 RUN pnpm install --frozen-lockfile
 
-RUN pnpm --filter bff run build
-# RUN pnpm turbo build
+RUN pnpm turbo build
 
 ENV PORT=80
 

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -21,7 +21,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/keyvault-keys": "^4.7.2",
     "@azure/monitor-opentelemetry": "1.7.0",
-    "@digdir/dialogporten-node-logger": "1.11.4",
+    "@digdir/dialogporten-node-logger": "workspace:*",
     "@digdir/dialogporten-schema": "1.40.0",
     "@fastify/cookie": "^9.3.1",
     "@fastify/cors": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: 1.7.0
         version: 1.7.0
       '@digdir/dialogporten-node-logger':
-        specifier: 1.11.4
-        version: 1.11.4
+        specifier: workspace:*
+        version: link:../node-logger
       '@digdir/dialogporten-schema':
         specifier: 1.40.0
         version: 1.40.0
@@ -1689,9 +1689,6 @@ packages:
 
   '@digdir/designsystemet-theme@1.0.0-next.14':
     resolution: {integrity: sha512-JWCLhXxDlMYwatg7mLkptfEkeiv/EKSaUOXX4nUoV8HjqyxMnLaaZZe6NKqx2SH1GPKOeSL5bEcs2NAEoFlGXg==}
-
-  '@digdir/dialogporten-node-logger@1.11.4':
-    resolution: {integrity: sha512-jvjkbJO/zHTdNWPCVw4V+nOMQ/Oyg32xA2wAxaU+oTGFHgxf9Do4g11BCkTGCoSU6HakljeQctRR38qdMSzF1A==}
 
   '@digdir/dialogporten-schema@1.40.0':
     resolution: {integrity: sha512-NVi1ZkQU4yynmw80Mz+YkG5rLVoOLsB9s5PqXHBnA08WTl2doQWX4aBDCHC29m1C8P6sxPA1dvIGOOrN/h0haw==}
@@ -11722,11 +11719,6 @@ snapshots:
       - '@types/react'
 
   '@digdir/designsystemet-theme@1.0.0-next.14': {}
-
-  '@digdir/dialogporten-node-logger@1.11.4':
-    dependencies:
-      pino: 9.3.2
-      pino-pretty: 11.2.2
 
   '@digdir/dialogporten-schema@1.40.0': {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -6,9 +6,14 @@
       "outputs": ["generated/**"],
       "cache": false
     },
+    "build:@digdir/dialogporten-node-logger": {
+      "dependsOn": ["^build"],
+      "outputs": ["packages/node-logger/dist/**"],
+      "cache": false
+    },
     "build": {
       "env": ["BASEURL", "URL"],
-      "dependsOn": ["build:bff-types-generated"],
+      "dependsOn": ["build:bff-types-generated", "build:@digdir/dialogporten-node-logger"],
       "cache": false
     },
     "dev": {


### PR DESCRIPTION
Revert back to use node-logger as workspace dependency and revert a change we did that might have broken for the verify bff deploy step.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
