### PR TITLE
fix: adds new media types for front channel embeds

### DIFF
--- a/packages/embeddable-markdown-html/src/markdown.tsx
+++ b/packages/embeddable-markdown-html/src/markdown.tsx
@@ -14,7 +14,7 @@ import './styles.css';
 const production = { Fragment: prod.Fragment, jsx: prod.jsx, jsxs: prod.jsxs };
 
 /**
- * Renders markdown as React elements.
+ * Renders markdown as React elements in common mark: https://spec.commonmark.org/0.31.2/spec.json.
  *
  * @param children - The markdown string to render.
  * @param onError - A callback for handling errors.

--- a/packages/embeddable-markdown-html/tests/__snapshots__/markdown.spec.tsx.snap
+++ b/packages/embeddable-markdown-html/tests/__snapshots__/markdown.spec.tsx.snap
@@ -1,9 +1,106 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Markdown > list items 1`] = `
+<ol>
+  
+
+  <li
+    class="__fce-list-item"
+  >
+    
+
+    <p
+      class="__fce-paragraph"
+    >
+      A paragraph
+with two lines.
+    </p>
+    
+
+    <pre>
+      <code>
+        indented code
+
+      </code>
+    </pre>
+    
+
+    <blockquote>
+      
+
+      <p
+        class="__fce-paragraph"
+      >
+        A block quote.
+      </p>
+      
+
+    </blockquote>
+    
+
+  </li>
+  
+
+</ol>
+`;
+
 exports[`Markdown > should render content 1`] = `
 <h1
   class="__fce-header-1"
 >
   header
 </h1>
+`;
+
+exports[`Markdown > should render emphasis and strong emphasis 1`] = `
+<p
+  class="__fce-paragraph"
+>
+  <strong
+    class="__fce-strong"
+  >
+    foo
+  </strong>
+    
+  <em>
+    bar
+  </em>
+</p>
+`;
+
+exports[`Markdown > should render hard line breaks, 1 1`] = `
+<p
+  class="__fce-paragraph"
+>
+  foo
+  <br />
+  
+
+  baz
+</p>
+`;
+
+exports[`Markdown > should render hard line breaks, 2 1`] = `
+<p
+  class="__fce-paragraph"
+>
+  This is the first line.
+  <br />
+  
+
+  This is the second line.
+</p>
+`;
+
+exports[`Markdown > should render link 1`] = `
+<p
+  class="__fce-paragraph"
+>
+  <a
+    href="/url"
+    title="title"
+  >
+    foo
+  </a>
+</p>
 `;

--- a/packages/embeddable-markdown-html/tests/markdown.spec.tsx
+++ b/packages/embeddable-markdown-html/tests/markdown.spec.tsx
@@ -1,7 +1,65 @@
-import { describe, test } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { Markdown } from '../src';
 
 describe('Markdown', () => {
   test('should render content', async () => {
-    // TODO: Add tests
+    const { container, getByText } = render(<Markdown onError={() => {}}># header</Markdown>);
+    await waitFor(() => {
+      expect(getByText('header')).toBeInTheDocument();
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render hard line breaks, 1', async () => {
+    const markdownString = `foo  \rbaz`;
+    const { container } = render(<Markdown onError={() => {}}>{markdownString}</Markdown>);
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent('foo');
+      expect(container).toHaveTextContent('baz');
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render hard line breaks, 2', async () => {
+    const markdownString = `This is the first line.  
+This is the second line.`;
+    const { container } = render(<Markdown onError={() => {}}>{markdownString}</Markdown>);
+
+    await waitFor(() => {
+      expect(container).toHaveTextContent('This is the first line');
+      expect(container).toHaveTextContent('This is the second line');
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('list items', async () => {
+    const markdownString = '1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n';
+    const { container } = render(<Markdown onError={() => {}}>{markdownString}</Markdown>);
+    await waitFor(() => {
+      expect(container).toHaveTextContent('A paragraph with two lines.');
+      expect(container).toHaveTextContent('indented code');
+      expect(container).toHaveTextContent('A block quote.');
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render link', async () => {
+    const markdownString = '[foo]: /url "title"\n\n[foo]\n';
+    const { container } = render(<Markdown onError={() => {}}>{markdownString}</Markdown>);
+    await waitFor(() => {
+      expect(container).toHaveTextContent('foo');
+    });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('should render emphasis and strong emphasis', async () => {
+    const markdownString = '**foo**  *bar*';
+    const { container } = render(<Markdown onError={() => {}}>{markdownString}</Markdown>);
+    await waitFor(() => {
+      expect(container).toHaveTextContent('foo');
+    });
+    expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/packages/frontend/src/api/useDialogById.tsx
+++ b/packages/frontend/src/api/useDialogById.tsx
@@ -25,8 +25,10 @@ export interface Participant {
 }
 
 export enum EmbeddableMediaType {
-  markdown = 'application/vnd.dialogporten.frontchannelembed+json;type=markdown',
-  html = 'application/vnd.dialogporten.frontchannelembed+json;type=html',
+  markdown = 'application/vnd.dialogporten.frontchannelembed-url;type=text/markdown',
+  html = 'application/vnd.dialogporten.frontchannelembed-url;type=text/html',
+  markdown_deprecated = 'application/vnd.dialogporten.frontchannelembed+json;type=markdown',
+  html_deprecated = 'application/vnd.dialogporten.frontchannelembed+json;type=html',
 }
 
 export interface EmbeddedContent {

--- a/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
+++ b/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
@@ -7,8 +7,10 @@ import styles from './mainContentReference.module.css';
 
 const getContent = (mediaType: EmbeddableMediaType, data: string) => {
   switch (mediaType) {
+    case EmbeddableMediaType.markdown_deprecated:
     case EmbeddableMediaType.markdown:
       return <Markdown onError={(e) => console.error('Markdown error: ', e)}>{data}</Markdown>;
+    case EmbeddableMediaType.html_deprecated:
     case EmbeddableMediaType.html:
       return <Html onError={(e) => console.error('Html error: ', e)}>{data}</Html>;
     default:

--- a/packages/frontend/src/components/MainContentReference/mainContentReference.spec.tsx
+++ b/packages/frontend/src/components/MainContentReference/mainContentReference.spec.tsx
@@ -22,7 +22,7 @@ describe('MainContentReference Component', () => {
   it('should render markdown content', async () => {
     const mockContent = {
       url: 'https://altinn.mock/content',
-      mediaType: EmbeddableMediaType.markdown,
+      mediaType: EmbeddableMediaType.markdown_deprecated,
     };
 
     const mockResponse = '# header ## subheader ### subsubheader';
@@ -42,7 +42,7 @@ describe('MainContentReference Component', () => {
   it('should render html content', async () => {
     const mockContent = {
       url: 'https://altinn.mock/content',
-      mediaType: EmbeddableMediaType.html,
+      mediaType: EmbeddableMediaType.html_deprecated,
     };
 
     const mockResponse = '<html><body><h1>header 1</h1></body></html>';

--- a/packages/frontend/src/mocks/data/base/helper.ts
+++ b/packages/frontend/src/mocks/data/base/helper.ts
@@ -13,7 +13,7 @@ export const getMockedMainContent = (dialogId: string) => {
 
   if (idWithLegacyHTML === dialogId) {
     return {
-      mediaType: 'application/vnd.dialogporten.frontchannelembed+json;type=html',
+      mediaType: 'application/vnd.dialogporten.frontchannelembed-url;type=text/html',
       value: [
         {
           value: 'https://dialogporten-serviceprovider.net/fce-html',
@@ -24,7 +24,7 @@ export const getMockedMainContent = (dialogId: string) => {
   }
 
   return {
-    mediaType: 'application/vnd.dialogporten.frontchannelembed+json;type=markdown',
+    mediaType: 'application/vnd.dialogporten.frontchannelembed-url;type=text/markdown',
     value: [
       {
         value: 'https://dialogporten-serviceprovider.net/fce-markdown',


### PR DESCRIPTION
`application/vnd.dialogporten.frontchannelembed-url;type=text/markdown` and `application/vnd.dialogporten.frontchannelembed-url;type=text/html` are now supported, alongside _deprecated_ `vnd.dialogporten.frontchannelembed+json;type=markdown ` and `vnd.dialogporten.frontchannelembed+json;type=html`


<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1704 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
