### PR TITLE
fix(infra): ensure correct role assignment for uploading source maps

### DIFF
--- a/.azure/modules/applicationInsights/create.bicep
+++ b/.azure/modules/applicationInsights/create.bicep
@@ -7,8 +7,6 @@ param tags object
 @description('The blob container name for source maps')
 param sourceMapContainerName string = 'sourcemaps'
 
-
-
 var sourceMapStorageAccountName = substring(replace('${namePrefix}sourcemaps${uniqueString(resourceGroup().id)}', '-', ''), 0, 24)
 
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {

--- a/.azure/modules/applicationInsights/create.bicep
+++ b/.azure/modules/applicationInsights/create.bicep
@@ -7,6 +7,8 @@ param tags object
 @description('The blob container name for source maps')
 param sourceMapContainerName string = 'sourcemaps'
 
+
+
 var sourceMapStorageAccountName = substring(replace('${namePrefix}sourcemaps${uniqueString(resourceGroup().id)}', '-', ''), 0, 24)
 
 resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
@@ -63,6 +65,23 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
   tags: union(tags, {
     'hidden-link:Insights.Sourcemap.Storage': '{"Uri": "${sourceMapUri}"}'
   })
+}
+
+@description('This is the built-in Storage Blob Data Contributor role. See https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage')
+resource storageBlobDataContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+}
+
+// Role assignment for source maps storage account - assign to the deployer
+resource sourceMapStorageBlobDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('${namePrefix}-sourcemaps-storage', deployer().objectId, storageBlobDataContributorRoleDefinition.id)
+  scope: sourceMapStorageAccount
+  properties: {
+    roleDefinitionId: storageBlobDataContributorRoleDefinition.id
+    principalId: deployer().objectId
+    principalType: 'ServicePrincipal'
+  }
 }
 
 output connectionString string = appInsights.properties.ConnectionString

--- a/.github/workflows/workflow-upload-source-maps.yml
+++ b/.github/workflows/workflow-upload-source-maps.yml
@@ -77,8 +77,6 @@ jobs:
               echo "Uploaded $mapfile successfully"
             fi
           done
-          
-          echo "source_maps_uploaded=true" >> $GITHUB_OUTPUT
 
       - name: Logout from Azure
         if: always()

--- a/packages/docs/docs/deployment/applications.md
+++ b/packages/docs/docs/deployment/applications.md
@@ -18,6 +18,8 @@ Use the following steps:
 
 - From the infrastructure resources created, add the following GitHub secrets in the new environment (this will not be necessary in the future as secrets would be added directly from infrastructure deployment): `AZURE_APP_INSIGHTS_CONNECTION_STRING`, `AZURE_CONTAINER_APP_ENVIRONMENT_NAME`, `AZURE_ENVIRONMENT_KEY_VAULT_NAME`, `AZURE_RESOURCE_GROUP_NAME`, `AZURE_SOURCE_MAPS_STORAGE_ACCOUNT_NAME`, and `AZURE_SOURCE_MAPS_CONTAINER_NAME`
 
+**Note:** The source maps storage account and container are automatically created by the infrastructure, and the necessary role assignments are automatically configured for the service principal.
+
 - Add new parameter files for the environment in all applications `.azure/applications/*/<env>.bicepparam`
 
 - Run the GitHub action `Dispatch applications` in order to deploy all applications to the new environment.


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

In order to upload source maps, the service principal needs atleast the storage blob data contributor. Adding a role assignment for the current deployer which translates to the service principal used in github actions. 

## Related Issue(s)

- #2223 

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
