### PR TITLE
fix(infra): avoid using containerappenv subnet for private link in app gateway

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -185,7 +185,6 @@ module applicationGateway '../modules/applicationGateway/main.bicep' = {
     location: location
     containerAppEnvName: containerAppEnv.outputs.name
     subnetId: vnet.outputs.applicationGatewaySubnetId
-    targetSubnetId: vnet.outputs.containerAppEnvironmentSubnetId
     configuration: applicationGatewayConfiguration
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
     tags: tags

--- a/.azure/modules/applicationGateway/main.bicep
+++ b/.azure/modules/applicationGateway/main.bicep
@@ -209,7 +209,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2024-01-01' =
             id: resourceId(
               'Microsoft.Network/applicationGateways/privateLinkConfigurations',
               gatewayName,
-              '${gatewayName}-privateLinkConfig'
+              '${gatewayName}-plc'
             )
           }
         }

--- a/.azure/modules/applicationGateway/main.bicep
+++ b/.azure/modules/applicationGateway/main.bicep
@@ -7,9 +7,6 @@ param location string
 @description('The identifier of the subnet where the Application Gateway will be deployed.')
 param subnetId string
 
-@description('The identifier of the subnet where the Application Gateway will route requests.')
-param targetSubnetId string
-
 @description('The name of the existing container app environment to be used.')
 param containerAppEnvName string
 
@@ -192,7 +189,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2024-01-01' =
                 primary: true
                 privateIPAllocationMethod: 'Dynamic'
                 subnet: {
-                  id: targetSubnetId
+                  id: subnetId
                 }
               }
             }
@@ -212,7 +209,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2024-01-01' =
             id: resourceId(
               'Microsoft.Network/applicationGateways/privateLinkConfigurations',
               gatewayName,
-              '${gatewayName}-plc'
+              '${gatewayName}-privateLinkConfig'
             )
           }
         }


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

The container app environment subnet is exclusive to the container app environment. Will think that we can use the app gateway subnet to create the private link instead. 

## Related Issue(s)

- #N/A

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
