### PR TITLE
chore(refactor): introduce useGlobalState as cleaner shared state utility with a simple API

### DIFF
--- a/packages/frontend/src/components/PageLayout/Search/useSearchString.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/useSearchString.tsx
@@ -1,31 +1,19 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { getSearchStringFromQueryParams } from '../../../pages/Inbox/queryParams.ts';
 import { PageRoutes } from '../../../pages/routes.ts';
+import { useGlobalState } from '../../../useGlobalState.ts';
 
 export const useSearchString = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
   const searchQueryParams = getSearchStringFromQueryParams(searchParams);
-  const queryClient = useQueryClient();
+  const [searchValue, setSearchValue] = useGlobalState(QUERY_KEYS.SEARCH_VALUE, searchQueryParams);
+  const [enteredSearchValue, setEnteredSearchValue] = useGlobalState(QUERY_KEYS.ENTERED_SEARCH_VALUE, '');
 
-  const { data: searchValue } = useQuery<string>({
-    queryKey: [QUERY_KEYS.SEARCH_VALUE],
-    enabled: false,
-    staleTime: Number.POSITIVE_INFINITY,
-    initialData: searchQueryParams,
-  });
-
-  const { data: enteredSearchValue } = useQuery<string>({
-    queryKey: [QUERY_KEYS.ENTERED_SEARCH_VALUE],
-    enabled: false,
-    staleTime: Number.POSITIVE_INFINITY,
-    initialData: '',
-  });
-
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const searchBarParam = new URLSearchParams(searchParams);
     const searchParamValue = searchBarParam.get('search') ?? '';
@@ -35,14 +23,6 @@ export const useSearchString = () => {
       setEnteredSearchValue(searchParamValue);
     }
   }, [searchParams, enteredSearchValue]);
-
-  const setSearchValue = (value: string) => {
-    queryClient.setQueryData([QUERY_KEYS.SEARCH_VALUE], value);
-  };
-
-  const setEnteredSearchValue = (value: string) => {
-    queryClient.setQueryData([QUERY_KEYS.ENTERED_SEARCH_VALUE], value);
-  };
 
   const onSearch = (value: string, org?: string) => {
     const newSearchParams = new URLSearchParams(searchParams);

--- a/packages/frontend/src/useGlobalState.ts
+++ b/packages/frontend/src/useGlobalState.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { QUERY_KEYS } from './constants/queryKeys.ts';
+
+type UseGlobalStateReturn<T> = [T, (newValue: T) => void];
+
+export function useGlobalState<T>(
+  queryKey: (typeof QUERY_KEYS)[keyof typeof QUERY_KEYS],
+  defaultValue: T,
+): UseGlobalStateReturn<T> {
+  const queryClient = useQueryClient();
+
+  const { data = defaultValue } = useQuery<T>({
+    queryKey: [queryKey],
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled: false,
+    initialData: defaultValue,
+  });
+
+  const { mutate } = useMutation<T, unknown, T>({
+    mutationFn: async (newValue) => newValue,
+    onMutate: (newValue) => {
+      queryClient.setQueryData([queryKey], newValue);
+    },
+  });
+
+  return [data, mutate];
+}


### PR DESCRIPTION
**Background**

Since we already use `react-query` for handling global state, I thought it might be handy to abstract some of this boilerplate a cleaner and more reusable hook with a friendly and familiar looking API (using `useState` as inspiration).

This is not for state / cache where response of a request is involved, only for shared state which is explicitly handled.

**useGlobalState**

Instead of manually handling useQuery and queryClient.setQueryData in multiple places, components can now manage global state with a simple [value, setValue] API.


*Before*

```
  const { data: allOrganizationsSelected } = useQuery<boolean>({
    queryKey: [QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED],
    enabled: false,
    staleTime: Number.POSITIVE_INFINITY,
    initialData: false,
  });

queryClient.setQueryData([QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED], true);

```

*Now*

```
  const [allOrganizationsSelected, setAllOrganizationsSelected] = useGlobalState<boolean>(
    QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED,
    false,
  );

setAllOrganizationsSelected(true);

```



## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
