### PR TITLE
fix: ensure filters are active in Toolbar on reload of state

### DIFF
--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -89,6 +89,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
         {selectedAccount ? (
           <>
             <Toolbar
+              key={`toolbar-${filters.length}`}
               data-testid="inbox-toolbar"
               accountMenu={{
                 accounts,


### PR DESCRIPTION
Fixes issue with filters not being loaded in Toolbar after reload.
The problem was that filters are empty initially (before dialogs are loaded) and the Toolbar, once it gets the new filters, doesn't apply the changes. To solve this, the length of filters are part of the Toolbar's key, causing the Toolbar to re-render once the dialogs are loaded and the filters are applicable.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1920 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
