### PR TITLE
chore(renovate): change rangeStategy to pin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>digdir/renovate-config"]
+  "extends": ["local>digdir/renovate-config"],
+  "rangeStrategy": "pin"
 }


### PR DESCRIPTION
Renovate lager PR-er som kun endrer lockfile dersom dependency er innenfor range siden vi ikke har låst versjon per dependency. 

jf. https://docs.renovatebot.com/configuration-options/

default er `auto` som gjør at vi får `update-lockfile ` som bare oppdaterer lockfile, og ikke manifest.
Gå over til pinned nå, ~eller som PR foreslår (her er jeg litt blank - har spurt https://digdir.slack.com/archives/C079D6P85AQ/p1743753569579859?thread_ts=1742975139.237819&cid=C079D6P85AQ ) gå over til "bump" (alltid lage innslag i manifest-fil i PR)~?

Er redd for mer renovate-spam enn nødvendig 😬 


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
