### PR TITLE
fix: simplify by always directing user to main entry on successful login

### DIFF
--- a/packages/bff/src/auth/oidc.ts
+++ b/packages/bff/src/auth/oidc.ts
@@ -289,7 +289,7 @@ export const handleAuthRequest = async (request: FastifyRequest, reply: FastifyR
       await redisClient.set(`idp-sid:${idpSid}`, appSessionId, 'EX', 3600 * 8);
     }
 
-    reply.redirect('/?loggedIn=true');
+    reply.redirect('/');
   } catch (e: unknown) {
     if (axios.isAxiosError(e)) {
       console.error('handleAuthRequest error e.data', e.response?.data);

--- a/packages/frontend/src/auth/url.ts
+++ b/packages/frontend/src/auth/url.ts
@@ -1,8 +1,5 @@
 import type { FilterState } from '@altinn/altinn-components';
 
-const LOGIN_REDIRECT_STORAGE_KEY = 'arbeidsflate::auth::login_Redirect';
-const LOGIN_REDIRECT_QUERY_KEY = 'loggedIn';
-
 export const createFiltersURLQuery = (activeFilters: FilterState, allFilterKeys: string[], baseURL: string): URL => {
   const url = new URL(baseURL);
 
@@ -20,36 +17,4 @@ export const createFiltersURLQuery = (activeFilters: FilterState, allFilterKeys:
     }
   }
   return url;
-};
-
-export const sanitizeURL = (url: string) => {
-  const urlObj = new URL(url);
-  urlObj.searchParams.delete(LOGIN_REDIRECT_QUERY_KEY);
-  return urlObj.toString();
-};
-
-export const saveURL = (url: string) => {
-  if (!isLogoutURL(url)) {
-    localStorage.setItem(LOGIN_REDIRECT_STORAGE_KEY, sanitizeURL(url));
-  }
-};
-
-export const isRedirectURL = (url: string): boolean => {
-  return url.includes(LOGIN_REDIRECT_QUERY_KEY);
-};
-
-export const isLogoutURL = (url: string): boolean => {
-  return url.includes('loggedout');
-};
-
-export const removeStoredURL = () => {
-  localStorage.removeItem(LOGIN_REDIRECT_STORAGE_KEY);
-};
-
-export const getStoredURL = (): string | null => {
-  const url = localStorage.getItem(LOGIN_REDIRECT_STORAGE_KEY);
-  if (url) {
-    return sanitizeURL(url);
-  }
-  return null;
 };

--- a/packages/frontend/src/components/Login/AuthContext.tsx
+++ b/packages/frontend/src/components/Login/AuthContext.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import type React from 'react';
 import { createContext, useContext, useEffect } from 'react';
-import { getIsAuthenticated, getStoredURL, isRedirectURL, removeStoredURL, saveURL } from '../../auth';
+import { getIsAuthenticated } from '../../auth';
 
 interface AuthContextProps {
   isAuthenticated: boolean;
@@ -20,19 +20,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   });
 
   useEffect(() => {
-    const currentHref = window.location.href;
     if (!isAuthenticated && isFetchedAfterMount) {
-      if (currentHref) saveURL(currentHref);
       (window as Window).location = `/api/login`;
-    } else if (isAuthenticated) {
-      // already has a valid session or just logged in
-      if (isRedirectURL(currentHref)) {
-        const storedURL = getStoredURL();
-        if (storedURL) {
-          removeStoredURL();
-          (window as Window).location = storedURL;
-        }
-      }
     }
   }, [isAuthenticated, isFetchedAfterMount]);
 


### PR DESCRIPTION
Removed storing of last visited URL in local storage to prevent unintended navigation after logout/login in shared browser scenarios. This will make the flow safer and less error-prone.

The trade off, however, is that the user will not be able to return to referer upon login.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
