### PR TITLE
fix: reduce requests to fce and increase staale time for dialog by id requests

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,7 +21,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.24.0",
+    "@altinn/altinn-components": "^0.24.1",
     "@digdir/designsystemet-css": "1.0.0-next.50",
     "@digdir/designsystemet-react": "1.0.0-next.50",
     "@digdir/designsystemet-theme": "1.0.0-next.50",

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -230,7 +230,8 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   const partyURIs = parties.map((party) => party.party);
   const { data, isSuccess, isLoading, isError } = useQuery<GetDialogByIdQuery>({
     queryKey: [QUERY_KEYS.DIALOG_BY_ID, id, organizations],
-    staleTime: 1000 * 60 * 10,
+    staleTime: 1000 * 60 * 30,
+    refetchOnWindowFocus: false,
     retry: 3,
     queryFn: () =>
       getDialogsById(id!).then((data) => {

--- a/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
+++ b/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
@@ -9,6 +9,7 @@ import {
   DialogHistory,
   DialogTabs,
 } from '@altinn/altinn-components';
+import type { DialogHistorySegmentProps } from '@altinn/altinn-components/dist/types/lib/components';
 import { DialogStatus } from 'bff-types-generated';
 import { type ReactElement, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -147,12 +148,13 @@ export const DialogDetails = ({ dialog, isLoading }: DialogDetailsProps): ReactE
       return [];
     }
     /* Add content reference to each item in the transmission - ensure they are not eagerly loaded, will only render on expand */
-    return dialog.transmissions.map((transmission) => ({
+    return dialog.transmissions.map((transmission: DialogHistorySegmentProps) => ({
       ...transmission,
       items: transmission.items.map((item) => ({
         ...item,
         children: dialog.contentReferenceForTransmissions[item.id] ? (
           <MainContentReference
+            id={item.id}
             content={dialog.contentReferenceForTransmissions[item.id]}
             dialogToken={dialog.dialogToken}
           />
@@ -161,6 +163,7 @@ export const DialogDetails = ({ dialog, isLoading }: DialogDetailsProps): ReactE
           ...subItem,
           children: dialog.contentReferenceForTransmissions[subItem.id] ? (
             <MainContentReference
+              id={subItem.id}
               content={dialog.contentReferenceForTransmissions[subItem.id]}
               dialogToken={dialog.dialogToken}
             />
@@ -222,8 +225,6 @@ export const DialogDetails = ({ dialog, isLoading }: DialogDetailsProps): ReactE
     },
   }));
 
-  console.info(transmissions);
-
   return (
     <Article padding={6} spacing={6}>
       <DialogHeader
@@ -241,7 +242,7 @@ export const DialogDetails = ({ dialog, isLoading }: DialogDetailsProps): ReactE
         seenByLog={dialog.seenByLog}
       >
         <p>{dialog.summary}</p>
-        <MainContentReference content={dialog.mainContentReference} dialogToken={dialog.dialogToken} />
+        <MainContentReference content={dialog.mainContentReference} dialogToken={dialog.dialogToken} id={dialog.id} />
         {dialog.attachments.length > 0 && (
           <DialogAttachments
             title={t('inbox.heading.attachments', { count: dialog.attachments.length })}

--- a/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
+++ b/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
@@ -20,9 +20,14 @@ const getContent = (mediaType: EmbeddableMediaType, data: string) => {
 };
 
 export const MainContentReference = memo(
-  ({ content, dialogToken }: { content: DialogByIdDetails['mainContentReference']; dialogToken: string }) => {
+  ({
+    content,
+    dialogToken,
+    id,
+  }: { content: DialogByIdDetails['mainContentReference']; dialogToken: string; id: string }) => {
     const { data, isSuccess } = useQuery({
-      queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, content?.url, content?.mediaType],
+      queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, id],
+      staleTime: 1000 * 60 * 10,
       queryFn: () =>
         fetch(content!.url, {
           headers: {

--- a/packages/frontend/src/components/MainContentReference/mainContentReference.spec.tsx
+++ b/packages/frontend/src/components/MainContentReference/mainContentReference.spec.tsx
@@ -32,7 +32,7 @@ describe('MainContentReference Component', () => {
     );
 
     const { asFragment } = await waitFor(() =>
-      customRender(<MainContentReference content={mockContent} dialogToken={mockDialogToken} />, {
+      customRender(<MainContentReference content={mockContent} dialogToken={mockDialogToken} id="test" />, {
         wrapper,
       } as RenderOptions),
     );
@@ -52,7 +52,7 @@ describe('MainContentReference Component', () => {
     );
 
     const { asFragment } = await waitFor(() =>
-      customRender(<MainContentReference content={mockContent} dialogToken={mockDialogToken} />, {
+      customRender(<MainContentReference content={mockContent} dialogToken={mockDialogToken} id="test" />, {
         wrapper,
       } as RenderOptions),
     );

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -124,7 +124,7 @@ export const PageLayout: React.FC = () => {
       ...(accountSearch && {
         accountSearch,
       }),
-      isVirtualized: true,
+      isVirtualized: accounts.length > 20,
       logoutButton: {
         label: t('word.log_out'),
         onClick: () => {

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -107,7 +107,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
                 accountGroups,
                 currentAccount: selectedAccount,
                 onSelectAccount: (account: string) => onSelectAccount(account, PageRoutes[viewType]),
-                isVirtualized: true,
+                isVirtualized: accounts.length > 20,
               }}
               filterState={filterState}
               getFilterLabel={getFilterLabel}

--- a/packages/frontend/src/profile/useProfile.tsx
+++ b/packages/frontend/src/profile/useProfile.tsx
@@ -9,6 +9,7 @@ export const useProfile = () => {
   const { data } = useQuery<ProfileQuery>({
     queryKey: [QUERY_KEYS.PROFILE],
     queryFn: () => profile(),
+    refetchOnWindowFocus: false,
   });
   const { i18n } = useTranslation();
   const language = data?.profile?.language || i18n.language || 'nb';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,8 +383,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: ^0.24.0
-        version: 0.24.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^0.24.1
+        version: 0.24.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@digdir/designsystemet-css':
         specifier: 1.0.0-next.50
         version: 1.0.0-next.50
@@ -600,8 +600,8 @@ packages:
     resolution: {integrity: sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.24.0':
-    resolution: {integrity: sha512-tYls+DY8N3zz89ErzfXOr+CQquXbqvVJ6ue8AUS/n28IpHvtQ3GiJG2fFuhKmPuIPIKKHX4N6Z/aMWzGdo6ptw==}
+  '@altinn/altinn-components@0.24.1':
+    resolution: {integrity: sha512-rEHOpdGPZLZkXzkjinI8o5DH5HUA6rkmeMBTt+aXMTDB5iUMBYkMzW7QyDSMWKqE7xi3yZ17EdrYNnz8yhe8Dg==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -10380,7 +10380,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.19.0
 
-  '@altinn/altinn-components@0.24.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@altinn/altinn-components@0.24.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@navikt/aksel-icons': 7.14.1
       '@tanstack/react-virtual': 3.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)


### PR DESCRIPTION
Reduces amount of requests of getting dialog by id by increasing the stale time (how long the data is considered fresh) significantly and add cache for `fce` for the id on which the fce is related, e.g. id of transmission for contentReference or dialog of id for main content reference. 

Also through discussions with @mbacherycz  , only used virtualized for accounts menu if accounts length > 20, since this is only meant for high performance for slow lists. 


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1997

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
