### PR TITLE
chore(linting): ignore lint check of ./package.json 

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -75,5 +75,16 @@
       "test-results",
       "mockServiceWorker.js"
     ]
-  }
+  },
+  "overrides": [
+    {
+      "include": ["./package.json"],
+      "linter": {
+        "enabled": false
+      },
+      "formatter": {
+        "enabled": true
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Release Please consistently rewrites ./package.json in a way that violates our strict lint rule for max line width. This causes unnecessary churn, since we end up reformatting the file after every release. To reduce overhead, we’re disabling lint checks for ./package.json while still keeping Biome formatting enabled.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
