### PR TITLE
fix: show counts only for contented that is fetched when filter is applied

### DIFF
--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -63,8 +63,8 @@ export const Inbox = ({ viewType }: InboxProps) => {
 
   const validSearchString = enteredSearchValue.length > 2 ? enteredSearchValue : undefined;
   const hasValidFilters = Object.values(filterState).some((arr) => typeof arr !== 'undefined' && arr?.length > 0);
-  const displayAsSearchResults = hasValidFilters || !!validSearchString;
-  const enableSavedSearch = displayAsSearchResults && !isSavedSearchDisabled(filterState, enteredSearchValue);
+  const searchMode = viewType === 'inbox' && (hasValidFilters || !!validSearchString);
+  const enableSavedSearch = searchMode && !isSavedSearchDisabled(filterState, enteredSearchValue);
 
   const {
     dialogs,
@@ -98,13 +98,13 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const isLoading = isLoadingParties || isLoadingDialogs;
   const { groupedDialogs, groups } = useGroupedDialogs({
     items: dialogs,
-    displaySearchResults: displayAsSearchResults,
+    displaySearchResults: searchMode,
     filters: filterState,
     viewType,
     isLoading,
     isFetchingNextPage,
     getCollapsedGroupTitle: (count) => t(`inbox.heading.title.${viewType}`, { count }),
-    collapseGroups: displayAsSearchResults,
+    collapseGroups: viewType !== 'inbox',
   });
 
   const windowSize = useWindowSize();
@@ -179,12 +179,8 @@ export const Inbox = ({ viewType }: InboxProps) => {
       <Section>
         {dialogsSuccess && !dialogs.length && (
           <EmptyState
-            title={
-              displayAsSearchResults ? t('inbox.no_results.title') : t(`inbox.heading.title.${viewType}`, { count: 0 })
-            }
-            description={
-              displayAsSearchResults ? t('inbox.no_results.description') : t(`inbox.heading.description.${viewType}`)
-            }
+            title={searchMode ? t('inbox.no_results.title') : t(`inbox.heading.title.${viewType}`, { count: 0 })}
+            description={searchMode ? t('inbox.no_results.description') : t(`inbox.heading.description.${viewType}`)}
           />
         )}
         <DialogList

--- a/packages/frontend/src/pages/Inbox/filters.ts
+++ b/packages/frontend/src/pages/Inbox/filters.ts
@@ -140,7 +140,7 @@ export const getFilters = (
   allOrganizations: OrganizationFieldsFragment[],
   viewType: InboxViewType,
 ): ToolbarFilterProps[] => {
-  const orgsInFilteredDialogs = allDialogs.map((d) => d.org);
+  const orgsInFilteredDialogs = dialogs.map((d) => d.org);
   const orgCount = countOccurrences(orgsInFilteredDialogs);
   const orgsFoundInAllDialogs = Array.from(new Set(allDialogs.map((d) => d.org)));
 
@@ -158,8 +158,8 @@ export const getFilters = (
       .sort((a, b) => a.label?.localeCompare(b.label)),
   };
 
-  const statusList = allDialogs.map((p) => p.status);
-  const labelList = allDialogs.map((p) => p.systemLabel);
+  const statusList = dialogs.map((p) => p.status);
+  const labelList = dialogs.map((p) => p.label);
   const statusCount = countOccurrences(statusList);
   const labelCounts = countOccurrences(labelList);
 

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.spec.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.spec.tsx
@@ -227,7 +227,7 @@ describe('useGroupedDialogs', () => {
 
     expect(result.current.groupedDialogs).toHaveLength(7);
     expect(result.current.groups).toEqual({
-      inbox: { title: 'inbox.heading.search_results.inbox', orderIndex: null },
+      inbox: { title: 'inbox.heading.search_results.inbox', orderIndex: 4 },
     });
   });
 

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -36,7 +36,7 @@ interface UseGroupedDialogsProps {
   isFetchingNextPage?: boolean;
   /* true if the search results are displayed */
   displaySearchResults?: boolean;
-  /* collapse all groups into one group, default=false */
+  /* collapse all groups into one group, default=false 	(Only if displaySearchResults===true) */
   collapseGroups?: boolean;
   /* title for the collapsed group, only applicable if collapseGroups=true */
   getCollapsedGroupTitle?: (count: number) => string;
@@ -90,9 +90,8 @@ const useGroupedDialogs = ({
 
   const clockPrefix = t('word.clock_prefix');
   const formatString = `do MMMM yyyy ${clockPrefix ? `'${clockPrefix}' ` : ''}HH.mm`;
-
   const allWithinSameYear = items.every((d) => new Date(d.updatedAt).getFullYear() === new Date().getFullYear());
-  const isNotInbox = items.every((d) => ['drafts', 'sent', 'bin', 'archive'].includes(d.viewType));
+  const isInbox = viewType === 'inbox';
 
   const formatDialogItem = (item: InboxItemInput, groupId: string): DialogListItemProps => ({
     groupId,
@@ -139,7 +138,7 @@ const useGroupedDialogs = ({
       };
     }
 
-    if (!displaySearchResults && isNotInbox) {
+    if (!displaySearchResults && !isInbox) {
       const groupedDialogs = items.map((item) => formatDialogItem(item, item.viewType));
       if (isFetchingNextPage) {
         groupedDialogs.push(...renderLoadingItems(1));
@@ -183,7 +182,12 @@ const useGroupedDialogs = ({
         if (existingGroup) {
           existingGroup.items.push(item);
         } else {
-          const orderIndex = isDateKey ? (allWithinSameYear ? updatedAt.getMonth() : updatedAt.getFullYear()) : null;
+          const viewTypeIndex = ['bin', 'archive', 'sent', 'drafts', 'inbox'].indexOf(item.viewType);
+          const orderIndex = isDateKey
+            ? allWithinSameYear
+              ? updatedAt.getMonth()
+              : updatedAt.getFullYear()
+            : viewTypeIndex;
           acc.push({ id: groupKey, label, items: [item], orderIndex });
         }
 
@@ -200,11 +204,12 @@ const useGroupedDialogs = ({
     );
 
     const groupedDialogs = sortByUpdatedAt(mappedGroupedDialogs);
+
     if (isFetchingNextPage) {
       groupedDialogs.push(...renderLoadingItems(1));
     }
     return { groupedDialogs, groups };
-  }, [items, displaySearchResults, t, format, isNotInbox, viewType, allWithinSameYear, isLoading]);
+  }, [items, displaySearchResults, t, format, viewType, allWithinSameYear, isLoading]);
 };
 
 export default useGroupedDialogs;


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4ae2a60c-0a22-4524-a946-e3180243eae4)

The count for dialog matching the filter, should only count dialogs that are relevant for filters already applied (i.e. dialogs is has fetched already). 

Further more, if results (filter applied or search string provided) are listed in inbox, they should be grouped by folder, sorted by the logical order they appear in. 

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #2217 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
