### PR TITLE
fix(bff): ensure security headers are always exposed

### DIFF
--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -23,6 +23,7 @@
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^10.1.0",
     "@fastify/formbody": "^8.0.2",
+    "@fastify/helmet": "13.0.1",
     "@fastify/session": "^11.1.0",
     "@graphql-tools/executor-http": "^1.3.3",
     "@graphql-tools/schema": "^10.0.23",

--- a/packages/bff/src/graphql/fastifyHeaders.ts
+++ b/packages/bff/src/graphql/fastifyHeaders.ts
@@ -1,36 +1,68 @@
 import { logger } from '@digdir/dialogporten-node-logger';
+import helmet from '@fastify/helmet';
 import type { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
 const plugin: FastifyPluginAsync = async (fastify) => {
-  logger.info('Setting up fastify headers');
+  logger.info('Setting up fastify security headers with helmet');
 
-  // Register the onSend hook directly
-  fastify.addHook('onSend', async (_request, reply) => {
-    // Main headers that are security headers to protect against common web vulnerabilities
-    const securityHeaders: Record<string, string> = {
-      'HTTP-Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
-      'X-Frame-Options': 'SAMEORIGIN',
-      'X-Content-Type-Options': 'nosniff',
-      'Content-Security-Policy': "default-src 'self'; script-src 'self'; object-src 'none'; img-src 'self';",
-      'X-Permitted-Cross-Domain-Policies': 'none',
-      'Referrer-Policy': 'no-referrer',
-      'Cross-Origin-Embedder-Policy': 'require-corp',
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Resource-Policy': 'same-origin',
-      'Permissions-Policy': 'none',
-      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-      'X-XSS-Protection': '1; mode=block',
-    };
-
-    reply.headers(securityHeaders);
+  // Register helmet with configuration matching our previous manual headers
+  await fastify.register(helmet, {
+    // HTTP Strict Transport Security
+    hsts: {
+      maxAge: 31536000,
+      includeSubDomains: true,
+      preload: true,
+    },
+    // X-Frame-Options
+    frameguard: {
+      action: 'sameorigin',
+    },
+    // X-Content-Type-Options
+    noSniff: true,
+    // Content Security Policy
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        imgSrc: ["'self'"],
+      },
+    },
+    // Referrer Policy
+    referrerPolicy: {
+      policy: 'no-referrer',
+    },
+    // Cross-Origin Embedder Policy
+    crossOriginEmbedderPolicy: {
+      policy: 'require-corp',
+    },
+    // Cross-Origin Opener Policy
+    crossOriginOpenerPolicy: {
+      policy: 'same-origin',
+    },
+    // Cross-Origin Resource Policy
+    crossOriginResourcePolicy: {
+      policy: 'same-origin',
+    },
+    // X-XSS-Protection
+    xssFilter: true,
   });
 
-  // Register the onRequest hook directly
+  // Add the custom headers that helmet doesn't cover
   fastify.addHook('onRequest', (request, reply, done) => {
+    // Custom headers not covered by helmet
+    reply.headers({
+      'X-Permitted-Cross-Domain-Policies': 'none',
+      'Permissions-Policy': 'none',
+      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+    });
+
+    // Set secure cookie if HTTPS
     if (request.headers['x-forwarded-proto'] === 'https') {
       request.session.cookie.secure = true;
     }
+
     done();
   });
 };

--- a/packages/bff/src/graphql/fastifyHeaders.ts
+++ b/packages/bff/src/graphql/fastifyHeaders.ts
@@ -6,65 +6,70 @@ import fp from 'fastify-plugin';
 const plugin: FastifyPluginAsync = async (fastify) => {
   logger.info('Setting up fastify security headers with helmet');
 
-  // Register helmet with configuration matching our previous manual headers
-  await fastify.register(helmet, {
-    // HTTP Strict Transport Security
-    hsts: {
-      maxAge: 31536000,
-      includeSubDomains: true,
-      preload: true,
-    },
-    // X-Frame-Options
-    frameguard: {
-      action: 'sameorigin',
-    },
-    // X-Content-Type-Options
-    noSniff: true,
-    // Content Security Policy
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"],
-        scriptSrc: ["'self'"],
-        objectSrc: ["'none'"],
-        imgSrc: ["'self'"],
+  try {
+    // Register helmet
+    fastify.register(helmet, {
+      // HTTP Strict Transport Security
+      hsts: {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: true,
       },
-    },
-    // Referrer Policy
-    referrerPolicy: {
-      policy: 'no-referrer',
-    },
-    // Cross-Origin Embedder Policy
-    crossOriginEmbedderPolicy: {
-      policy: 'require-corp',
-    },
-    // Cross-Origin Opener Policy
-    crossOriginOpenerPolicy: {
-      policy: 'same-origin',
-    },
-    // Cross-Origin Resource Policy
-    crossOriginResourcePolicy: {
-      policy: 'same-origin',
-    },
-    // X-XSS-Protection
-    xssFilter: true,
-  });
-
-  // Add the custom headers that helmet doesn't cover
-  fastify.addHook('onRequest', (request, reply, done) => {
-    // Custom headers not covered by helmet
-    reply.headers({
-      'X-Permitted-Cross-Domain-Policies': 'none',
-      'Permissions-Policy': 'none',
-      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      // X-Frame-Options
+      frameguard: {
+        action: 'sameorigin',
+      },
+      // X-Content-Type-Options
+      noSniff: true,
+      // Content Security Policy
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          objectSrc: ["'none'"],
+          imgSrc: ["'self'"],
+        },
+      },
+      // Referrer Policy
+      referrerPolicy: {
+        policy: 'no-referrer',
+      },
+      // Cross-Origin Embedder Policy
+      crossOriginEmbedderPolicy: {
+        policy: 'require-corp',
+      },
+      // Cross-Origin Opener Policy
+      crossOriginOpenerPolicy: {
+        policy: 'same-origin',
+      },
+      // Cross-Origin Resource Policy
+      crossOriginResourcePolicy: {
+        policy: 'same-origin',
+      },
+      // X-XSS-Protection
+      xssFilter: true,
     });
 
-    // Set secure cookie if HTTPS
-    if (request.headers['x-forwarded-proto'] === 'https') {
-      request.session.cookie.secure = true;
-    }
+    // Add the custom headers that helmet doesn't cover
+    fastify.addHook('onRequest', (request, reply, done) => {
+      // Custom headers not covered by helmet
+      reply.headers({
+        'X-Permitted-Cross-Domain-Policies': 'none',
+        'Permissions-Policy': 'none',
+        'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      });
 
-    done();
-  });
+      // Set secure cookie if HTTPS
+      if (request.headers['x-forwarded-proto'] === 'https') {
+        request.session.cookie.secure = true;
+      }
+
+      done();
+    });
+  } catch (error) {
+    logger.error(error, 'Failed to register security headers');
+    throw error; // Re-throw to prevent server startup with compromised security
+  }
 };
 
 export const fastifyHeaders = fp(plugin, {

--- a/packages/bff/src/graphql/fastifyHeaders.ts
+++ b/packages/bff/src/graphql/fastifyHeaders.ts
@@ -1,39 +1,37 @@
 import { logger } from '@digdir/dialogporten-node-logger';
-import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import type { FastifyPluginAsync } from 'fastify';
 import fp from 'fastify-plugin';
 
 const plugin: FastifyPluginAsync = async (fastify) => {
-  fastify.decorate('headers', () => {
-    return async (request: FastifyRequest) => {
-      try {
-        fastify.addHook('onSend', async (request, reply) => {
-          reply.headers({
-            'HTTP-Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
-            'X-Frame-Options': 'SAMEORIGIN',
-            'X-Content-Type-Options': 'nosniff',
-            'Content-Security-Policy': "default-src 'self'; script-src 'self'; object-src 'none'; img-src 'self';",
-            'X-Permitted-Cross-Domain-Policies': 'none',
-            'Referrer-Policy': 'no-referrer',
-            'Cross-Origin-Embedder-Policy': 'require-corp',
-            'Cross-Origin-Opener-Policy': 'same-origin',
-            'Cross-Origin-Resource-Policy': 'same-origin',
-            'Permissions-Policy': 'none',
-            'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-            'X-XSS-Protection': '1; mode=block',
-          });
-        });
-        // Middleware to set secure cookies based on X-Forwarded-Proto header
-        fastify.addHook('onRequest', (request, reply, done) => {
-          if (request.headers['x-forwarded-proto'] === 'https') {
-            request.session.cookie.secure = true;
-          }
-          done();
-        });
-      } catch (e) {
-        logger.error(e, 'Error setting headers');
-        request.tokenIsValid = false;
-      }
+  logger.info('Setting up fastify headers');
+
+  // Register the onSend hook directly
+  fastify.addHook('onSend', async (_request, reply) => {
+    // Main headers that are security headers to protect against common web vulnerabilities
+    const securityHeaders: Record<string, string> = {
+      'HTTP-Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+      'X-Frame-Options': 'SAMEORIGIN',
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; object-src 'none'; img-src 'self';",
+      'X-Permitted-Cross-Domain-Policies': 'none',
+      'Referrer-Policy': 'no-referrer',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Resource-Policy': 'same-origin',
+      'Permissions-Policy': 'none',
+      'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+      'X-XSS-Protection': '1; mode=block',
     };
+
+    reply.headers(securityHeaders);
+  });
+
+  // Register the onRequest hook directly
+  fastify.addHook('onRequest', (request, reply, done) => {
+    if (request.headers['x-forwarded-proto'] === 'https') {
+      request.session.cookie.secure = true;
+    }
+    done();
   });
 };
 

--- a/packages/bff/src/server.ts
+++ b/packages/bff/src/server.ts
@@ -38,6 +38,7 @@ const startServer = async (): Promise<void> => {
   };
 
   server.register(cors, corsOptions);
+  server.register(fastifyHeaders);
   server.register(formBody);
   server.register(cookie);
 
@@ -73,7 +74,6 @@ const startServer = async (): Promise<void> => {
     client_id,
     client_secret,
   });
-  server.register(fastifyHeaders);
   server.register(userApi);
   server.register(graphqlApi);
   server.register(graphqlStream);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@fastify/formbody':
         specifier: ^8.0.2
         version: 8.0.2
+      '@fastify/helmet':
+        specifier: 13.0.1
+        version: 13.0.1
       '@fastify/session':
         specifier: ^11.1.0
         version: 11.1.0
@@ -2217,6 +2220,9 @@ packages:
 
   '@fastify/forwarded@3.0.0':
     resolution: {integrity: sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==}
+
+  '@fastify/helmet@13.0.1':
+    resolution: {integrity: sha512-i+ifqazG3d0HwHL3zuZdg6B/WPc9Ee6kVfGpwGho4nxm0UaK1htss0zq+1rVhOoAorZlCgTZ3/i4S58hUGkkoA==}
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
@@ -6420,6 +6426,10 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -12847,6 +12857,11 @@ snapshots:
 
   '@fastify/forwarded@3.0.0': {}
 
+  '@fastify/helmet@13.0.1':
+    dependencies:
+      fastify-plugin: 5.0.1
+      helmet: 8.1.0
+
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
@@ -17925,6 +17940,8 @@ snapshots:
       tslib: 2.8.1
 
   headers-polyfill@4.0.3: {}
+
+  helmet@8.1.0: {}
 
   help-me@5.0.0: {}
 


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

* Replaced manual security headers with industry-standard helmet library
* Moved security headers early in middleware chain (after CORS, before form parsing) Headers will then be applied to ALL endpoints (GraphQL, OIDC, health checks)
* Maintained identical security coverage - all previous headers preserved

## Related Issue(s)

- #N/A

