### PR TITLE
feat: add route for front channel logout responsibility

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { ProtectedPageLayout } from './components/PageLayout/PageLayout.tsx';
 import { DialogDetailsPage } from './pages/DialogDetailsPage';
 import { Inbox } from './pages/Inbox';
-import { Logout } from './pages/LogoutPage';
+import { LoggedOut } from './pages/LogoutPage';
 import { Activities } from './pages/Profile/Activities/Activities.tsx';
 import { Actors } from './pages/Profile/Actors/Actors.tsx';
 import { Notifications } from './pages/Profile/Notifications/Notifications.tsx';
@@ -12,6 +12,7 @@ import { SavedSearchesPage } from './pages/SavedSearches';
 import { PageRoutes } from './pages/routes.ts';
 
 import './app.css';
+import { FrontChannelLogout } from './pages/LogoutPage/FrontChannelLogout.tsx';
 
 function App() {
   return (
@@ -33,7 +34,8 @@ function App() {
           <Route path={PageRoutes.activities} element={<Activities />} />
           <Route path="*" element={<Navigate to="/" />} />
         </Route>
-        <Route path="/loggedout" element={<Logout />} />
+        <Route path="/loggedout" element={<LoggedOut />} />
+        <Route path="/logout" element={<FrontChannelLogout />} />
       </Routes>
     </div>
   );

--- a/packages/frontend/src/pages/LogoutPage/FrontChannelLogout.tsx
+++ b/packages/frontend/src/pages/LogoutPage/FrontChannelLogout.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export const FrontChannelLogout = () => {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const sid = params.get('sid');
+    const iss = params.get('iss');
+
+    if (sid && iss) {
+      void fetch(`/api/frontchannel-logout?sid=${sid}&iss=${encodeURIComponent(iss)}`).catch((error) => {
+        console.error('Error during front channel logout:', error);
+      });
+    }
+  }, []);
+  return null;
+};

--- a/packages/frontend/src/pages/LogoutPage/LoggedOut.tsx
+++ b/packages/frontend/src/pages/LogoutPage/LoggedOut.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import styles from './logout.module.css';
 
-export const Logout = () => {
+export const LoggedOut = () => {
   const { t } = useTranslation();
   return (
     <main className={styles.logout}>

--- a/packages/frontend/src/pages/LogoutPage/index.ts
+++ b/packages/frontend/src/pages/LogoutPage/index.ts
@@ -1,1 +1,1 @@
-export { Logout } from './Logout';
+export { LoggedOut } from './LoggedOut.tsx';


### PR DESCRIPTION
## Support for frontchannel logout via IdPorten

This PR adds support for frontchannel logout in the app.

- The frontchannel logout URI (`/logout`) has been added as a route in the app.
- When this route is hit (via an iframe from IdPorten), the client extracts `sid` and `iss` from the URL parameters, forwarding the request to BFF's front channel endpoint (`/api/frontchannel-logout`) with these values. It cannot relieve on the cookie (and thus the current session) being available, so i needs to do a lookup in the session store before destroying it, cf. https://docs.digdir.no/docs/idporten/oidc/oidc_func_sso.html#2-h%C3%A5ndtere-utlogging-fra-id-porten-front-channel-logout
- The API endpoint validates `iss`, looks up the session based on `sid`, and deletes the associated session data if found.
- No redirect or user interface is shown – the logout happens silently in the background as specified by OIDC frontchannel logout.


## Related Issue(s)

- #2050 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
