### PR TITLE
fix: skip unauthorized FCE and attachments

### DIFF
--- a/packages/bff-types-generated/queries/dialog.fragment.graphql
+++ b/packages/bff-types-generated/queries/dialog.fragment.graphql
@@ -105,6 +105,7 @@ fragment DialogByIdFields on Dialog {
 
 fragment TransmissionFields on Transmission {
   id
+  isAuthorized
   createdAt
   type
   sender {

--- a/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
+++ b/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
@@ -173,6 +173,30 @@ export const DialogDetails = ({ dialog, isLoading }: DialogDetailsProps): ReactE
     }));
   }, [dialog]);
 
+  const activityHistoryItems = useMemo(() => {
+    if (!dialog?.activityHistory) {
+      return [];
+    }
+    return dialog.activityHistory.map((dialogHistoryItem: DialogHistorySegmentProps) => {
+      if (dialogHistoryItem.items[0]?.variant === 'transmission') {
+        return {
+          ...dialogHistoryItem,
+          items: dialogHistoryItem.items.map((item) => ({
+            ...item,
+            children: dialog.contentReferenceForTransmissions[item.id] ? (
+              <MainContentReference
+                id={item.id}
+                content={dialog.contentReferenceForTransmissions[item.id]}
+                dialogToken={dialog.dialogToken}
+              />
+            ) : null,
+          })),
+        };
+      }
+      return dialogHistoryItem;
+    });
+  }, [dialog]);
+
   if (isLoading) {
     return (
       <Article padding={6} spacing={6}>
@@ -257,20 +281,11 @@ export const DialogDetails = ({ dialog, isLoading }: DialogDetailsProps): ReactE
           selected: item.id === activeTab,
         }))}
       />
-      {activeTab === 'transmissions' && (
-        <DialogHistory items={transmissions} collapseLabel="Skjul historikk" collapsible expandLabel="Vis historikk" />
-      )}
+      {activeTab === 'transmissions' && <DialogHistory items={transmissions} collapsible />}
       {activeTab === 'additional_info' && (
         <AdditionalInfoContent mediaType={dialog.additionalInfo?.mediaType} value={dialog.additionalInfo?.value} />
       )}
-      {activeTab === 'activities' && (
-        <DialogHistory
-          items={dialog.activityHistory}
-          collapseLabel="Skjul aktiviteter"
-          collapsible
-          expandLabel="Vis aktiviteter"
-        />
-      )}
+      {activeTab === 'activities' && <DialogHistory items={activityHistoryItems} />}
     </Article>
   );
 };

--- a/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
+++ b/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
@@ -6,6 +6,15 @@ import { type DialogByIdDetails, EmbeddableMediaType } from '../../api/hooks/use
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import styles from './mainContentReference.module.css';
 
+const isValidURL = (url: string) => {
+  try {
+    const newUrl = new URL(url);
+    return newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
+  } catch (_) {
+    return false;
+  }
+};
+
 const getContent = (mediaType: EmbeddableMediaType, data: string) => {
   switch (mediaType) {
     case EmbeddableMediaType.markdown_deprecated:
@@ -25,6 +34,7 @@ export const MainContentReference = memo(
     dialogToken,
     id,
   }: { content: DialogByIdDetails['mainContentReference']; dialogToken: string; id: string }) => {
+    const validURL = content?.url ? isValidURL(content.url) : false;
     const { data, isSuccess } = useQuery({
       queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, id],
       staleTime: 1000 * 60 * 10,
@@ -35,7 +45,7 @@ export const MainContentReference = memo(
             Authorization: `Bearer ${dialogToken}`,
           },
         }).then((res) => res.text()),
-      enabled: content?.url !== undefined && Object.values(EmbeddableMediaType).includes(content.mediaType),
+      enabled: validURL && content?.mediaType && Object.values(EmbeddableMediaType).includes(content.mediaType),
     });
 
     if (!content || !isSuccess) {

--- a/packages/frontend/src/mocks/data/base/helper.ts
+++ b/packages/frontend/src/mocks/data/base/helper.ts
@@ -47,6 +47,18 @@ export const getMockedFCEContent = (transmissionId: string) => {
   };
 };
 
+export const getMockedUnauthorizedFCEContent = () => {
+  return {
+    mediaType: 'application/vnd.dialogporten.frontchannelembed-url;type=text/html',
+    value: [
+      {
+        value: 'urn:dialogporten:unauthorized',
+        languageCode: 'nb',
+      },
+    ],
+  };
+}
+
 export const getMockedActivities = (latestActivity: SearchDialogFieldsFragment['latestActivity'], id: string) => {
   if (id === '019241f7-8218-7756-be82-123qwe456rtA') {
     return [
@@ -124,6 +136,7 @@ export const getMockedTransmissions = (dialogId: string) => {
       {
         "id": "transmission-1",
         "createdAt": "2024-07-30T18:12:54.233Z",
+        isAuthorized: true,
         "type": TransmissionType.Information,
         "sender": {
           "actorType": ActorType.ServiceOwner,
@@ -152,6 +165,7 @@ export const getMockedTransmissions = (dialogId: string) => {
       {
         "id": "transmission-2",
         relatedTransmissionId: 'transmission-1',
+        isAuthorized: true,
         "createdAt": "2024-07-31T18:12:54.233Z",
         "type": TransmissionType.Information,
         "sender": {
@@ -181,6 +195,7 @@ export const getMockedTransmissions = (dialogId: string) => {
       {
         "id": "transmission-3",
         "createdAt": "2024-07-31T18:12:54.233Z",
+        isAuthorized: false,
         "type": TransmissionType.Information,
         "sender": {
           "actorType": ActorType.PartyRepresentative,
@@ -195,7 +210,7 @@ export const getMockedTransmissions = (dialogId: string) => {
             }],
             "mediaType": "text/plain"
           },
-          "contentReference": getMockedFCEContent('transmission-3'),
+          "contentReference": getMockedUnauthorizedFCEContent(),
           "summary": {
             "value": [ {
               value: 'Oppsummering 3',
@@ -209,6 +224,7 @@ export const getMockedTransmissions = (dialogId: string) => {
       {
         "id": "transmission-4",
         relatedTransmissionId: 'transmission-2',
+        isAuthorized: true,
         "createdAt": "2024-08-13T12:12:54.233Z",
         "type": TransmissionType.Information,
         "sender": {


### PR DESCRIPTION
Attachments and front channel embeds (both as main content on dialog and content on transmission) can be `unathorized` both  and should not be attempted to or available for the end user.

I seemingly forgot to add content references from dialog history, so this is in place now.

Just to be clear, this is only in order to prevent unwanted noise, not a security measure (this is already taken care of, rightfully so, of Dialogporten).

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1998 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
