### PR TITLE
fix: Disclaimers spacing and size

### DIFF
--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -8,6 +8,7 @@ import {
   Section,
   type SeenByLogItemProps,
   Toolbar,
+  Typography,
 } from '@altinn/altinn-components';
 import type { FilterState } from '@altinn/altinn-components/dist/types/lib/components/Toolbar/Toolbar';
 import { useEffect, useState } from 'react';
@@ -194,10 +195,11 @@ export const Inbox = ({ viewType }: InboxProps) => {
         ) : null}
       </section>
       {(viewType === 'archive' || viewType === 'bin') && (
-        <Section>
+        <Typography size="sm">
           <p>{t(`inbox.${viewType}.info_message`)}</p>
-        </Section>
+        </Typography>
       )}
+
       <Section>
         {dialogsSuccess && !dialogs.length && (
           <EmptyState


### PR DESCRIPTION
Now looks like:

<img width="1489" height="491" alt="CleanShot 2025-08-07 at 13 53 53" src="https://github.com/user-attachments/assets/96b17a15-268a-4c0c-b55d-57f35a99ccc2" />

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
