### PR TITLE
chore: Cover App routes with AxeBuilder in Playwright

### DIFF
--- a/packages/frontend/tests/accessibility/axe.test.ts
+++ b/packages/frontend/tests/accessibility/axe.test.ts
@@ -1,13 +1,33 @@
-import AxeBuilder from '@axe-core/playwright';
-import { expect, test } from '@playwright/test';
+import { AxeBuilder } from '@axe-core/playwright';
+import { type Page, expect, test } from '@playwright/test';
 import { defaultAppURL } from '..';
 
+const WCAG_TAGS_CONFIG = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+const VIOLATION_FILTERS = ['critical', 'serious'];
+const expectWithFilterViolations = (violations) => {
+  const filteredViolations = violations.filter((violation) => VIOLATION_FILTERS.includes(violation.impact));
+  expect(filteredViolations).toEqual([]);
+};
+
+const testAccessibility = async (page: Page, url: string) => {
+  await page.goto(url);
+  const accessibilityScanResults = await new AxeBuilder({ page }).withTags(WCAG_TAGS_CONFIG).analyze();
+
+  expectWithFilterViolations(accessibilityScanResults.violations);
+};
+
 test.describe('Axe test', () => {
-  test('should not have any automatically detectable accessibility issues', async ({ page }) => {
-    await page.goto(defaultAppURL);
+  const testCases = [
+    { name: 'Inbox', path: '' },
+    { name: 'Drafts', path: '/drafts' },
+    { name: 'Sent', path: '/sent' },
+    { name: 'Archive', path: '/archive' },
+    { name: 'Bin', path: '/bin' },
+  ];
 
-    const accessibilityScanResults = await new AxeBuilder({ page }).analyze();
-
-    expect(accessibilityScanResults.violations).toEqual([]);
-  });
+  for (const { name, path } of testCases) {
+    test(`${name} - should not have any automatically detectable accessibility issues`, async ({ page }) => {
+      await testAccessibility(page, `${defaultAppURL}${path}`);
+    });
+  }
 });


### PR DESCRIPTION
Enabling accessibility tests for all Routes in the app throws many violations. 
Most of them are coming directly from Altinn-Components library and need to be fixed there I believe. 
Suggestion: Enable Playwright accessibility test in altinn-components so it's easier to track where the issues are and fix them.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

[#1592](https://github.com/Altinn/dialogporten-frontend/issues/1592)

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
