### PR TITLE
chore(apps): upload source maps to app insights on deploy

### DIFF
--- a/.github/slack-templates/pipeline-failed.json
+++ b/.github/slack-templates/pipeline-failed.json
@@ -23,7 +23,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": "*Job Status:*\n• Infrastructure: ${{ env.INFRA_STATUS }}\n• Apps: ${{ env.APPS_STATUS }}\n• Build and Test: ${{ env.BUILD_AND_TEST_STATUS }}\n• Docker Build and Push: ${{ env.DOCKER_BUILD_AND_PUSH_STATUS }}\n• Publish Node Logger to NPM: ${{ env.PUBLISH_NODE_LOGGER_TO_NPM_STATUS }}\n• Release Please: ${{ env.RELEASE_PLEASE_STATUS }}\n• Notify Release Created: ${{ env.NOTIFY_RELEASE_CREATED_STATUS }}"
+            "text": "*Job Status:*\n• Infrastructure: ${{ env.INFRA_STATUS }}\n• Apps: ${{ env.APPS_STATUS }}\n• Build and Test: ${{ env.BUILD_AND_TEST_STATUS }}\n• Source Maps Upload: ${{ env.SOURCE_MAPS_UPLOAD_STATUS }}\n• Docker Build and Push: ${{ env.DOCKER_BUILD_AND_PUSH_STATUS }}\n• Publish Node Logger to NPM: ${{ env.PUBLISH_NODE_LOGGER_TO_NPM_STATUS }}\n• Release Please: ${{ env.RELEASE_PLEASE_STATUS }}\n• Notify Release Created: ${{ env.NOTIFY_RELEASE_CREATED_STATUS }}"
           }
         },
         {

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -97,8 +97,6 @@ jobs:
     with:
       environment: test
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
-      appInsightsName: dp-fe-test-applicationInsights
-      resourceGroupName: dp-fe-test-rg
 
   deploy-apps:
     name: Deploy apps to test

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -92,6 +92,8 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME }}
+      AZURE_SOURCE_MAPS_CONTAINER_NAME: ${{ secrets.AZURE_SOURCE_MAPS_CONTAINER_NAME }}
     with:
       environment: test
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -77,6 +77,27 @@ jobs:
       region: norwayeast
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
 
+  upload-source-maps:
+    name: Upload source maps to Application Insights
+    needs:
+      [
+        get-current-version,
+        check-for-changes,
+        generate-git-short-sha,
+        build-and-test
+      ]
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
+    uses: ./.github/workflows/workflow-upload-source-maps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    with:
+      environment: test
+      version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
+      appInsightsName: dp-fe-test-applicationInsights
+      resourceGroupName: dp-fe-test-rg
+
   deploy-apps:
     name: Deploy apps to test
     needs:
@@ -85,7 +106,8 @@ jobs:
         check-for-changes,
         generate-git-short-sha,
         docker-build-and-push,
-        deploy-infrastructure
+        deploy-infrastructure,
+        upload-source-maps
       ]
     # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to deploy the apps
     if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
@@ -112,6 +134,7 @@ jobs:
       build-and-test,
       docker-build-and-push,
       deploy-infrastructure,
+      upload-source-maps,
       deploy-apps,
     ]
     if: ${{ always() && failure() && !cancelled() }}
@@ -121,6 +144,7 @@ jobs:
       build_and_test_status: ${{ needs.build-and-test.result }}
       docker_build_and_push_status: ${{ needs.docker-build-and-push.result }}
       infra_status: ${{ needs.deploy-infrastructure.result }}
+      source_maps_upload_status: ${{ needs.upload-source-maps.result }}
       apps_status: ${{ needs.deploy-apps.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -77,12 +77,35 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
+  upload-source-maps:
+    name: Upload source maps to Application Insights
+    needs:
+      [
+        check-for-changes,
+        deploy-infrastructure
+      ]
+    if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
+    uses: ./.github/workflows/workflow-upload-source-maps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME }}
+      AZURE_SOURCE_MAPS_CONTAINER_NAME: ${{ secrets.AZURE_SOURCE_MAPS_CONTAINER_NAME }}
+    with:
+      environment: prod
+      version: ${{ inputs.version }}
+      appInsightsName: dp-fe-prod-applicationInsights
+      resourceGroupName: dp-fe-prod-rg
+      ref: "refs/tags/v${{ inputs.version }}"
+
   deploy-apps:
     name: Deploy apps to prod
     needs:
       [
         check-for-changes,
-        deploy-infrastructure
+        deploy-infrastructure,
+        upload-source-maps
       ]
     # we want deployment of apps to be dependent on a dry-run deployment of apps, but if deploying infrastructure is skipped, we still want to deploy the apps
     if: ${{ always() && !failure() && !cancelled() && (needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
@@ -120,6 +143,7 @@ jobs:
     name: Send Slack message on failure
     needs: [
       deploy-infrastructure,
+      upload-source-maps,
       deploy-apps,
     ]
     if: ${{ always() && failure() && !cancelled() }}
@@ -127,6 +151,7 @@ jobs:
     with:
       environment: prod
       infra_status: ${{ needs.deploy-infrastructure.result }}
+      source_maps_upload_status: ${{ needs.upload-source-maps.result }}
       apps_status: ${{ needs.deploy-apps.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -95,8 +95,6 @@ jobs:
     with:
       environment: prod
       version: ${{ inputs.version }}
-      appInsightsName: dp-fe-prod-applicationInsights
-      resourceGroupName: dp-fe-prod-rg
       ref: "refs/tags/v${{ inputs.version }}"
 
   deploy-apps:

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -75,8 +75,6 @@ jobs:
     with:
       environment: staging
       version: ${{ github.event.client_payload.version }}
-      appInsightsName: dp-fe-staging-applicationInsights
-      resourceGroupName: dp-fe-staging-rg
       ref: "refs/tags/v${{ github.event.client_payload.version }}"
 
   deploy-apps:

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -57,12 +57,35 @@ jobs:
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
 
+  upload-source-maps:
+    name: Upload source maps to Application Insights
+    needs:
+      [
+        check-for-changes,
+        deploy-infrastructure,
+      ]
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
+    uses: ./.github/workflows/workflow-upload-source-maps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME }}
+      AZURE_SOURCE_MAPS_CONTAINER_NAME: ${{ secrets.AZURE_SOURCE_MAPS_CONTAINER_NAME }}
+    with:
+      environment: staging
+      version: ${{ github.event.client_payload.version }}
+      appInsightsName: dp-fe-staging-applicationInsights
+      resourceGroupName: dp-fe-staging-rg
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
+
   deploy-apps:
     name: Deploy apps to staging
     needs:
       [
         check-for-changes,
         deploy-infrastructure,
+        upload-source-maps
       ]
     # we want deployment of apps to be dependent on deployment of infrastructure, but if infrastructure is skipped, we still want to deploy the apps
     if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
@@ -111,6 +134,7 @@ jobs:
     name: Send Slack message on failure
     needs: [
       deploy-infrastructure,
+      upload-source-maps,
       deploy-apps,
       publish-node-logger-to-npm,
     ]
@@ -119,6 +143,7 @@ jobs:
     with:
       environment: staging
       infra_status: ${{ needs.deploy-infrastructure.result }}
+      source_maps_upload_status: ${{ needs.upload-source-maps.result }}
       apps_status: ${{ needs.deploy-apps.result }}
       publish_node_logger_to_npm_status: ${{ needs.publish-node-logger-to-npm.result }}
     secrets:

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -56,6 +56,28 @@ jobs:
       environment: yt01
     secrets:
       GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}
+
+  upload-source-maps:
+    name: Upload source maps to Application Insights
+    needs:
+      [
+        check-for-changes,
+        deploy-infrastructure,
+      ]
+    if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
+    uses: ./.github/workflows/workflow-upload-source-maps.yml
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME }}
+      AZURE_SOURCE_MAPS_CONTAINER_NAME: ${{ secrets.AZURE_SOURCE_MAPS_CONTAINER_NAME }}
+    with:
+      environment: yt01
+      version: ${{ github.event.client_payload.version }}
+      appInsightsName: dp-fe-yt01-applicationInsights
+      resourceGroupName: dp-fe-yt01-rg
+      ref: "refs/tags/v${{ github.event.client_payload.version }}"
       
   deploy-apps:
     name: Deploy apps to YT01
@@ -63,6 +85,7 @@ jobs:
       [
         check-for-changes,
         deploy-infrastructure,
+        upload-source-maps
       ]
     if: ${{ always() && !failure() && !cancelled() && (github.event_name == 'workflow_dispatch' || needs.check-for-changes.outputs.hasApplicationChanges == 'true') }}
     uses: ./.github/workflows/workflow-deploy-apps.yml
@@ -98,6 +121,7 @@ jobs:
     name: Send Slack message on failure
     needs: [
       deploy-infrastructure,
+      upload-source-maps,
       deploy-apps,
     ]
     if: ${{ always() && failure() && !cancelled() }}
@@ -105,6 +129,7 @@ jobs:
     with:
       environment: yt01
       infra_status: ${{ needs.deploy-infrastructure.result }}
+      source_maps_upload_status: ${{ needs.upload-source-maps.result }}
       apps_status: ${{ needs.deploy-apps.result }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -75,8 +75,6 @@ jobs:
     with:
       environment: yt01
       version: ${{ github.event.client_payload.version }}
-      appInsightsName: dp-fe-yt01-applicationInsights
-      resourceGroupName: dp-fe-yt01-rg
       ref: "refs/tags/v${{ github.event.client_payload.version }}"
       
   deploy-apps:

--- a/.github/workflows/workflow-send-ci-cd-status-slack-message.yml
+++ b/.github/workflows/workflow-send-ci-cd-status-slack-message.yml
@@ -22,6 +22,10 @@ on:
         type: string
         description: "Status of the build and test job"
         default: "skipped"
+      source_maps_upload_status:
+        type: string
+        description: "Status of the source maps upload job"
+        default: "skipped"
       publish_node_logger_to_npm_status:
         type: string
         description: "Status of the publish node logger to npm job"
@@ -65,6 +69,7 @@ jobs:
             echo "INFRA_EMOJI=$(determine_emoji "${{ inputs.infra_status }}")"
             echo "APPS_EMOJI=$(determine_emoji "${{ inputs.apps_status }}")"
             echo "BUILD_AND_TEST_EMOJI=$(determine_emoji "${{ inputs.build_and_test_status }}")"
+            echo "SOURCE_MAPS_UPLOAD_EMOJI=$(determine_emoji "${{ inputs.source_maps_upload_status }}")"
             echo "DOCKER_BUILD_AND_PUSH_EMOJI=$(determine_emoji "${{ inputs.docker_build_and_push_status }}")"
             echo "PUBLISH_NODE_LOGGER_TO_NPM_EMOJI=$(determine_emoji "${{ inputs.publish_node_logger_to_npm_status }}")"
             echo "RELEASE_PLEASE_EMOJI=$(determine_emoji "${{ inputs.release_please_status }}")"
@@ -81,6 +86,7 @@ jobs:
           INFRA_STATUS: "${{ steps.status-emojis.outputs.INFRA_EMOJI }}"
           APPS_STATUS: "${{ steps.status-emojis.outputs.APPS_EMOJI }}"
           BUILD_AND_TEST_STATUS: "${{ steps.status-emojis.outputs.BUILD_AND_TEST_EMOJI }}"
+          SOURCE_MAPS_UPLOAD_STATUS: "${{ steps.status-emojis.outputs.SOURCE_MAPS_UPLOAD_EMOJI }}"
           DOCKER_BUILD_AND_PUSH_STATUS: "${{ steps.status-emojis.outputs.DOCKER_BUILD_AND_PUSH_EMOJI }}"
           PUBLISH_NODE_LOGGER_TO_NPM_STATUS: "${{ steps.status-emojis.outputs.PUBLISH_NODE_LOGGER_TO_NPM_EMOJI }}"
           RELEASE_PLEASE_STATUS: "${{ steps.status-emojis.outputs.RELEASE_PLEASE_EMOJI }}"

--- a/.github/workflows/workflow-upload-source-maps.yml
+++ b/.github/workflows/workflow-upload-source-maps.yml
@@ -1,0 +1,125 @@
+name: Upload Source Maps to Application Insights
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      appInsightsName:
+        required: true
+        type: string
+      resourceGroupName:
+        required: true
+        type: string
+      ref:
+        description: "The branch or tag ref to use. Using default checkout ref if not provided."
+        required: false
+        default: ${{ github.ref }}
+        type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+
+jobs:
+  upload-source-maps:
+    name: Upload source maps to Application Insights (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install dependencies
+        uses: ./.github/actions/install
+
+      - name: Build frontend with source maps
+        run: pnpm --filter frontend run build
+        working-directory: ${{ github.workspace }}
+
+      - name: Azure Login
+        uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get storage account name
+        id: get-storage
+        run: |
+          STORAGE_ACCOUNT_NAME=$(az deployment group show \
+            --resource-group "${{ inputs.resourceGroupName }}" \
+            --name "main" \
+            --query "properties.outputs.storageAccountName.value" \
+            --output tsv)
+          
+          echo "storage_account_name=$STORAGE_ACCOUNT_NAME" >> $GITHUB_OUTPUT
+
+      - name: Create blob container for source maps
+        run: |
+          # Create a private blob container for source maps
+          az storage container create \
+            --account-name "${{ steps.get-storage.outputs.storage_account_name }}" \
+            --name "sourcemaps-${{ inputs.environment }}" \
+            --public-access off \
+            --auth-mode login
+
+      - name: Upload source maps to blob storage
+        id: upload-source-maps
+        run: |
+          cd packages/frontend/dist/assets
+          
+          # Upload each source map file with version prefix
+          for mapfile in *.map; do
+            if [ -f "$mapfile" ]; then
+              echo "Uploading $mapfile..."
+              
+              # Get the corresponding JS file name
+              jsfile="${mapfile%.map}"
+              
+              # Upload with version prefix
+              az storage blob upload \
+                --account-name "${{ steps.get-storage.outputs.storage_account_name }}" \
+                --container-name "sourcemaps-${{ inputs.environment }}" \
+                --name "${{ inputs.version }}/$mapfile" \
+                --file "$mapfile" \
+                --auth-mode login
+              
+              echo "Uploaded $mapfile successfully"
+            fi
+          done
+          
+          echo "source_maps_uploaded=true" >> $GITHUB_OUTPUT
+
+      - name: Configure Application Insights to use source maps
+        run: |
+          # Configure Application Insights to read source maps from blob storage
+          # This is done by setting the source map URL in the Application Insights configuration
+          # The URL format is: https://<storage-account>.blob.core.windows.net/<container>/<version>/<source-map-file>
+          
+          STORAGE_URL="https://${{ steps.get-storage.outputs.storage_account_name }}.blob.core.windows.net/sourcemaps-${{ inputs.environment }}"
+          
+          echo "Source maps are available at: $STORAGE_URL"
+          echo "Application Insights will automatically detect and use source maps from this location"
+
+      - name: Note about source map cleanup
+        run: |
+          echo "Source map cleanup is handled automatically by Application Insights"
+          echo "The service will retain source maps for a configurable period"
+
+      - name: Logout from Azure
+        if: always()
+        continue-on-error: true
+        run: az logout 

--- a/.github/workflows/workflow-upload-source-maps.yml
+++ b/.github/workflows/workflow-upload-source-maps.yml
@@ -9,12 +9,6 @@ on:
       version:
         required: true
         type: string
-      appInsightsName:
-        required: true
-        type: string
-      resourceGroupName:
-        required: true
-        type: string
       ref:
         description: "The branch or tag ref to use. Using default checkout ref if not provided."
         required: false

--- a/.github/workflows/workflow-upload-source-maps.yml
+++ b/.github/workflows/workflow-upload-source-maps.yml
@@ -27,6 +27,12 @@ on:
         required: true
       AZURE_SUBSCRIPTION_ID:
         required: true
+      AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME:
+        description: "The Azure Storage Account name for source maps"
+        required: true
+      AZURE_SOURCE_MAPS_CONTAINER_NAME:
+        description: "The Azure Blob Storage container name for source maps"
+        required: true
 
 jobs:
   upload-source-maps:
@@ -56,26 +62,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Get storage account name
-        id: get-storage
-        run: |
-          STORAGE_ACCOUNT_NAME=$(az deployment group show \
-            --resource-group "${{ inputs.resourceGroupName }}" \
-            --name "main" \
-            --query "properties.outputs.storageAccountName.value" \
-            --output tsv)
-          
-          echo "storage_account_name=$STORAGE_ACCOUNT_NAME" >> $GITHUB_OUTPUT
-
-      - name: Create blob container for source maps
-        run: |
-          # Create a private blob container for source maps
-          az storage container create \
-            --account-name "${{ steps.get-storage.outputs.storage_account_name }}" \
-            --name "sourcemaps-${{ inputs.environment }}" \
-            --public-access off \
-            --auth-mode login
-
       - name: Upload source maps to blob storage
         id: upload-source-maps
         run: |
@@ -86,13 +72,10 @@ jobs:
             if [ -f "$mapfile" ]; then
               echo "Uploading $mapfile..."
               
-              # Get the corresponding JS file name
-              jsfile="${mapfile%.map}"
-              
               # Upload with version prefix
               az storage blob upload \
-                --account-name "${{ steps.get-storage.outputs.storage_account_name }}" \
-                --container-name "sourcemaps-${{ inputs.environment }}" \
+                --account-name "${{ secrets.AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME }}" \
+                --container-name "${{ secrets.AZURE_SOURCE_MAPS_CONTAINER_NAME }}" \
                 --name "${{ inputs.version }}/$mapfile" \
                 --file "$mapfile" \
                 --auth-mode login
@@ -102,22 +85,6 @@ jobs:
           done
           
           echo "source_maps_uploaded=true" >> $GITHUB_OUTPUT
-
-      - name: Configure Application Insights to use source maps
-        run: |
-          # Configure Application Insights to read source maps from blob storage
-          # This is done by setting the source map URL in the Application Insights configuration
-          # The URL format is: https://<storage-account>.blob.core.windows.net/<container>/<version>/<source-map-file>
-          
-          STORAGE_URL="https://${{ steps.get-storage.outputs.storage_account_name }}.blob.core.windows.net/sourcemaps-${{ inputs.environment }}"
-          
-          echo "Source maps are available at: $STORAGE_URL"
-          echo "Application Insights will automatically detect and use source maps from this location"
-
-      - name: Note about source map cleanup
-        run: |
-          echo "Source map cleanup is handled automatically by Application Insights"
-          echo "The service will retain source maps for a configurable period"
 
       - name: Logout from Azure
         if: always()

--- a/packages/docs/docs/deployment/applications.md
+++ b/packages/docs/docs/deployment/applications.md
@@ -16,7 +16,7 @@ Ensure you have followed the steps in [Deploying a new infrastructure environmen
 
 Use the following steps:
 
-- From the infrastructure resources created, add the following GitHub secrets in the new environment (this will not be necessary in the future as secrets would be added directly from infrastructure deployment): `AZURE_APP_INSIGHTS_CONNECTION_STRING`, `AZURE_CONTAINER_APP_ENVIRONMENT_NAME`, `AZURE_ENVIRONMENT_KEY_VAULT_NAME`, and `AZURE_RESOURCE_GROUP_NAME`
+- From the infrastructure resources created, add the following GitHub secrets in the new environment (this will not be necessary in the future as secrets would be added directly from infrastructure deployment): `AZURE_APP_INSIGHTS_CONNECTION_STRING`, `AZURE_CONTAINER_APP_ENVIRONMENT_NAME`, `AZURE_ENVIRONMENT_KEY_VAULT_NAME`, `AZURE_RESOURCE_GROUP_NAME`, `AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME`, and `AZURE_SOURCE_MAPS_CONTAINER_NAME`
 
 - Add new parameter files for the environment in all applications `.azure/applications/*/<env>.bicepparam`
 

--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore source maps in the frontend build output
+dist/**/*.map 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -15,7 +15,7 @@ export default () => {
       __APP_VERSION__: JSON.stringify(pkg.version),
     },
     build: {
-      sourcemap: true,
+      sourcemap: 'hidden',
       rollupOptions: {
         output: {
           // Ensure source maps are generated with proper naming

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -14,5 +14,14 @@ export default () => {
     define: {
       __APP_VERSION__: JSON.stringify(pkg.version),
     },
+    build: {
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          // Ensure source maps are generated with proper naming
+          sourcemapExcludeSources: false,
+        },
+      },
+    },
   });
 };


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Supersedes https://github.com/Altinn/dialogporten-frontend/pull/2299

## Overview
This PR adds functionality to upload source maps to Azure Blob Storage for better error tracking and debugging in Application Insights across all environments.

### New Workflow
- **Added** `.github/workflows/workflow-upload-source-maps.yml` - New reusable workflow for uploading source maps to Azure Blob Storage
- **Added** source maps upload job to all CI/CD workflows:
  - `ci-cd-main.yml` (test environment)
  - `ci-cd-staging.yml` 
  - `ci-cd-yt01.yml`
  - `ci-cd-prod.yml`

### Configuration Updates
- **Updated** Vite configuration in `packages/frontend/vite.config.ts` to generate source maps with `sourcemap: 'hidden'`
- **Added** `.dockerignore` rule in `packages/frontend/.dockerignore` to exclude source maps from Docker builds
- **Updated** Slack notification templates to include source maps upload status

### Required Secrets
The following GitHub secrets need to be added to each environment:
- `AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME` - Azure Storage Account name for source maps
- `AZURE_SOURCE_MAPS_CONTAINER_NAME` - Azure Blob Storage container name for source maps

### Documentation
- **Updated** `packages/docs/docs/deployment/applications.md` to include the new required secrets

## How it Works
1. Source maps are generated during the frontend build process
2. The upload workflow authenticates with Azure using OIDC
3. Source maps are uploaded to the specified Azure Blob Storage container with version prefixes
4. Application Insights can then use these source maps for better error stack traces

## Related Issue(s)

- #2223

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
