### PR TITLE
feat: Transmission will now be shown as read based on activities

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -150,7 +150,6 @@ export function mapDialogToToInboxItem(
   if (!item) {
     return undefined;
   }
-
   const clockPrefix = t('word.clock_prefix');
   const formatString = `do MMMM yyyy ${clockPrefix ? `'${clockPrefix}' ` : ''}HH.mm`;
   const titleObj = item?.content?.title?.value;
@@ -223,7 +222,7 @@ export function mapDialogToToInboxItem(
       })),
     },
     activityHistory: getActivityHistory(item.activities, item.transmissions, format, serviceOwner),
-    transmissions: getTransmissions(item.transmissions, format, serviceOwner),
+    transmissions: getTransmissions(item.transmissions, format, item.activities, serviceOwner),
     createdAt: item.createdAt,
     updatedAt: item.updatedAt,
     label: item.endUserContext?.systemLabels,

--- a/packages/frontend/src/api/utils/activities.tsx
+++ b/packages/frontend/src/api/utils/activities.tsx
@@ -126,14 +126,17 @@ export const getActivityHistory = (
     date: activity.datetime ?? new Date().toISOString(),
   }));
 
-  const dialogHistoryTransmissions: ActivityLogEntry[] = getTransmissions(transmissions, format, serviceOwner).map(
-    (transmission) => ({
-      id: transmission.id ?? '',
-      type: 'transmission',
-      date: transmission.datetime ?? new Date().toISOString(),
-      items: transmission.items,
-    }),
-  );
+  const dialogHistoryTransmissions: ActivityLogEntry[] = getTransmissions(
+    transmissions,
+    format,
+    activities,
+    serviceOwner,
+  ).map((transmission) => ({
+    id: transmission.id ?? '',
+    type: 'transmission',
+    date: transmission.datetime ?? new Date().toISOString(),
+    items: transmission.items,
+  }));
 
   return [...dialogHistoryActivities, ...dialogHistoryTransmissions].sort((a, b) => {
     return new Date(b.date).getTime() - new Date(a.date).getTime();


### PR DESCRIPTION
Transmissions will now be shown as read if a corresponding "activity" with type "Transmission Opened" type exists for the given transmission id.

<img width="1638" height="1524" alt="image" src="https://github.com/user-attachments/assets/81c00bbb-1d34-4a2c-9fc3-68eb6258ab78" />

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #1954

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
