### PR TITLE
feat(infra): add maintenance page to application gateway

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -47,6 +47,9 @@ param applicationGatewayConfiguration ApplicationGatewayConfiguration
 @description('Optional list of IP addresses/ranges to whitelist for incoming traffic')
 param applicationGatewayWhitelistedIps array = []
 
+@description('Enable maintenance mode to redirect all traffic to maintenance page')
+param enableMaintenancePage bool = false
+
 // PostgreSQL configuration parameters
 import { Sku as PostgreSQLSku } from '../modules/postgreSql/create.bicep'
 import { StorageConfiguration as PostgreSQLStorageConfiguration } from '../modules/postgreSql/create.bicep'
@@ -202,6 +205,7 @@ module applicationGateway '../modules/applicationGateway/main.bicep' = {
     subnetId: vnet.outputs.applicationGatewaySubnetId
     configuration: applicationGatewayConfiguration
     appInsightWorkspaceName: appInsights.outputs.appInsightsWorkspaceName
+    enableMaintenancePage: enableMaintenancePage
     tags: tags
   }
 }

--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -63,3 +63,6 @@ param entraDevelopersGroupId = 'a94de4bf-0a83-4d30-baba-0c6a7365571c'
 
 // Container App Environment
 param containerAppEnvZoneRedundancyEnabled = true
+
+// Maintenance Mode
+param enableMaintenancePage = false

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -60,3 +60,6 @@ param entraDevelopersGroupId = 'a94de4bf-0a83-4d30-baba-0c6a7365571c'
 
 // Container App Environment
 param containerAppEnvZoneRedundancyEnabled = true
+
+// Maintenance Mode
+param enableMaintenancePage = false

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -57,3 +57,6 @@ param postgresConfiguration = {
 
 // Altinn Product Dialogporten: Developers Dev
 param entraDevelopersGroupId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+
+// Maintenance Mode
+param enableMaintenancePage = false

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -57,3 +57,6 @@ param postgresConfiguration = {
 
 // Altinn Product Dialogporten: Developers Dev
 param entraDevelopersGroupId = 'c12e51e3-5cbd-4229-8a31-5394c423fb5f'
+
+// Maintenance Mode
+param enableMaintenancePage = false


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
Added a maintenance page backend pool that points to the maintenance site created in https://github.com/Altinn/dialogporten-frontend/issues/2544

Ways of switching to maintenance mode:
- Do a switch in the portal and re-deploy the gateway
- Enable the maintenance mode in the bicepparam and redeploy

## Related Issue(s)

- #2544