### PR TITLE
chore(infra): ensure correct ssl certificate key for yt01 and test

### DIFF
--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -32,7 +32,13 @@ param applicationGatewayConfiguration = {
   hostName: 'af.yt01.altinn.no'
   sslCertificate: {
     keyVaultName: readEnvironmentVariable('CERTIFICATE_KEY_VAULT_NAME')
+<<<<<<< Updated upstream
     secretKey: 'star-yt01-altinn-no'
+||||||| Stash base
+    secretKey: 'star-yt-altinn-cloud'
+=======
+    secretKey: 'af-yt-altinn-cloud'
+>>>>>>> Stashed changes
   }
 } 
 

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -32,13 +32,7 @@ param applicationGatewayConfiguration = {
   hostName: 'af.yt01.altinn.no'
   sslCertificate: {
     keyVaultName: readEnvironmentVariable('CERTIFICATE_KEY_VAULT_NAME')
-<<<<<<< Updated upstream
-    secretKey: 'star-yt01-altinn-no'
-||||||| Stash base
-    secretKey: 'star-yt-altinn-cloud'
-=======
     secretKey: 'af-yt-altinn-cloud'
->>>>>>> Stashed changes
   }
 } 
 


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

We are going to use the centralized key vault for certificates moving forward. The key vault name has been changed in `test` and `yt01` for now. Needs to be done for `staging` and `prod` as well. This is so that we can ensure when certificates are rotated that we use the latest version of the certificate, instead of downloading the certificate into our own key-vault. 

Also not using wildcard certificates anymore. 

## Related Issue(s)

- #N/A

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
