### PR TITLE
feat(infra): enable workload profiles for CAE

### DIFF
--- a/.azure/applications/bff-migration-job/main.bicep
+++ b/.azure/applications/bff-migration-job/main.bicep
@@ -19,6 +19,9 @@ param appInsightConnectionString string
 @secure()
 param environmentKeyVaultName string
 
+@description('The workload profile name to use, defaults to "Consumption"')
+param workloadProfileName string = 'Consumption'
+
 var namePrefix = 'dp-fe-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-frontend-'
 var containerAppJobName = '${namePrefix}-bff-migration-job'
@@ -138,6 +141,7 @@ module containerAppJob '../../modules/containerAppJob/main.bicep' = {
     secrets: secrets
     command: ['pnpm', '--filter', 'bff', 'run', 'start']
     tags: tags
+    workloadProfileName: workloadProfileName
   }
 }
 

--- a/.azure/applications/bff-migration-job/prod.bicepparam
+++ b/.azure/applications/bff-migration-job/prod.bicepparam
@@ -4,6 +4,7 @@ param environment = 'prod'
 param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param oicdUrl = 'idporten.no'
+param workloadProfileName = 'Consumption'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/bff-migration-job/staging.bicepparam
+++ b/.azure/applications/bff-migration-job/staging.bicepparam
@@ -4,6 +4,7 @@ param environment = 'staging'
 param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param oicdUrl = 'test.idporten.no'
+param workloadProfileName = 'Consumption'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/bff-migration-job/test.bicepparam
+++ b/.azure/applications/bff-migration-job/test.bicepparam
@@ -4,6 +4,7 @@ param environment = 'test'
 param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param oicdUrl = 'test.idporten.no'
+param workloadProfileName = 'Consumption'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/bff-migration-job/yt01.bicepparam
+++ b/.azure/applications/bff-migration-job/yt01.bicepparam
@@ -4,6 +4,7 @@ param environment = 'yt01'
 param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param oicdUrl = 'test.idporten.no'
+param workloadProfileName = 'Consumption'
 
 // secrets
 param environmentKeyVaultName = readEnvironmentVariable('ENVIRONMENT_KEY_VAULT_NAME')

--- a/.azure/applications/bff/main.bicep
+++ b/.azure/applications/bff/main.bicep
@@ -42,6 +42,9 @@ param environmentKeyVaultName string
 @description('Additional environment variables to be added to the container app')
 param additionalEnvironmentVariables array = []
 
+@description('The workload profile name to use, defaults to "Consumption"')
+param workloadProfileName string = 'Consumption'
+
 var namePrefix = 'dp-fe-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-frontend-'
 var containerAppName = '${namePrefix}-bff'
@@ -187,6 +190,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     minReplicas: minReplicas
     maxReplicas: maxReplicas
     tags: tags
+    workloadProfileName: workloadProfileName
   }
 }
 

--- a/.azure/applications/bff/prod.bicepparam
+++ b/.azure/applications/bff/prod.bicepparam
@@ -9,6 +9,7 @@ param oicdUrl = 'idporten.no'
 param minReplicas = 2
 param maxReplicas = 3
 param graphiQLEnabled = 'false'
+param workloadProfileName = 'Consumption'
 
 param platformExchangeTokenEndpointUrl = 'https://platform.altinn.no/authentication/api/v1/exchange/id-porten'
 param platformProfileApiUrl = 'https://platform.altinn.no/profile/api/v1/'

--- a/.azure/applications/bff/staging.bicepparam
+++ b/.azure/applications/bff/staging.bicepparam
@@ -8,6 +8,7 @@ param dialogportenURL = 'https://altinn-tt02-api.azure-api.net/dialogporten/grap
 param oicdUrl = 'test.idporten.no'
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 param platformExchangeTokenEndpointUrl = 'https://platform.at22.altinn.cloud/authentication/api/v1/exchange/id-porten?test=true'
 param platformProfileApiUrl = 'https://platform.at22.altinn.cloud/profile/api/v1/'

--- a/.azure/applications/bff/test.bicepparam
+++ b/.azure/applications/bff/test.bicepparam
@@ -8,6 +8,7 @@ param dialogportenURL = 'https://altinn-dev-api.azure-api.net/dialogporten/graph
 param oicdUrl = 'test.idporten.no'
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 param platformExchangeTokenEndpointUrl = 'https://platform.at22.altinn.cloud/authentication/api/v1/exchange/id-porten?test=true'
 param platformProfileApiUrl = 'https://platform.at22.altinn.cloud/profile/api/v1/'

--- a/.azure/applications/bff/yt01.bicepparam
+++ b/.azure/applications/bff/yt01.bicepparam
@@ -8,6 +8,7 @@ param dialogportenURL = 'https://platform.yt01.altinn.cloud/dialogporten/graphql
 param oicdUrl = 'test.idporten.no'
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 param platformExchangeTokenEndpointUrl = 'https://platform.yt01.altinn.cloud/authentication/api/v1/exchange/id-porten?test=true'
 param platformProfileApiUrl = 'https://platform.yt01.altinn.cloud/profile/api/v1/'

--- a/.azure/applications/frontend/main.bicep
+++ b/.azure/applications/frontend/main.bicep
@@ -17,6 +17,9 @@ param containerAppEnvironmentName string
 @secure()
 param applicationInsightsInstrumentationKey string
 
+@description('The workload profile name to use, defaults to "Consumption"')
+param workloadProfileName string = 'Consumption'
+
 var namePrefix = 'dp-fe-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-frontend-'
 var serviceName = 'frontend'
@@ -75,6 +78,7 @@ module containerApp '../../modules/containerApp/main.bicep' = {
     maxReplicas: maxReplicas
     tags: tags
     environmentVariables: environmentVariables
+    workloadProfileName: workloadProfileName
   }
 }
 

--- a/.azure/applications/frontend/prod.bicepparam
+++ b/.azure/applications/frontend/prod.bicepparam
@@ -5,6 +5,7 @@ param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 // secrets
 param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/frontend/staging.bicepparam
+++ b/.azure/applications/frontend/staging.bicepparam
@@ -5,6 +5,7 @@ param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 // secrets
 param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/frontend/test.bicepparam
+++ b/.azure/applications/frontend/test.bicepparam
@@ -5,6 +5,7 @@ param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 // secrets
 param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/applications/frontend/yt01.bicepparam
+++ b/.azure/applications/frontend/yt01.bicepparam
@@ -5,6 +5,7 @@ param location = 'norwayeast'
 param imageTag = readEnvironmentVariable('IMAGE_TAG')
 param minReplicas = 2
 param maxReplicas = 3
+param workloadProfileName = 'Consumption'
 
 // secrets
 param containerAppEnvironmentName = readEnvironmentVariable('CONTAINER_APP_ENVIRONMENT_NAME')

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -28,6 +28,9 @@ param sshJumperAdminLoginGroupObjectId string
 @description('Whether to enable zone redundancy for the container app environment')
 param containerAppEnvZoneRedundancyEnabled bool = false
 
+@description('The workload profiles for the container app environment')
+param containerAppEnvWorkloadProfiles array = []
+
 import { Sku as RedisSku } from '../modules/redis/main.bicep'
 param redisSku RedisSku
 @minLength(1)
@@ -131,6 +134,7 @@ module containerAppEnv '../modules/containerAppEnv/main.bicep' = {
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
     subnetId: vnet.outputs.containerAppEnvironmentSubnetId
     zoneRedundancyEnabled: containerAppEnvZoneRedundancyEnabled
+    workloadProfiles: containerAppEnvWorkloadProfiles
     tags: tags
   }
 }

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -74,6 +74,7 @@ module vnet '../modules/vnet/main.bicep' = {
     location: location
     tags: tags
     applicationGatewayWhitelistedIps: applicationGatewayWhitelistedIps
+    environment: environment
   }
 }
 

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -77,7 +77,6 @@ module vnet '../modules/vnet/main.bicep' = {
     location: location
     tags: tags
     applicationGatewayWhitelistedIps: applicationGatewayWhitelistedIps
-    environment: environment
   }
 }
 

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -43,3 +43,9 @@ param sshJumperAdminLoginGroupObjectId = 'a94de4bf-0a83-4d30-baba-0c6a7365571c'
 
 // Container App Environment
 param containerAppEnvZoneRedundancyEnabled = true
+param containerAppEnvWorkloadProfiles = [
+  {
+    name: 'Consumption'
+    maximumCount: 10
+  }
+]

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -41,3 +41,9 @@ param sshJumperAdminLoginGroupObjectId = 'a94de4bf-0a83-4d30-baba-0c6a7365571c'
 
 // Container App Environment
 param containerAppEnvZoneRedundancyEnabled = true
+param containerAppEnvWorkloadProfiles = [
+  {
+    name: 'Consumption'
+    maximumCount: 10
+  }
+]

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -6,6 +6,14 @@ param redisVersion = '6.0'
 
 param keyVaultSourceKeys = json(readEnvironmentVariable('KEY_VAULT_SOURCE_KEYS'))
 
+// Container App Environment Configuration
+param containerAppEnvWorkloadProfiles = [
+  {
+    name: 'Consumption'
+    maximumCount: 10
+  }
+]
+
 // secrets
 param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
 param sourceKeyVaultSubscriptionId = readEnvironmentVariable('SOURCE_KEY_VAULT_SUBSCRIPTION_ID')

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -6,14 +6,6 @@ param redisVersion = '6.0'
 
 param keyVaultSourceKeys = json(readEnvironmentVariable('KEY_VAULT_SOURCE_KEYS'))
 
-// Container App Environment Configuration
-param containerAppEnvWorkloadProfiles = [
-  {
-    name: 'Consumption'
-    maximumCount: 10
-  }
-]
-
 // secrets
 param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
 param sourceKeyVaultSubscriptionId = readEnvironmentVariable('SOURCE_KEY_VAULT_SUBSCRIPTION_ID')
@@ -46,3 +38,11 @@ param applicationGatewayConfiguration = {
 
 // Altinn Product Dialogporten: Developers Dev
 param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+
+// Container App Environment Configuration
+param containerAppEnvWorkloadProfiles = [
+  {
+    name: 'Consumption'
+    maximumCount: 10
+  }
+]

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -6,6 +6,14 @@ param redisVersion = '6.0'
 
 param keyVaultSourceKeys = json(readEnvironmentVariable('KEY_VAULT_SOURCE_KEYS'))
 
+// Container App Environment Configuration
+param containerAppEnvWorkloadProfiles = [
+  {
+    name: 'Consumption'
+    maximumCount: 10
+  }
+]
+
 // secrets
 param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
 param sourceKeyVaultSubscriptionId = readEnvironmentVariable('SOURCE_KEY_VAULT_SUBSCRIPTION_ID')

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -6,14 +6,6 @@ param redisVersion = '6.0'
 
 param keyVaultSourceKeys = json(readEnvironmentVariable('KEY_VAULT_SOURCE_KEYS'))
 
-// Container App Environment Configuration
-param containerAppEnvWorkloadProfiles = [
-  {
-    name: 'Consumption'
-    maximumCount: 10
-  }
-]
-
 // secrets
 param dialogportenPgAdminPassword = readEnvironmentVariable('PG_ADMIN_PASSWORD')
 param sourceKeyVaultSubscriptionId = readEnvironmentVariable('SOURCE_KEY_VAULT_SUBSCRIPTION_ID')
@@ -46,3 +38,11 @@ param applicationGatewayConfiguration = {
 
 // Altinn Product Dialogporten: Developers Dev
 param sshJumperAdminLoginGroupObjectId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+
+// Container App Environment Configuration
+param containerAppEnvWorkloadProfiles = [
+  {
+    name: 'Consumption'
+    maximumCount: 10
+  }
+]

--- a/.azure/modules/containerApp/main.bicep
+++ b/.azure/modules/containerApp/main.bicep
@@ -10,6 +10,8 @@ param maxReplicas int = 3
 @description('The tags to apply to the resources')
 param tags object
 param secrets { name: string, keyVaultUrl: string, identity: 'System' }[] = []
+@description('The workload profile name to use, defaults to "Consumption"')
+param workloadProfileName string = 'Consumption'
 
 var healthProbes = empty(probes)
   ? [
@@ -63,6 +65,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         minReplicas: minReplicas
         maxReplicas: maxReplicas
       }
+      workloadProfileName: workloadProfileName
     }
   }
   tags: tags

--- a/.azure/modules/containerAppEnv/main.bicep
+++ b/.azure/modules/containerAppEnv/main.bicep
@@ -42,7 +42,7 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-10-02-preview' 
     availabilityZones: zoneRedundancyEnabled ? [
       '1', '2','3'
     ] : null
-    workloadProfiles: !empty(workloadProfiles) ? workloadProfiles : null
+    workloadProfiles: workloadProfiles
   }
   tags: tags
 }

--- a/.azure/modules/containerAppEnv/main.bicep
+++ b/.azure/modules/containerAppEnv/main.bicep
@@ -13,6 +13,9 @@ param appInsightWorkspaceName string
 @description('Whether to enable zone redundancy for the container app environment')
 param zoneRedundancyEnabled bool = false
 
+@description('The workload profiles for the container app environment')
+param workloadProfiles array = []
+
 @description('The tags to apply to the resources')
 param tags object
 
@@ -39,6 +42,7 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-10-02-preview' 
     availabilityZones: zoneRedundancyEnabled ? [
       '1', '2','3'
     ] : null
+    workloadProfiles: !empty(workloadProfiles) ? workloadProfiles : null
   }
   tags: tags
 }

--- a/.azure/modules/containerAppJob/main.bicep
+++ b/.azure/modules/containerAppJob/main.bicep
@@ -9,6 +9,8 @@ param command string[]
 param tags object
 
 param secrets { name: string, keyVaultUrl: string, identity: 'system' }[] = []
+@description('The workload profile name to use, defaults to "Consumption"')
+param workloadProfileName string = 'Consumption'
 
 var probes = [
   {
@@ -59,6 +61,7 @@ resource containerAppJob 'Microsoft.App/jobs@2024-03-01' = {
           command: command
         }
       ]
+      workloadProfileName: workloadProfileName
     }
   }
   tags: tags

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -7,6 +7,9 @@ param location string
 @description('The tags to apply to the resources')
 param tags object
 
+@description('The environment for the deployment')
+param environment string
+
 @description('Optional list of IP addresses/ranges to whitelist for incoming traffic')
 param applicationGatewayWhitelistedIps array = []
 
@@ -375,6 +378,14 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-09-01' = {
             id: containerAppEnvironmentNSG.id
           }
           privateLinkServiceNetworkPolicies: 'Disabled'
+          delegations: [
+            {
+              name: 'containerAppEnvironment'
+              properties: {
+                serviceName: 'Microsoft.App/environments'
+              }
+            }
+          ]
         }
       }
       {

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -7,9 +7,6 @@ param location string
 @description('The tags to apply to the resources')
 param tags object
 
-@description('The environment for the deployment')
-param environment string
-
 @description('Optional list of IP addresses/ranges to whitelist for incoming traffic')
 param applicationGatewayWhitelistedIps array = []
 


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->
Doing the same as we did for Dialogporten. Enabling workload profiles now, setting Consumption as the profile for all applications before we decide on what machines to use here. https://learn.microsoft.com/en-us/azure/container-apps/workload-profiles-overview

TLDR:
- Enables us to use dedicated machines for the container apps. (think Kubernetes nodes)
- Using Consumption aka automatic allocation and scaling for now

**NB:** Would need to recreate the CAEs, so some downtime is expected in each environment. 

## Related Issue(s)

- [#2257](https://github.com/Altinn/dialogporten/issues/2257)

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
