### PR TITLE
fix(infra): enable JIT for ssh-jumpers

### DIFF
--- a/.azure/modules/ssh-jumper/main.bicep
+++ b/.azure/modules/ssh-jumper/main.bicep
@@ -83,6 +83,7 @@ module virtualMachine '../../modules/virtualMachine/main.bicep' = {
     location: location
     tags: tags
     adminLoginGroupObjectId: adminLoginGroupObjectId
+    enableJit: true
     hardwareProfile: {
       vmSize: 'Standard_B1s'
     }

--- a/.azure/modules/virtualMachine/main.bicep
+++ b/.azure/modules/virtualMachine/main.bicep
@@ -75,6 +75,9 @@ param adminLoginGroupObjectId string
 @secure()
 param sshPublicKey string
 
+@description('Enable Just-in-Time access for the virtual machine')
+param enableJit bool = false
+
 resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-03-01' = {
   name: name
   location: location
@@ -119,6 +122,26 @@ resource virtualMachine 'Microsoft.Compute/virtualMachines@2024-03-01' = {
     type: 'SystemAssigned'
   }
   tags: tags
+}
+
+resource jitPolicy 'Microsoft.Security/locations/jitNetworkAccessPolicies@2020-01-01' = if (enableJit) {
+  name: '${location}/${name}'
+  kind: 'Basic'
+  properties: {
+    virtualMachines: [
+      {
+        id: virtualMachine.id
+        ports: [
+          {
+            number: 22
+            protocol: '*'
+            allowedSourceAddressPrefix: '*'
+            maxRequestAccessDuration: 'PT24H'
+          }
+        ]
+      }
+    ]
+  }
 }
 
 resource aadLoginExtension 'Microsoft.Compute/virtualMachines/extensions@2024-03-01' = {


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Enable JIT so that we can close off all inbound traffic to the virtual machine. Will update the script to use JIT to open a connection to the vm automatically later. 

Related dialogporten-issue: https://github.com/Altinn/dialogporten/pull/2091

## Related Issue(s)

- https://github.com/Altinn/dialogporten/issues/1995

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
