### PR TITLE
fix(frontend): use correct way of setting headers when tracking

### DIFF
--- a/packages/frontend/src/api/queries.ts
+++ b/packages/frontend/src/api/queries.ts
@@ -33,13 +33,10 @@ const requestMiddleware: RequestMiddleware = (request) => {
     const startTime = Date.now();
 
     // Store tracking data in request headers
-    if (!request.headers) {
-      request.headers = {};
-    }
-
-    // Add tracking headers
-    (request.headers as Record<string, string>)['x-graphql-operation'] = operationName;
-    (request.headers as Record<string, string>)['x-graphql-start-time'] = startTime.toString();
+    const headers = new Headers(request.headers);
+    headers.set('x-graphql-operation', operationName);
+    headers.set('x-graphql-start-time', startTime.toString());
+    request.headers = headers;
   } catch (err) {
     console.error('GraphQL request middleware error:', err);
   }


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Using the correct way of setting headers when tracking gql queries. 

## Related Issue(s)

- #2628