### PR TITLE
chore(pnpm+corepack): temporary fix for CI / docker locally due to corepack issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,5 @@
   "lint-staged": {
     "**/*.*": "biome check --staged --no-errors-on-unmatched --write"
   },
-  "packageManager": "pnpm@9.15.1"
+  "packageManager": "pnpm@10.1.0"
 }

--- a/packages/bff/Dockerfile
+++ b/packages/bff/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-slim AS build
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm i -g corepack@latest
 RUN corepack enable
 
 WORKDIR /app

--- a/packages/docs/Dockerfile
+++ b/packages/docs/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22-slim AS build
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm i -g corepack@latest
 RUN corepack enable
 
 WORKDIR /app

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:22.0.0-slim AS build
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+RUN npm i -g corepack@latest
 RUN corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
Related to https://github.com/nodejs/corepack/issues/612 - causes all version of pnpm (at least 9 >=) to fail because of missing integrity key (validating hash) through corepack 

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
