### PR TITLE
fix: update to v. 0.21.4 of altinn-components without font imports from altinn cdn

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.20.2",
+    "@altinn/altinn-components": "^0.21.4",
     "@digdir/designsystemet-css": "1.0.0-next.50",
     "@digdir/designsystemet-react": "1.0.0-next.50",
     "@digdir/designsystemet-theme": "1.0.0-next.50",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,8 +383,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: ^0.20.2
-        version: 0.20.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^0.21.4
+        version: 0.21.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@digdir/designsystemet-css':
         specifier: 1.0.0-next.50
         version: 1.0.0-next.50
@@ -600,8 +600,8 @@ packages:
     resolution: {integrity: sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.20.2':
-    resolution: {integrity: sha512-rZv3o5LP++WhjTG/hUr0/fMOjMkWoS3tQM5BtCBmzkVYHezBf8gvjQ0Pbi1pyuahSUkJXUrYVYNNHlzzP7rfgQ==}
+  '@altinn/altinn-components@0.21.4':
+    resolution: {integrity: sha512-5E4ZIlFA33rAvIr3Eb6EUa+ODlcCNKippxHQ7YiThiIjiPLiDzhDd11vWjAfHMIQUr8IZ2REh9RJwdEiAsLE4Q==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -10371,7 +10371,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.19.0
 
-  '@altinn/altinn-components@0.20.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@altinn/altinn-components@0.21.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@navikt/aksel-icons': 7.14.1
       classnames: 2.5.1


### PR DESCRIPTION

Now Arbeidsflate imports Inter v. 4.1 by loading the fonts itself and uses an updated version of altinn-components that leaves this responsibility to the consumer app.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1910 
- https://github.com/Altinn/altinn-components/issues/309

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
