### PR TITLE
fix: change kl to kl. as clock prefix for bm and nn

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.36.3",
+    "@altinn/altinn-components": "^0.36.4",
     "@microsoft/applicationinsights-react-js": "19.3.6",
     "@microsoft/applicationinsights-web": "3.3.9",
     "@navikt/aksel-icons": "^7.22.0",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -207,7 +207,7 @@
   "transmission.type.request": "Forespørsel",
   "transmission.type.submission": "Innsending",
   "word.back": "Tilbake",
-  "word.clock_prefix": "kl",
+  "word.clock_prefix": "kl.",
   "word.close": "Lukk",
   "word.everything": "Alt",
   "word.frontpage": "Forside",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -207,7 +207,7 @@
   "transmission.type.request": "Førespurnad",
   "transmission.type.submission": "Innsending",
   "word.back": "Tilbake",
-  "word.clock_prefix": "kl",
+  "word.clock_prefix": "kl.",
   "word.close": "Lukk",
   "word.everything": "Alt",
   "word.frontpage": "Forside",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,8 +383,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: ^0.36.3
-        version: 0.36.3(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^0.36.4
+        version: 0.36.4(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@microsoft/applicationinsights-react-js':
         specifier: 19.3.6
         version: 19.3.6(history@4.10.1)(react@19.1.0)(tslib@2.8.1)
@@ -594,8 +594,8 @@ packages:
     resolution: {integrity: sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.36.3':
-    resolution: {integrity: sha512-iUEpRGpJY3fE+VrUCbm7nz++ZtNls5Y7VYdsEHex8hKpIGVZ7LbDJKqFC5LQtaXOjDQC+k57WCUdfDC0UkiQwQ==}
+  '@altinn/altinn-components@0.36.4':
+    resolution: {integrity: sha512-p4Cp6JbI7phg3mQJdnBoPEDmCBQ4HJ99JJ01ZILzAOKAWF9aaWRBFHxOCjcAD9eM+IkJVBT2zgRQG8joiyNHCQ==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -10361,7 +10361,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.19.0
 
-  '@altinn/altinn-components@0.36.3(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@altinn/altinn-components@0.36.4(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@digdir/designsystemet-css': 1.0.6
       '@digdir/designsystemet-react': 1.0.6(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
1. Updates to latest version of altinn-components and resolves #2460 
2. Changes "kl" to "kl." as clock prefix for bm and nn

Prev

<img width="656" height="86" alt="image" src="https://github.com/user-attachments/assets/cdba3db7-5321-47ba-95fc-29cf99c85b2e" />

Now

<img width="810" height="120" alt="image" src="https://github.com/user-attachments/assets/90720ac9-ca64-40b7-914f-93471fad53d3" />



## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
