### PR TITLE
feat: fetch more

### DIFF
--- a/packages/bff-types-generated/queries/dialog.fragment.graphql
+++ b/packages/bff-types-generated/queries/dialog.fragment.graphql
@@ -224,3 +224,14 @@ fragment SeenLogFields on SeenLog {
   }
   isCurrentEndUser
 }
+
+fragment CountableDialogFields on SearchDialog {
+  id
+  party
+  updatedAt
+  status
+  systemLabel
+  seenSinceLastUpdate {
+    isCurrentEndUser
+  }
+}

--- a/packages/bff-types-generated/queries/dialogs.graphql
+++ b/packages/bff-types-generated/queries/dialogs.graphql
@@ -1,4 +1,39 @@
-query getAllDialogsForParties($partyURIs: [String!], $search: String, $org: [String!], $status: [DialogStatus!]) {
+query getAllDialogsForParties(
+  $partyURIs: [String!]
+  $search: String
+  $org: [String!]
+  $status: [DialogStatus!]
+  $continuationToken: String
+  $limit: Int
+  $label: [SystemLabel!]
+) {
+  searchDialogs(
+    input: {
+      party: $partyURIs
+      search: $search
+      org: $org
+      status: $status
+      continuationToken: $continuationToken
+      orderBy: { createdAt: null, updatedAt: DESC, dueAt: null }
+      systemLabel: $label
+      limit: $limit
+    }
+  ) {
+    items {
+      ...SearchDialogFields
+    }
+    hasNextPage
+    continuationToken
+  }
+}
+
+query getAllDialogsForCount(
+  $partyURIs: [String!]
+  $search: String
+  $org: [String!]
+  $status: [DialogStatus!]
+  $label: [SystemLabel!]
+) {
   searchDialogs(
     input: {
       party: $partyURIs
@@ -6,10 +41,11 @@ query getAllDialogsForParties($partyURIs: [String!], $search: String, $org: [Str
       org: $org
       status: $status
       orderBy: { createdAt: null, updatedAt: DESC, dueAt: null }
+      systemLabel: $label
     }
   ) {
     items {
-      ...SearchDialogFields
+      ...CountableDialogFields
     }
     hasNextPage
   }

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -23,9 +23,9 @@ import { useOrganizations } from '../../pages/Inbox/useOrganizations.ts';
 import { toTitleCase } from '../../profile';
 import { graphQLSDK } from '../queries.ts';
 import { getActivityHistory } from '../utils/activities.tsx';
+import { getSeenByLabel } from '../utils/dialog.ts';
 import { type OrganizationOutput, getOrganization } from '../utils/organizations.ts';
 import { getDialogHistoryForTransmissions } from '../utils/transmissions.ts';
-import { getSeenByLabel } from './useDialogs.tsx';
 
 export enum EmbeddableMediaType {
   markdown = 'application/vnd.dialogporten.frontchannelembed-url;type=text/markdown',
@@ -239,7 +239,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
     queryFn: () =>
       getDialogsById(id!).then((data) => {
         if (data?.dialogById.dialog) {
-          void queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.DIALOGS] });
+          void queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.COUNT_DIALOGS] });
         }
         return data;
       }),

--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -1,23 +1,11 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
-
-import {
-  DialogStatus,
-  type GetAllDialogsForPartiesQuery,
-  type GetSearchAutocompleteDialogsQuery,
-  type OrganizationFieldsFragment,
-  type PartyFieldsFragment,
-  type SearchAutocompleteDialogFieldsFragment,
-  type SearchDialogFieldsFragment,
-  SystemLabel,
-} from 'bff-types-generated';
-import { type TFunction, t } from 'i18next';
-import { useLocation } from 'react-router-dom';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
+import type { GetAllDialogsForPartiesQuery, PartyFieldsFragment } from 'bff-types-generated';
+import { useRef } from 'react';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
-import { getPreferredPropertyByLocale } from '../../i18n/property.ts';
 import type { InboxItemInput } from '../../pages/Inbox/InboxItemInput.ts';
 import { useOrganizations } from '../../pages/Inbox/useOrganizations.ts';
 import { graphQLSDK } from '../queries.ts';
-import { getOrganization } from '../utils/organizations.ts';
+import { getPartyIds, getQueryVariables, mapDialogToToInboxItems } from '../utils/dialog.ts';
 import { useParties } from './useParties.ts';
 
 export type InboxViewType = 'inbox' | 'drafts' | 'sent' | 'archive' | 'bin';
@@ -29,195 +17,62 @@ interface UseDialogsOutput {
   isSuccess: boolean;
   isLoading: boolean;
   isError: boolean;
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
 }
 
-export function mapDialogToToInboxItem(
-  input: SearchDialogFieldsFragment[],
-  parties: PartyFieldsFragment[],
-  organizations: OrganizationFieldsFragment[],
-): InboxItemInput[] {
-  return input.map((item) => {
-    const titleObj = item.content.title.value;
-    const summaryObj = item.content.summary.value;
-    const endUserParty = parties?.find((party) => party.isCurrentEndUser);
-    const senderName = item.content.senderName?.value;
-
-    const dialogReceiverParty = parties?.find((party) => party.party === item.party);
-    const dialogReceiverSubParty = parties?.find((party) =>
-      (party.subParties ?? []).some((subParty) => subParty.party === item.party),
-    );
-
-    const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
-    const serviceOwner = getOrganization(organizations || [], item.org, 'nb');
-    const { isSeenByEndUser, seenByOthersCount, seenByLabel } = getSeenByLabel(item.seenSinceLastUpdate, t);
-    return {
-      id: item.id,
-      party: item.party,
-      title: getPreferredPropertyByLocale(titleObj)?.value ?? '',
-      summary: getPreferredPropertyByLocale(summaryObj)?.value ?? '',
-      sender: {
-        name: getPreferredPropertyByLocale(senderName)?.value || serviceOwner?.name || '',
-        type: 'company',
-        imageUrl: serviceOwner?.logo,
-        imageUrlAlt: t('dialog.imageAltURL', { companyName: getPreferredPropertyByLocale(senderName)?.value }),
-      },
-      receiver: {
-        name: actualReceiverParty?.name ?? dialogReceiverSubParty?.name ?? '',
-        type: 'person',
-      },
-      guiAttachmentCount: item.guiAttachmentCount ?? 0,
-      createdAt: item.createdAt,
-      updatedAt: item.updatedAt,
-      status: item.status ?? 'UnknownStatus',
-      isSeenByEndUser,
-      label: item.systemLabel,
-      org: item.org,
-      seenByLabel,
-      seenByOthersCount,
-      viewType: getViewType(item),
-    };
-  });
-}
-
-export interface SearchAutocompleteDialogInput {
-  id: string;
-  title: string;
-  summary: string;
-  isSeenByEndUser: boolean;
-}
-
-export function mapAutocompleteDialogsDtoToInboxItem(
-  input: SearchAutocompleteDialogFieldsFragment[],
-): SearchAutocompleteDialogInput[] {
-  return input.map((item) => {
-    const titleObj = item.content.title.value;
-    const summaryObj = item.content.summary.value;
-    const isSeenByEndUser =
-      item.seenSinceLastUpdate.find((seenLogEntry) => seenLogEntry.isCurrentEndUser) !== undefined;
-    return {
-      id: item.id,
-      title: getPreferredPropertyByLocale(titleObj)?.value ?? '',
-      summary: getPreferredPropertyByLocale(summaryObj)?.value ?? '',
-      isSeenByEndUser,
-    };
-  });
-}
-
-interface SeenByItem {
-  isCurrentEndUser: boolean;
-}
-
-export const getSeenByLabel = (
-  seenBy: SeenByItem[],
-  t: TFunction<'translation', undefined>,
-): { isSeenByEndUser: boolean; seenByOthersCount: number; seenByLabel: string | undefined } => {
-  const isSeenByEndUser = seenBy?.some((item) => item.isCurrentEndUser);
-  const seenByOthersCount = seenBy?.filter((item) => !item.isCurrentEndUser).length;
-  let seenByLabel: string | undefined = undefined;
-  if (isSeenByEndUser) {
-    seenByLabel = `${t('word.seenBy')} ${t('word.you')}`;
-  }
-  if (seenByOthersCount > 0) {
-    seenByLabel = (seenByLabel ?? t('word.seenBy')) + (isSeenByEndUser ? ` + ` : ' ') + seenByOthersCount;
-  }
-
-  return { isSeenByEndUser, seenByOthersCount, seenByLabel };
-};
-
-export const searchDialogs = (
-  partyURIs: string[],
-  search: string | undefined,
-  org: string | undefined,
-): Promise<GetAllDialogsForPartiesQuery> => {
-  return graphQLSDK.getAllDialogsForParties({
-    partyURIs,
-    search: search?.length === 0 ? undefined : search,
-    org: org?.length === 0 ? undefined : org,
-  });
-};
-
-export const searchAutocompleteDialogs = (
-  partyURIs: string[],
-  search: string | undefined,
-): Promise<GetSearchAutocompleteDialogsQuery> => {
-  return graphQLSDK.getSearchAutocompleteDialogs({
-    partyURIs,
-    search,
-  });
-};
-
-export const getDialogs = (partyURIs: string[]): Promise<GetAllDialogsForPartiesQuery> =>
-  graphQLSDK.getAllDialogsForParties({
-    partyURIs,
-  });
-
-export const getPartyIds = (partiesToUse: PartyFieldsFragment[]) => {
-  const partyURIs = partiesToUse.filter((party) => !party.hasOnlyAccessToSubParties).map((party) => party.party);
-  const subPartyURIs = partiesToUse.flatMap((party) => (party.subParties ?? []).map((subParty) => subParty.party));
-  return [...partyURIs, ...subPartyURIs] as string[];
-};
-
-export const isBinDialog = (dialog: SearchDialogFieldsFragment): boolean => dialog.systemLabel === SystemLabel.Bin;
-
-export const isArchivedDialog = (dialog: SearchDialogFieldsFragment): boolean =>
-  dialog.systemLabel === SystemLabel.Archive;
-
-export const isInboxDialog = (dialog: SearchDialogFieldsFragment): boolean =>
-  !isBinDialog(dialog) &&
-  !isArchivedDialog(dialog) &&
-  [DialogStatus.New, DialogStatus.InProgress, DialogStatus.RequiresAttention, DialogStatus.Completed].includes(
-    dialog.status,
-  );
-
-export const isDraftDialog = (dialog: SearchDialogFieldsFragment): boolean =>
-  !isBinDialog(dialog) && !isArchivedDialog(dialog) && dialog.status === DialogStatus.Draft;
-
-export const isSentDialog = (dialog: SearchDialogFieldsFragment): boolean =>
-  !isBinDialog(dialog) && !isArchivedDialog(dialog) && dialog.status === DialogStatus.Sent;
-
-export const getViewType = (dialog: SearchDialogFieldsFragment): InboxViewType => {
-  if (isDraftDialog(dialog)) {
-    return 'drafts';
-  }
-  if (isArchivedDialog(dialog)) {
-    return 'archive';
-  }
-  if (isSentDialog(dialog)) {
-    return 'sent';
-  }
-  if (isBinDialog(dialog)) {
-    return 'bin';
-  }
-  if (isInboxDialog(dialog)) {
-    return 'inbox';
-  }
-  console.warn('Unknown dialog status, fallback=inbox', dialog.status);
-  return 'inbox';
-};
-
-export const useDialogs = (parties: PartyFieldsFragment[]): UseDialogsOutput => {
+export const useDialogs = (parties: PartyFieldsFragment[], viewType?: InboxViewType): UseDialogsOutput => {
   const { organizations } = useOrganizations();
   const { selectedParties } = useParties();
   const partiesToUse = parties ? parties : selectedParties;
-  const mergedPartiesWithSubParties = getPartyIds(partiesToUse);
-  const location = useLocation();
+  const partyIds = getPartyIds(partiesToUse);
+  const previousTokensRef = useRef<string>('');
+  const viewTypeKey = viewType ?? 'global';
 
-  const { data, isSuccess, isLoading, isError } = useQuery<GetAllDialogsForPartiesQuery>({
-    queryKey: [QUERY_KEYS.DIALOGS, mergedPartiesWithSubParties, location.pathname],
-    staleTime: 1000 * 60 * 10,
-    retry: 3,
-    queryFn: () => getDialogs(mergedPartiesWithSubParties),
-    enabled: mergedPartiesWithSubParties.length > 0,
-    gcTime: 0,
-    placeholderData: keepPreviousData,
-  });
+  const { data, isSuccess, isLoading, isError, fetchNextPage, isFetchingNextPage } =
+    useInfiniteQuery<GetAllDialogsForPartiesQuery>({
+      queryKey: [QUERY_KEYS.DIALOGS, partyIds, viewTypeKey],
+      staleTime: 1000 * 60 * 10,
+      retry: 3,
+      queryFn: (args) => {
+        const continuationToken = args.pageParam as string | undefined;
+        return graphQLSDK.getAllDialogsForParties({
+          partyURIs: partyIds,
+          continuationToken,
+          limit: 100,
+          ...getQueryVariables(viewType),
+        });
+      },
+      enabled: partyIds.length > 0,
+      gcTime: 0,
+      getNextPageParam(lastPage: GetAllDialogsForPartiesQuery): unknown | undefined | null {
+        const hasNextPage = lastPage?.searchDialogs?.hasNextPage;
+        const continuationToken = lastPage?.searchDialogs?.continuationToken;
+        if (hasNextPage && typeof continuationToken === 'string') {
+          previousTokensRef.current = continuationToken;
+          return continuationToken;
+        }
+      },
+      getPreviousPageParam(): unknown | undefined | null {
+        return previousTokensRef;
+      },
+      initialData: undefined,
+      initialPageParam: undefined,
+      placeholderData: keepPreviousData,
+    });
 
-  const dialogs = mapDialogToToInboxItem(data?.searchDialogs?.items ?? [], parties, organizations);
+  const content = data?.pages.flatMap((page) => page.searchDialogs?.items ?? []) || [];
+  const dialogCountInconclusive =
+    data?.pages?.[data?.pages.length - 1]?.searchDialogs?.hasNextPage === true ||
+    data?.pages?.[data?.pages.length - 1]?.searchDialogs?.items === null;
+  const dialogs = mapDialogToToInboxItems(content, parties, organizations);
 
   return {
     isLoading,
     isSuccess,
     isError,
+    fetchNextPage,
     dialogs,
     dialogsByView: {
       inbox: dialogs.filter((dialog) => dialog.viewType === 'inbox'),
@@ -226,6 +81,8 @@ export const useDialogs = (parties: PartyFieldsFragment[]): UseDialogsOutput => 
       archive: dialogs.filter((dialog) => dialog.viewType === 'archive'),
       bin: dialogs.filter((dialog) => dialog.viewType === 'bin'),
     },
-    dialogCountInconclusive: data?.searchDialogs?.hasNextPage === true || data?.searchDialogs?.items === null,
+    dialogCountInconclusive,
+    hasNextPage: data?.pages?.[data?.pages.length - 1]?.searchDialogs?.hasNextPage ?? false,
+    isFetchingNextPage,
   };
 };

--- a/packages/frontend/src/api/hooks/useDialogsCount.tsx
+++ b/packages/frontend/src/api/hooks/useDialogsCount.tsx
@@ -1,0 +1,63 @@
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import type {
+  CountableDialogFieldsFragment,
+  GetAllDialogsForCountQuery,
+  PartyFieldsFragment,
+} from 'bff-types-generated';
+import { useMemo } from 'react';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
+import { graphQLSDK } from '../queries.ts';
+import { getPartyIds, getQueryVariables } from '../utils/dialog.ts';
+import { getViewType } from '../utils/viewType.ts';
+import { useParties } from './useParties.ts';
+
+export type InboxViewType = 'inbox' | 'drafts' | 'sent' | 'archive' | 'bin';
+export type DialogsByViewCount = { [key in InboxViewType]: CountableDialogFieldsFragment[] };
+interface UseDialogsOutput {
+  dialogCountInconclusive: boolean;
+  dialogCountsByViewType: DialogsByViewCount;
+}
+
+export const useDialogsCount = (parties: PartyFieldsFragment[], viewType?: InboxViewType): UseDialogsOutput => {
+  const { selectedParties } = useParties();
+  const partiesToUse = parties ? parties : selectedParties;
+  const partyIds = getPartyIds(partiesToUse);
+
+  const { data } = useQuery<GetAllDialogsForCountQuery>({
+    queryKey: [QUERY_KEYS.COUNT_DIALOGS, partyIds, viewType],
+    staleTime: 1000 * 60 * 10,
+    retry: 3,
+    queryFn: () =>
+      graphQLSDK.getAllDialogsForCount({
+        partyURIs: partyIds,
+        ...getQueryVariables(viewType),
+      }),
+    enabled: partyIds.length > 0 && partyIds.length <= 20,
+    gcTime: 10 * 1000,
+    placeholderData: keepPreviousData,
+  });
+
+  const dialogCountsByViewType = useMemo(() => {
+    const items = data?.searchDialogs?.items ?? [];
+    const counts: DialogsByViewCount = {
+      inbox: [],
+      drafts: [],
+      sent: [],
+      archive: [],
+      bin: [],
+    };
+
+    for (const dialog of items) {
+      const viewType = getViewType(dialog);
+      if (counts[viewType]) {
+        counts[viewType].push(dialog);
+      }
+    }
+    return counts;
+  }, [data]);
+
+  return {
+    dialogCountsByViewType,
+    dialogCountInconclusive: data?.searchDialogs?.hasNextPage === true || data?.searchDialogs?.items === null,
+  };
+};

--- a/packages/frontend/src/api/queries.ts
+++ b/packages/frontend/src/api/queries.ts
@@ -3,6 +3,8 @@ import {
   type CreateSavedSearchMutation,
   type DeleteFavoriteActorMutation,
   type DeleteSavedSearchMutation,
+  type GetAllDialogsForPartiesQuery,
+  type GetSearchAutocompleteDialogsQuery,
   type OrganizationsQuery,
   type SavedSearchInput,
   type SavedSearchesQuery,
@@ -32,3 +34,24 @@ export const updateSystemLabel = (dialogId: string, label: SystemLabel): Promise
     dialogId,
     label,
   });
+export const searchDialogs = (
+  partyURIs: string[],
+  search: string | undefined,
+  org: string | undefined,
+): Promise<GetAllDialogsForPartiesQuery> => {
+  return graphQLSDK.getAllDialogsForParties({
+    partyURIs,
+    search: search?.length === 0 ? undefined : search,
+    org: org?.length === 0 ? undefined : org,
+  });
+};
+
+export const searchAutocompleteDialogs = (
+  partyURIs: string[],
+  search: string | undefined,
+): Promise<GetSearchAutocompleteDialogsQuery> => {
+  return graphQLSDK.getSearchAutocompleteDialogs({
+    partyURIs,
+    search,
+  });
+};

--- a/packages/frontend/src/api/utils/autcomplete.ts
+++ b/packages/frontend/src/api/utils/autcomplete.ts
@@ -1,0 +1,25 @@
+import type { SearchAutocompleteDialogFieldsFragment } from 'bff-types-generated';
+import { getPreferredPropertyByLocale } from '../../i18n/property.ts';
+export interface SearchAutocompleteDialogInput {
+  id: string;
+  title: string;
+  summary: string;
+  isSeenByEndUser: boolean;
+}
+
+export function mapAutocompleteDialogsDtoToInboxItem(
+  input: SearchAutocompleteDialogFieldsFragment[],
+): SearchAutocompleteDialogInput[] {
+  return input.map((item) => {
+    const titleObj = item.content.title.value;
+    const summaryObj = item.content.summary.value;
+    const isSeenByEndUser =
+      item.seenSinceLastUpdate.find((seenLogEntry) => seenLogEntry.isCurrentEndUser) !== undefined;
+    return {
+      id: item.id,
+      title: getPreferredPropertyByLocale(titleObj)?.value ?? '',
+      summary: getPreferredPropertyByLocale(summaryObj)?.value ?? '',
+      isSeenByEndUser,
+    };
+  });
+}

--- a/packages/frontend/src/api/utils/dialog.ts
+++ b/packages/frontend/src/api/utils/dialog.ts
@@ -1,0 +1,125 @@
+import {
+  DialogStatus,
+  type GetAllDialogsForPartiesQueryVariables,
+  type OrganizationFieldsFragment,
+  type PartyFieldsFragment,
+  type SearchDialogFieldsFragment,
+  SystemLabel,
+} from 'bff-types-generated';
+import { type TFunction, t } from 'i18next';
+import { getPreferredPropertyByLocale } from '../../i18n/property.ts';
+import type { InboxItemInput } from '../../pages/Inbox/InboxItemInput.ts';
+import type { InboxViewType } from '../hooks/useDialogs.tsx';
+import { getOrganization } from './organizations.ts';
+import { getViewType } from './viewType.ts';
+
+interface SeenByItem {
+  isCurrentEndUser: boolean;
+}
+
+export const getPartyIds = (partiesToUse: PartyFieldsFragment[]) => {
+  const partyURIs = partiesToUse.filter((party) => !party.hasOnlyAccessToSubParties).map((party) => party.party);
+  const subPartyURIs = partiesToUse.flatMap((party) => (party.subParties ?? []).map((subParty) => subParty.party));
+  return [...partyURIs, ...subPartyURIs] as string[];
+};
+
+export const getSeenByLabel = (
+  seenBy: SeenByItem[],
+  t: TFunction<'translation', undefined>,
+): { isSeenByEndUser: boolean; seenByOthersCount: number; seenByLabel: string | undefined } => {
+  const isSeenByEndUser = seenBy?.some((item) => item.isCurrentEndUser);
+  const seenByOthersCount = seenBy?.filter((item) => !item.isCurrentEndUser).length;
+  let seenByLabel: string | undefined = undefined;
+  if (isSeenByEndUser) {
+    seenByLabel = `${t('word.seenBy')} ${t('word.you')}`;
+  }
+  if (seenByOthersCount > 0) {
+    seenByLabel = (seenByLabel ?? t('word.seenBy')) + (isSeenByEndUser ? ` + ` : ' ') + seenByOthersCount;
+  }
+
+  return { isSeenByEndUser, seenByOthersCount, seenByLabel };
+};
+
+export function mapDialogToToInboxItems(
+  input: SearchDialogFieldsFragment[],
+  parties: PartyFieldsFragment[],
+  organizations: OrganizationFieldsFragment[],
+): InboxItemInput[] {
+  return input.map((item) => {
+    const titleObj = item.content.title.value;
+    const summaryObj = item.content.summary.value;
+    const endUserParty = parties?.find((party) => party.isCurrentEndUser);
+    const senderName = item.content.senderName?.value;
+
+    const dialogReceiverParty = parties?.find((party) => party.party === item.party);
+    const dialogReceiverSubParty = parties?.find((party) =>
+      (party.subParties ?? []).some((subParty) => subParty.party === item.party),
+    );
+
+    const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
+    const serviceOwner = getOrganization(organizations || [], item.org, 'nb');
+    const { isSeenByEndUser, seenByOthersCount, seenByLabel } = getSeenByLabel(item.seenSinceLastUpdate, t);
+    return {
+      id: item.id,
+      party: item.party,
+      title: getPreferredPropertyByLocale(titleObj)?.value ?? '',
+      summary: getPreferredPropertyByLocale(summaryObj)?.value ?? '',
+      sender: {
+        name: getPreferredPropertyByLocale(senderName)?.value || serviceOwner?.name || '',
+        type: 'company',
+        imageUrl: serviceOwner?.logo,
+        imageUrlAlt: t('dialog.imageAltURL', { companyName: getPreferredPropertyByLocale(senderName)?.value }),
+      },
+      receiver: {
+        name: actualReceiverParty?.name ?? dialogReceiverSubParty?.name ?? '',
+        type: 'person',
+      },
+      guiAttachmentCount: item.guiAttachmentCount ?? 0,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      status: item.status ?? 'UnknownStatus',
+      isSeenByEndUser,
+      label: item.systemLabel,
+      org: item.org,
+      seenByLabel,
+      seenByOthersCount,
+      viewType: getViewType(item),
+    };
+  });
+}
+
+export const getQueryVariables = (viewType?: InboxViewType): Partial<GetAllDialogsForPartiesQueryVariables> => {
+  if (!viewType) {
+    return {};
+  }
+
+  switch (viewType) {
+    case 'inbox':
+      return {
+        status: [DialogStatus.New, DialogStatus.InProgress, DialogStatus.RequiresAttention, DialogStatus.Completed],
+        label: SystemLabel.Default,
+      };
+    case 'drafts':
+      return {
+        status: [DialogStatus.Draft],
+        label: SystemLabel.Default,
+      };
+    case 'sent':
+      return {
+        status: [DialogStatus.Sent],
+        label: SystemLabel.Default,
+      };
+    case 'archive':
+      return {
+        label: SystemLabel.Archive,
+      };
+    case 'bin':
+      return {
+        label: SystemLabel.Bin,
+      };
+    default: {
+      console.error(`Unknown viewType: ${viewType}`);
+      return {};
+    }
+  }
+};

--- a/packages/frontend/src/api/utils/viewType.ts
+++ b/packages/frontend/src/api/utils/viewType.ts
@@ -1,0 +1,44 @@
+import { DialogStatus, SystemLabel } from 'bff-types-generated';
+import type { InboxViewType } from '../hooks/useDialogs.tsx';
+
+type viewTypeDerivable = {
+  systemLabel: SystemLabel;
+  status: DialogStatus;
+};
+
+export const isBinDialog = (dialog: viewTypeDerivable): boolean => dialog.systemLabel === SystemLabel.Bin;
+
+export const isArchivedDialog = (dialog: viewTypeDerivable): boolean => dialog.systemLabel === SystemLabel.Archive;
+
+export const isInboxDialog = (dialog: viewTypeDerivable): boolean =>
+  !isBinDialog(dialog) &&
+  !isArchivedDialog(dialog) &&
+  [DialogStatus.New, DialogStatus.InProgress, DialogStatus.RequiresAttention, DialogStatus.Completed].includes(
+    dialog.status,
+  );
+
+export const isDraftDialog = (dialog: viewTypeDerivable): boolean =>
+  !isBinDialog(dialog) && !isArchivedDialog(dialog) && dialog.status === DialogStatus.Draft;
+
+export const isSentDialog = (dialog: viewTypeDerivable): boolean =>
+  !isBinDialog(dialog) && !isArchivedDialog(dialog) && dialog.status === DialogStatus.Sent;
+
+export const getViewType = (dialog: viewTypeDerivable): InboxViewType => {
+  if (isDraftDialog(dialog)) {
+    return 'drafts';
+  }
+  if (isArchivedDialog(dialog)) {
+    return 'archive';
+  }
+  if (isSentDialog(dialog)) {
+    return 'sent';
+  }
+  if (isBinDialog(dialog)) {
+    return 'bin';
+  }
+  if (isInboxDialog(dialog)) {
+    return 'inbox';
+  }
+  console.warn('Unknown dialog status, fallback=inbox', dialog.status);
+  return 'inbox';
+};

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
@@ -9,8 +9,8 @@ import type { PartyFieldsFragment } from 'bff-types-generated';
 import { type ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { getPartyIds } from '../../../api/hooks/useDialogs.tsx';
 import { useParties } from '../../../api/hooks/useParties.ts';
+import { getPartyIds } from '../../../api/utils/dialog.ts';
 import type { PageRoutes } from '../../../pages/routes.ts';
 import { getAlertBadgeProps } from '../GlobalMenu';
 

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
@@ -4,7 +4,7 @@ import {
   BookmarkIcon,
   DocPencilIcon,
   FileCheckmarkIcon,
-  InboxIcon,
+  InboxFillIcon,
   MenuGridIcon,
   PersonChatIcon,
   TrashIcon,
@@ -102,7 +102,7 @@ export const useGlobalMenu = ({
       id: '1',
       groupId: 'global',
       size: 'lg',
-      icon: { svgElement: InboxIcon, theme: 'base' },
+      icon: { svgElement: InboxFillIcon, theme: 'base' },
       title: t('sidebar.inbox'),
       iconBadge: getAlertBadgeProps(needsAttentionPerView.inbox),
       badge: getBadgeProps(itemsPerViewCount.inbox, dialogCountsInconclusive),
@@ -115,7 +115,7 @@ export const useGlobalMenu = ({
         {
           id: '2',
           groupId: '2',
-          icon: DocPencilIcon,
+          icon: { svgElement: DocPencilIcon, theme: 'default' },
           title: t('sidebar.drafts'),
           badge: getBadgeProps(itemsPerViewCount.drafts, dialogCountsInconclusive),
           selected: pathname === PageRoutes.drafts,
@@ -126,7 +126,7 @@ export const useGlobalMenu = ({
         {
           id: '3',
           groupId: '2',
-          icon: FileCheckmarkIcon,
+          icon: { svgElement: FileCheckmarkIcon, theme: 'default' },
           title: t('sidebar.sent'),
           badge: getBadgeProps(itemsPerViewCount.sent, dialogCountsInconclusive),
           selected: pathname === PageRoutes.sent,
@@ -137,7 +137,7 @@ export const useGlobalMenu = ({
         {
           id: '4',
           groupId: '3',
-          icon: BookmarkIcon,
+          icon: { svgElement: BookmarkIcon, theme: 'default' },
           title: t('sidebar.saved_searches'),
           badge: getBadgeProps(itemsPerViewCount['saved-searches']),
           selected: pathname === PageRoutes.savedSearches,
@@ -148,7 +148,7 @@ export const useGlobalMenu = ({
         {
           id: '5',
           groupId: '4',
-          icon: ArchiveIcon,
+          icon: { svgElement: ArchiveIcon, theme: 'default' },
           title: t('sidebar.archived'),
           badge: getBadgeProps(itemsPerViewCount.archive, dialogCountsInconclusive),
           selected: pathname === PageRoutes.archive,
@@ -159,7 +159,7 @@ export const useGlobalMenu = ({
         {
           id: '6',
           groupId: '4',
-          icon: TrashIcon,
+          icon: { svgElement: TrashIcon, theme: 'default' },
           title: t('sidebar.deleted'),
           badge: getBadgeProps(itemsPerViewCount.bin, dialogCountsInconclusive),
           selected: pathname === PageRoutes.bin,

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -11,6 +11,7 @@ import { type ChangeEvent, useEffect, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useLocation, useSearchParams } from 'react-router-dom';
 import { useDialogs } from '../../api/hooks/useDialogs.tsx';
+import { useDialogsCount } from '../../api/hooks/useDialogsCount.tsx';
 import { useParties } from '../../api/hooks/useParties.ts';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
 import { useSavedSearches } from '../../pages/SavedSearches/useSavedSearches.tsx';
@@ -37,7 +38,8 @@ export const PageLayout: React.FC = () => {
   const queryClient = useQueryClient();
   const { searchValue, setSearchValue, onClear } = useSearchString();
   const { selectedProfile, selectedParties, parties, selectedPartyIds, allOrganizationsSelected } = useParties();
-  const { dialogsByView, dialogCountInconclusive: partyDialogsCountInconclusive } = useDialogs(selectedParties);
+  const { dialogCountsByViewType, dialogCountInconclusive: partyDialogsCountInconclusive } =
+    useDialogsCount(selectedParties);
   const { dialogsByView: allDialogsByView, dialogCountInconclusive: allDialogCountInconclusive } = useDialogs(parties);
   const { autocomplete } = useSearchAutocompleteDialogs({ selectedParties: selectedParties, searchValue });
   const { accounts, selectedAccount, accountSearch, accountGroups, onSelectAccount } = useAccounts({
@@ -50,21 +52,25 @@ export const PageLayout: React.FC = () => {
   const { currentPartySavedSearches } = useSavedSearches(selectedPartyIds);
 
   const needsAttentionPerView = {
-    inbox: dialogsByView.inbox.filter((item) => !item.isSeenByEndUser).length,
-    drafts: dialogsByView.drafts.filter((item) => !item.isSeenByEndUser).length,
-    sent: dialogsByView.sent.filter((item) => !item.isSeenByEndUser).length,
+    inbox: dialogCountsByViewType.inbox.filter((item) => !item.seenSinceLastUpdate?.some((s) => s.isCurrentEndUser))
+      .length,
+    drafts: dialogCountsByViewType.drafts.filter((item) => !item.seenSinceLastUpdate?.some((s) => s.isCurrentEndUser))
+      .length,
+    sent: dialogCountsByViewType.sent.filter((item) => !item.seenSinceLastUpdate?.some((s) => s.isCurrentEndUser))
+      .length,
     'saved-searches': 0,
-    archive: dialogsByView.archive.filter((item) => !item.isSeenByEndUser).length,
-    bin: dialogsByView.bin.filter((item) => !item.isSeenByEndUser).length,
+    archive: dialogCountsByViewType.archive.filter((item) => !item.seenSinceLastUpdate?.some((s) => s.isCurrentEndUser))
+      .length,
+    bin: dialogCountsByViewType.bin.filter((item) => !item.seenSinceLastUpdate?.some((s) => s.isCurrentEndUser)).length,
   };
 
   const itemsPerViewCount = {
-    inbox: dialogsByView.inbox.length,
-    drafts: dialogsByView.drafts.length,
-    sent: dialogsByView.sent.length,
+    inbox: dialogCountsByViewType.inbox.length,
+    drafts: dialogCountsByViewType.drafts.length,
+    sent: dialogCountsByViewType.sent.length,
     'saved-searches': currentPartySavedSearches?.length ?? 0,
-    archive: dialogsByView.archive.length,
-    bin: dialogsByView.bin.length,
+    archive: dialogCountsByViewType.archive.length,
+    bin: dialogCountsByViewType.bin.length,
   };
 
   const footer: FooterProps = useFooter();

--- a/packages/frontend/src/components/PageLayout/Search/useSearchAutocompleteDialogs.spec.ts
+++ b/packages/frontend/src/components/PageLayout/Search/useSearchAutocompleteDialogs.spec.ts
@@ -2,7 +2,7 @@ import type { DialogStatus, SystemLabel } from 'bff-types-generated';
 import { describe, expect, it } from 'vitest';
 import type { InboxViewType } from '../../../api/hooks/useDialogs.tsx';
 import type { InboxItemInput } from '../../../pages/Inbox/InboxItemInput.ts';
-import { generateSendersAutocompleteBySearchString } from './useSearchAutocompleteDialogs';
+import { createSendersForAutocomplete } from './useSearchAutocompleteDialogs';
 
 describe('generateSendersAutocompleteBySearchString', () => {
   const mockDialogs: InboxItemInput[] = [
@@ -60,7 +60,7 @@ describe('generateSendersAutocompleteBySearchString', () => {
   ];
 
   it('should return no hits when sender (searchValue) is empty', () => {
-    const result = generateSendersAutocompleteBySearchString('', mockDialogs as InboxItemInput[]);
+    const result = createSendersForAutocomplete('', mockDialogs as InboxItemInput[]);
     expect(result.items).toEqual([]);
     expect(result.groups).toEqual({
       noHits: { title: 'noHits' },
@@ -68,8 +68,8 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return matched sender when search value matches sender name', () => {
-    const resultSKD = generateSendersAutocompleteBySearchString('skat', mockDialogs as InboxItemInput[]);
-    const resultSSB = generateSendersAutocompleteBySearchString('sentralby', mockDialogs as InboxItemInput[]);
+    const resultSKD = createSendersForAutocomplete('skat', mockDialogs as InboxItemInput[]);
+    const resultSSB = createSendersForAutocomplete('sentralby', mockDialogs as InboxItemInput[]);
 
     expect(resultSKD.items).toHaveLength(1);
     expect(resultSKD.items[0].title).toBe('Skatteetaten');
@@ -85,7 +85,7 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return matched sender and unmatched search string', () => {
-    const resultSKD = generateSendersAutocompleteBySearchString('skat test1', mockDialogs as InboxItemInput[]);
+    const resultSKD = createSendersForAutocomplete('skat test1', mockDialogs as InboxItemInput[]);
     //@ts-ignore Property 'params' does not exist on type 'AutocompleteItemProps'.
     const searchUnmatechedValue = resultSKD.items[0].params.find((item) => item.type === 'search');
     expect(searchUnmatechedValue.type === 'search');
@@ -99,7 +99,7 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return all matched senders and unmatched search string if provided', () => {
-    const result = generateSendersAutocompleteBySearchString('skat sentralby test1', mockDialogs as InboxItemInput[]);
+    const result = createSendersForAutocomplete('skat sentralby test1', mockDialogs as InboxItemInput[]);
     //@ts-ignore Property 'params' does not exist on type 'AutocompleteItemProps'.
     const searchUnmatechedValueSKD = result.items[0].params.find((item) => item.type === 'search');
     //@ts-ignore Property 'params' does not exist on type 'AutocompleteItemProps'.
@@ -121,7 +121,7 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return no hits when search value does not match any sender name', () => {
-    const result = generateSendersAutocompleteBySearchString('Nonexistent Sender', mockDialogs as InboxItemInput[]);
+    const result = createSendersForAutocomplete('Nonexistent Sender', mockDialogs as InboxItemInput[]);
 
     expect(result.items).toEqual([]);
     expect(result.groups).toEqual({

--- a/packages/frontend/src/components/PageLayout/Search/useSearchDialogs.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/useSearchDialogs.tsx
@@ -3,7 +3,8 @@ import type { DialogStatus, GetAllDialogsForPartiesQuery, PartyFieldsFragment } 
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
-import { mapDialogToToInboxItem, searchDialogs } from '../../../api/hooks/useDialogs.tsx';
+import { searchDialogs } from '../../../api/queries.ts';
+import { mapDialogToToInboxItems } from '../../../api/utils/dialog.ts';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import type { InboxItemInput } from '../../../pages/Inbox/InboxItemInput.ts';
 import { useOrganizations } from '../../../pages/Inbox/useOrganizations.ts';
@@ -39,7 +40,7 @@ export const useSearchDialogs = ({ parties, searchValue }: searchDialogsProps): 
   const [searchResults, setSearchResults] = useState([] as InboxItemInput[]);
 
   useEffect(() => {
-    setSearchResults(enabled ? mapDialogToToInboxItem(data?.searchDialogs?.items ?? [], parties, organizations) : []);
+    setSearchResults(enabled ? mapDialogToToInboxItems(data?.searchDialogs?.items ?? [], parties, organizations) : []);
   }, [data?.searchDialogs?.items, enabled, parties, organizations]);
 
   return {

--- a/packages/frontend/src/constants/queryKeys.ts
+++ b/packages/frontend/src/constants/queryKeys.ts
@@ -7,6 +7,7 @@ export const QUERY_KEYS = {
   SEARCH_DIALOGS: 'searchDialogs',
   SEARCH_AUTOCOMPLETE_DIALOGS: 'searchAutocompleteDialogs',
   DIALOGS: 'dialogs',
+  COUNT_DIALOGS: 'countDialogs',
   MAIN_CONTENT_REFERENCE: 'mainContentReference',
   SAVED_SEARCHES: 'savedSearches',
   PROFILE: 'profile',

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -16,6 +16,8 @@
   "activity.status.sent_to_signing": "Sent to signing by {actor}.",
   "activity.status.signature_provided": "Signature provided by {actor}.",
   "activity.status.transmission_opened": "{transmission} opened by {actor}.",
+  "dialog.fetch_more": "Show more ...",
+  "dialog.aria.fetch_more": "Fetch and show more dialogs",
   "dialog.tabs.transmissions": "Last activity",
   "dialog.tabs.additional_info": "Additional information",
   "dialog.tabs.activities": "Activities",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -16,6 +16,8 @@
   "activity.status.sent_to_signing": "Sendt til signering av {actor}.",
   "activity.status.signature_provided": "Signert av {actor}.",
   "activity.status.transmission_opened": "{transmission} åpnet av {actor}.",
+  "dialog.aria.fetch_more": "Hent og vis flere dialoger",
+  "dialog.fetch_more": "Vis flere ...",
   "dialog.tabs.transmissions": "Siste aktivitet",
   "dialog.tabs.additional_info": "Tilleggsinformasjon",
   "dialog.tabs.activities": "Aktivitetslogg",

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -34,6 +34,7 @@ interface UseGroupedDialogsProps {
   displaySearchResults: boolean;
   viewType: InboxViewType;
   isLoading: boolean;
+  isFetchingNextPage?: boolean;
 }
 
 const sortByUpdatedAt = (arr: DialogListItemProps[]) => {
@@ -75,6 +76,7 @@ const useGroupedDialogs = ({
   displaySearchResults,
   viewType,
   isLoading,
+  isFetchingNextPage,
 }: UseGroupedDialogsProps): UseGroupedDialogsOutput => {
   const { t } = useTranslation();
   const format = useFormat();
@@ -129,8 +131,12 @@ const useGroupedDialogs = ({
     }
 
     if (!displaySearchResults && isNotInbox) {
+      const groupedDialogs = items.map((item) => formatDialogItem(item, item.viewType));
+      if (isFetchingNextPage) {
+        groupedDialogs.push(...renderLoadingItems(1));
+      }
       return {
-        groupedDialogs: items.map((item) => formatDialogItem(item, viewType)),
+        groupedDialogs,
         groups: {
           [viewType]: { title: t(`inbox.heading.title.${viewType}`, { count: items.length }) },
         },
@@ -184,6 +190,9 @@ const useGroupedDialogs = ({
     );
 
     const groupedDialogs = sortByUpdatedAt(mappedGroupedDialogs);
+    if (isFetchingNextPage) {
+      groupedDialogs.push(...renderLoadingItems(1));
+    }
 
     return { groupedDialogs, groups };
   }, [items, displaySearchResults, t, format, isNotInbox, viewType, allWithinSameYear, isLoading]);


### PR DESCRIPTION
This PR introduces "Fetch more" button at the bottom of the dialog list to allow users to load additional dialogs beyond the initial 100 (this number is configurable and up for discussion). This enables access to older dialogs within the current folder or view type. This uses [useInfiniteQuery](https://tanstack.com/query/v4/docs/framework/react/reference/useInfiniteQuery) from React Query to implement this pagination behavior cleanly and efficiently.
![image](https://github.com/user-attachments/assets/5137c8cd-222e-44fa-b36b-1e21e5b2ac82)

A few simplifications worth noting:
- Performance on large datasets: Repeatedly fetching more (e.g., for users with 800+ dialogs) may lead to sluggish UI due to rendering many items in the DOM. This is an acceptable trade-off for now, as we expect users to rely more on filters or search for deep navigation. In the future, we can address this with virtualization (e.g. like we’ve done in the actor lists).
- Resets always start fresh: Switching between view types or folders, or otherwise resetting the list, will always start from the first page of results. This keeps the logic simple and predictable.

**Refactoring notes:**
To support this, this PR suggest refactoring how dialogs are fetched:

Previously, we fetched the first 100 dialogs globally and then filtered them client-side based on view type (inbox, sent, etc.). This approach caused inconsistencies, especially when switching views or paginating.

Now, we fetch dialogs directly based on the selected view type/folder, with the relevant filters passed to Dialogporten. This ensures:
- Each view loads only the data it needs.
- Additional fetches ("fetch more") reliably append dialogs only relevant to the current view, avoiding incorrect or missing results.

This PR also introduces an improvement to the API calls to Dialogporten we use only in order collect count / unread dialogs:  `useDialogsCount` which only fetches a very minimal collection of fields instead of reusing `useDialogs` for this.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1663 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
