### PR TITLE
fix: use components from Designsystemet through Altinn components

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -21,10 +21,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.24.2",
-    "@digdir/designsystemet-css": "1.0.0-next.50",
-    "@digdir/designsystemet-react": "1.0.0-next.50",
-    "@digdir/designsystemet-theme": "1.0.0-next.50",
+    "@altinn/altinn-components": "^0.24.5",
     "@microsoft/applicationinsights-react-js": "17.3.2",
     "@microsoft/applicationinsights-web": "3.3.3",
     "@navikt/aksel-icons": "^7.14.1",

--- a/packages/frontend/src/components/BetaBanner/BetaBanner.tsx
+++ b/packages/frontend/src/components/BetaBanner/BetaBanner.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@digdir/designsystemet-react';
+import { DsButton } from '@altinn/altinn-components';
 import { InformationSquareIcon, XMarkIcon } from '@navikt/aksel-icons';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,9 +29,9 @@ export const BetaBanner = () => {
           testdata og kun ment for demonstrasjon.
         </span>
       </div>
-      <Button variant="tertiary" onClick={handleClick} type="button" className={styles.closeButton}>
+      <DsButton variant="tertiary" onClick={handleClick} type="button" className={styles.closeButton}>
         <XMarkIcon className={styles.closeIcon} aria-label={t('word.close')} />
-      </Button>
+      </DsButton>
     </section>
   );
 };

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
@@ -167,7 +167,10 @@ export const useAccounts = ({
     name: t('parties.labels.all_organizations'),
     type: 'company' as AccountType,
     groupId: 'secondary',
-    accountNames: organizations.map((party) => party.name),
+    items: organizations.map((party) => ({
+      name: party.name,
+      type: 'company' as AccountType,
+    })),
     badge: getAccountBadge(countableItems, organizations, dialogCountInconclusive),
     alertBadge: getAccountAlertBadge(countableItems, organizations),
   };

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -39,7 +39,8 @@ export const PageLayout: React.FC = () => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { searchValue, setSearchValue, onClear } = useSearchString();
-  const { selectedProfile, selectedParties, parties, selectedPartyIds, allOrganizationsSelected } = useParties();
+  const { selectedProfile, selectedParties, parties, selectedPartyIds, allOrganizationsSelected, currentEndUser } =
+    useParties();
   const { dialogCountsByViewType, dialogCountInconclusive: partyDialogsCountInconclusive } =
     useDialogsCount(selectedParties);
   const { dialogsByView: allDialogsByView, dialogCountInconclusive: allDialogCountInconclusive } = useDialogs(parties);
@@ -142,6 +143,7 @@ export const PageLayout: React.FC = () => {
       ...(accountSearch && {
         accountSearch,
       }),
+      currentEndUserLabel: t('parties.current_end_user', { name: currentEndUser?.name ?? 'n/a' }),
       isVirtualized: accounts.length > 20,
       logoutButton: {
         label: t('word.log_out'),

--- a/packages/frontend/src/components/ProfileButton/ProfileButton.tsx
+++ b/packages/frontend/src/components/ProfileButton/ProfileButton.tsx
@@ -1,4 +1,4 @@
-import { Button, type ButtonProps, Spinner } from '@digdir/designsystemet-react';
+import { DsButton, type DsButtonProps, DsSpinner } from '@altinn/altinn-components';
 import cx from 'classnames';
 
 import { useTranslation } from 'react-i18next';
@@ -6,7 +6,7 @@ import styles from './profileButton.module.css';
 
 type ProfileButtonProps = {
   isLoading?: boolean;
-} & Omit<ButtonProps, 'size'>;
+} & Omit<DsButtonProps, 'size'>;
 
 export const ProfileButton = (props: ProfileButtonProps) => {
   const { t } = useTranslation();
@@ -17,16 +17,16 @@ export const ProfileButton = (props: ProfileButtonProps) => {
 
   if (isLoading) {
     return (
-      <Button className={classes} {...restProps} aria-disabled data-size="sm" variant="tertiary">
-        <Spinner aria-label="loading" fontSize="0.875rem" />
+      <DsButton className={classes} {...restProps} aria-disabled data-size="sm" variant="tertiary">
+        <DsSpinner aria-label="loading" fontSize="0.875rem" />
         {t('word.loading')}
-      </Button>
+      </DsButton>
     );
   }
 
   return (
-    <Button className={classes} {...restProps} variant="tertiary">
+    <DsButton className={classes} {...restProps} variant="tertiary">
       {children}
-    </Button>
+    </DsButton>
   );
 };

--- a/packages/frontend/src/globals.css
+++ b/packages/frontend/src/globals.css
@@ -1,13 +1,12 @@
 /* GLOBAL VARIABLES */
-@import "@digdir/designsystemet-css";
 @import "@altinn/altinn-components/dist/global.css";
 
 :root {
   /* Layer 1 - Semantic colors */
   --text-neutral-subtle: #5b6471;
   --text-accent-subtle: #0163ba;
-  /* temporary overrides until https://github.com/Altinn/altinn-components/issues/285 is solved */
-  --ds-body-md-font-size: 1rem; /* work-around until order of css is fixed */
+  /* work-around until tinted is available for colors in brand/theme in altinn-components */
+  --ds-color-neutral-surface-default: var(--ds-color-neutral-surface-tinted);
 }
 
 body,

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -17,6 +17,7 @@
   "activity.status.signature_provided": "Signature provided by {actor}.",
   "activity.status.transmission_opened": "{transmission} opened by {actor}.",
   "dialog.fetch_more": "Show more ...",
+  "parties.current_end_user": "Logged in as {name}",
   "dialog.aria.fetch_more": "Fetch and show more dialogs",
   "dialog.tabs.transmissions": "Last activity",
   "dialog.tabs.additional_info": "Additional information",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -18,6 +18,7 @@
   "activity.status.transmission_opened": "{transmission} åpnet av {actor}.",
   "dialog.aria.fetch_more": "Hent og vis flere dialoger",
   "dialog.fetch_more": "Vis flere ...",
+  "parties.current_end_user": "Logget inn som {name}",
   "dialog.tabs.transmissions": "Siste aktivitet",
   "dialog.tabs.additional_info": "Tilleggsinformasjon",
   "dialog.tabs.activities": "Aktivitetslogg",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -61,6 +61,7 @@
   "menuBar.all_services": "Alle tenester",
   "menuBar.chat": "Få hjelp på chat",
   "parties.groups.other_accounts": "Andre kontoar",
+  "parties.current_end_user": "Logga inn som {name}",
   "parties.groups.yourself": "Deg sjølv",
   "parties.labels.all_organizations": "Alle verksemder",
   "parties.results": "{hits, plural, one {# treff} other {# treff}}",

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './i18n/config.ts';
-import '@digdir/designsystemet-theme';
 
 import { RootProvider } from '@altinn/altinn-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -1,5 +1,4 @@
-import { DialogList, Heading, Section, Toolbar } from '@altinn/altinn-components';
-import { Alert, Button, Paragraph } from '@digdir/designsystemet-react';
+import { DialogList, DsAlert, DsButton, DsParagraph, Heading, Section, Toolbar } from '@altinn/altinn-components';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
@@ -87,13 +86,13 @@ export const Inbox = ({ viewType }: InboxProps) => {
   if (unableToLoadParties) {
     return (
       <section className={styles.noParties}>
-        <Alert data-color="danger">
+        <DsAlert data-color="danger">
           <Heading data-size="xs">{t('inbox.unable_to_load_parties.title')}</Heading>
-          <Paragraph>
+          <DsParagraph>
             {t('inbox.unable_to_load_parties.body')}
             <a href="/api/logout">{t('inbox.unable_to_load_parties.link')}</a>
-          </Paragraph>
-        </Alert>
+          </DsParagraph>
+        </DsAlert>
       </section>
     );
   }
@@ -145,9 +144,9 @@ export const Inbox = ({ viewType }: InboxProps) => {
           sortGroupBy={([aKey], [bKey]) => (groups[bKey]?.orderIndex ?? 0) - (groups[aKey]?.orderIndex ?? 0)}
         />
         {hasNextPage && (
-          <Button aria-label={t('dialog.aria.fetch_more')} onClick={fetchNextPage} variant="tertiary">
+          <DsButton aria-label={t('dialog.aria.fetch_more')} onClick={fetchNextPage} variant="tertiary">
             {t('dialog.fetch_more')}
-          </Button>
+          </DsButton>
         )}
       </Section>
     </>

--- a/packages/frontend/src/pages/Profile/Actors/Actors.tsx
+++ b/packages/frontend/src/pages/Profile/Actors/Actors.tsx
@@ -1,5 +1,4 @@
-import { ListBase, PageNav, Toolbar, Typography } from '@altinn/altinn-components';
-import { Alert, Chip } from '@digdir/designsystemet-react';
+import { DsAlert, DsChip, ListBase, PageNav, Toolbar, Typography } from '@altinn/altinn-components';
 import { useState } from 'react';
 import { useParties } from '../../../api/hooks/useParties';
 import { useProfile } from '../../../profile';
@@ -40,12 +39,12 @@ export const Actors = () => {
         ]}
       />
       <h1>Innstillinger for Mine aktører</h1>
-      <Alert className={styles.alert} data-color="info">
+      <DsAlert className={styles.alert} data-color="info">
         <Typography>
           <div className={styles.alertTitle}>På denne siden kan du organisere, favorisere og...</div>
           Her må vi legge inn utfyllende informasjon om maks antall aktører, favoritter o.l.
         </Typography>
-      </Alert>
+      </DsAlert>
       <div className={styles.searchContainer}>
         <Toolbar
           search={{
@@ -105,7 +104,7 @@ export const Actors = () => {
           showResultsLabel="Vis alle treff"
         >
           <div>
-            <Chip.Radio
+            <DsChip.Radio
               name="underenheter"
               value="underenheter"
               checked={showSubActors}
@@ -113,8 +112,8 @@ export const Actors = () => {
               onClick={() => setShowSubActors((showSubActors) => !showSubActors)}
             >
               Underenheter
-            </Chip.Radio>
-            <Chip.Radio
+            </DsChip.Radio>
+            <DsChip.Radio
               name="slettede-aktorer"
               value="slettede-aktorer"
               data-size="md"
@@ -122,7 +121,7 @@ export const Actors = () => {
               onClick={() => setShowDeletedActors(!showDeletedActors)}
             >
               Slettede aktører
-            </Chip.Radio>
+            </DsChip.Radio>
           </div>
         </Toolbar>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,17 +368,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: ^0.24.2
-        version: 0.24.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@digdir/designsystemet-css':
-        specifier: 1.0.0-next.50
-        version: 1.0.0-next.50
-      '@digdir/designsystemet-react':
-        specifier: 1.0.0-next.50
-        version: 1.0.0-next.50(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@digdir/designsystemet-theme':
-        specifier: 1.0.0-next.50
-        version: 1.0.0-next.50
+        specifier: ^0.24.5
+        version: 0.24.5(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@microsoft/applicationinsights-react-js':
         specifier: 17.3.2
         version: 17.3.2(history@4.10.1)(react@19.0.0)(tslib@2.8.1)
@@ -588,8 +579,8 @@ packages:
     resolution: {integrity: sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.24.2':
-    resolution: {integrity: sha512-8ySpM/oOTkl5TKqulD/yKhmxu2zWd5SboB18bdnFuGhGGpBU3jtzVxI9nhHBql+qlKyXdOecCmeGVIKbVv21AQ==}
+  '@altinn/altinn-components@0.24.5':
+    resolution: {integrity: sha512-uVPo4UN42ih2aEN3Qi8knMlhxWcvNIHLiUoqYcpHo3+hvrYht/jllWCtUwxqoMxKf3+e/kNSwqiMnd9MluZgJA==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -1624,17 +1615,17 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
-  '@digdir/designsystemet-css@1.0.0-next.50':
-    resolution: {integrity: sha512-Tloe8Nr7mvv5cjxWFn5teokoY707UW8OGoAsauMIl4U0sR3nnBQw6+VNZQOvebVUXQ/kxt7ShyldJ9f0735yqg==}
+  '@digdir/designsystemet-css@1.0.3':
+    resolution: {integrity: sha512-9WiE6XmGI8OfFmf1XyhrNpDRIMNFpPyqx5ij5AYqF6zqfqJ02DQelERenoDKJOIjcF6+gd33xzlOPAX8wJ485A==}
 
-  '@digdir/designsystemet-react@1.0.0-next.50':
-    resolution: {integrity: sha512-7FmELIuNzT4SunkQdA/HDkHcBqzYEccaC5up9+jgc67S7P3qRL1Tfp0wzqqRWjawZWY+Jz/yDykMWofV4RdUjg==}
+  '@digdir/designsystemet-react@1.0.3':
+    resolution: {integrity: sha512-bYqUhVI6mXQIpJQiYM1EA/AlC6OR5f98I4gXANUKqbnpbrpt2wAqP/81n42PgsYyxgHWY+NGDqLpGH5LL4twlQ==}
     peerDependencies:
-      react: '>=18.3.1'
-      react-dom: '>=18.3.1'
+      react: '>=18.3.1 || ^19.0.0'
+      react-dom: '>=18.3.1 || ^19.0.0'
 
-  '@digdir/designsystemet-theme@1.0.0-next.50':
-    resolution: {integrity: sha512-6+kdopfhZ8EuA4hzZ9KAlIRTU0Vcgyf9q697wt2Oz5eCWhiga/R1/W3C+HgNPr/OzF7odu1SJLisDgq14RXaiw==}
+  '@digdir/designsystemet-theme@1.0.3':
+    resolution: {integrity: sha512-Fdx0tGknFxp+dyMU95QvkGe2yNevjPTuW1FIKFcmZx/ZF5Txd9oZsSK6ylutlEc9R+BMd7yk2o5JI64x4ZqTgg==}
 
   '@digdir/dialogporten-schema@1.62.1-0ba6a7c':
     resolution: {integrity: sha512-KskPsaMtbK//i/m0dI9LDavms6CmBsxc9IuJw+0LnAxFvektvGfQGYRITkPqUaekrgs+H8ZHlW/zcTqO1iJz8A==}
@@ -3762,20 +3753,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
-  '@tanstack/react-virtual@3.11.2':
-    resolution: {integrity: sha512-OuFzMXPF4+xZgx8UzJha0AieuMihhhaWG0tCqpp6tDzlFwOmNBPYMuLOtMJ1Tr4pXLHmgjcWhG6RlknY2oNTdQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@tanstack/react-virtual@3.13.5':
     resolution: {integrity: sha512-MzSSMGkFWCDSb2xXqmdbfQqBG4wcRI3JKVjpYGZG0CccnViLpfRW4tGU97ImfBbSYzvEWJ/2SK/OiIoSmcUBAA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/virtual-core@3.11.2':
-    resolution: {integrity: sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==}
 
   '@tanstack/virtual-core@3.13.5':
     resolution: {integrity: sha512-gMLNylxhJdUlfRR1G3U9rtuwUh2IjdrrniJIDcekVJN3/3i+bluvdMi3+eodnxzJq5nKnxnigo9h0lIpaqV6HQ==}
@@ -4207,6 +4189,9 @@ packages:
 
   '@u-elements/u-details@0.1.0':
     resolution: {integrity: sha512-PAyTwXXsKj7SOI5U+iqSFrnOcMbOkw9aR6egTVlj4CgTZ+apxhS/RE5MW7t3LDXJp+ecVQA21u+XVyEGyuMW6Q==}
+
+  '@u-elements/u-tags@0.1.4':
+    resolution: {integrity: sha512-5VbqbFatd42ZY6Zf2d5MGvOIsJdflf5+ixpR4B5YT97dustT9csAS6SEHrUFgGdFzJDpASIbZdojsnU1j7GArA==}
 
   '@ungap/structured-clone@1.2.1':
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
@@ -10360,13 +10345,18 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.19.0
 
-  '@altinn/altinn-components@0.24.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@altinn/altinn-components@0.24.5(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
+      '@digdir/designsystemet-css': 1.0.3
+      '@digdir/designsystemet-react': 1.0.3(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@digdir/designsystemet-theme': 1.0.3
       '@navikt/aksel-icons': 7.14.1
       '@tanstack/react-virtual': 3.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       classnames: 2.5.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -11665,24 +11655,25 @@ snapshots:
     dependencies:
       postcss: 8.4.49
 
-  '@digdir/designsystemet-css@1.0.0-next.50': {}
+  '@digdir/designsystemet-css@1.0.3': {}
 
-  '@digdir/designsystemet-react@1.0.0-next.50(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@digdir/designsystemet-react@1.0.3(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@floating-ui/dom': 1.6.13
       '@floating-ui/react': 0.26.23(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@navikt/aksel-icons': 7.14.1
       '@radix-ui/react-slot': 1.1.1(@types/react@19.0.10)(react@19.0.0)
-      '@tanstack/react-virtual': 3.11.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-virtual': 3.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@u-elements/u-datalist': 0.1.3
       '@u-elements/u-details': 0.1.0
+      '@u-elements/u-tags': 0.1.4
       clsx: 2.1.1
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@digdir/designsystemet-theme@1.0.0-next.50': {}
+  '@digdir/designsystemet-theme@1.0.3': {}
 
   '@digdir/dialogporten-schema@1.62.1-0ba6a7c': {}
 
@@ -14739,19 +14730,11 @@ snapshots:
       '@tanstack/query-core': 5.62.16
       react: 19.0.0
 
-  '@tanstack/react-virtual@3.11.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@tanstack/virtual-core': 3.11.2
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-
   '@tanstack/react-virtual@3.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@tanstack/virtual-core': 3.13.5
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-
-  '@tanstack/virtual-core@3.11.2': {}
 
   '@tanstack/virtual-core@3.13.5': {}
 
@@ -15259,6 +15242,8 @@ snapshots:
   '@u-elements/u-datalist@0.1.3': {}
 
   '@u-elements/u-details@0.1.0': {}
+
+  '@u-elements/u-tags@0.1.4': {}
 
   '@ungap/structured-clone@1.2.1': {}
 


### PR DESCRIPTION
This PR removes designsystemet as a direct dependency and instead upgrades to the latest version of altinn-components, which now imports and exports components (for now unmodified) from designsystemet.

This aligns with the strategy of gradually bringing in the components we use from designsystemet, exporting them as DS<Component> so they can coexist with existing components for a transitional period. This avoids double imports and allows us to tweak and adapt the DS components to fit the look and behavior of altinn-components. Once they align well, we drop the DS prefix.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #2044 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
