### PR TITLE
fix: use sender in filters instead of senders from 100 first dialogs

### DIFF
--- a/packages/frontend/src/components/PageLayout/Search/senderSuggestions.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/senderSuggestions.tsx
@@ -1,14 +1,13 @@
 import type { AutocompleteItemProps, AutocompleteProps, QueryItemType } from '@altinn/altinn-components';
-import type { OrganizationFieldsFragment } from 'bff-types-generated';
+import type { CountableDialogFieldsFragment, OrganizationFieldsFragment } from 'bff-types-generated';
 import { t } from 'i18next';
 import { Link, type LinkProps } from 'react-router-dom';
 import { getOrganization } from '../../../api/utils/organizations.ts';
-import type { InboxItemInput } from '../../../pages/Inbox/InboxItemInput.ts';
 import { pruneSearchQueryParams } from '../../../pages/Inbox/queryParams.ts';
 
 export const createSendersForAutocomplete = (
   searchValue: string,
-  dialogs: InboxItemInput[],
+  dialogs: CountableDialogFieldsFragment[],
   organizations?: OrganizationFieldsFragment[],
 ): AutocompleteProps => {
   const TYPE_SUGGEST = 'suggest';

--- a/packages/frontend/src/components/PageLayout/Search/useAutocomplete.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/useAutocomplete.tsx
@@ -5,7 +5,7 @@ import { t } from 'i18next';
 import { useMemo } from 'react';
 import { Link, type LinkProps } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
-import { useDialogs } from '../../../api/hooks/useDialogs.tsx';
+import { useDialogsCount } from '../../../api/hooks/useDialogsCount.tsx';
 import { searchAutocompleteDialogs } from '../../../api/queries.ts';
 import {
   type SearchAutocompleteDialogInput,
@@ -112,7 +112,7 @@ interface UseAutocompleteDialogsOutput {
 export const useAutocomplete = ({ selectedParties, searchValue }: searchDialogsProps): UseAutocompleteDialogsOutput => {
   const partyURIs = getPartyIds(selectedParties);
   const debouncedSearchString = useDebounce(searchValue, 300)[0];
-  const { dialogs } = useDialogs({ parties: selectedParties, queryKey: QUERY_KEYS.AUTOCOMPLETE });
+  const { dialogCounts: allDialogs } = useDialogsCount();
   const { organizations } = useOrganizations();
   const enabled = !!debouncedSearchString && debouncedSearchString.length > 2 && selectedParties.length > 0;
   const {
@@ -128,7 +128,7 @@ export const useAutocomplete = ({ selectedParties, searchValue }: searchDialogsP
     gcTime: 0,
   });
 
-  const suggestedSenders = createSendersForAutocomplete(searchValue ?? '', dialogs, organizations);
+  const suggestedSenders = createSendersForAutocomplete(searchValue ?? '', allDialogs, organizations);
 
   const autocomplete: AutocompleteProps = useMemo(() => {
     const results = hits?.searchDialogs?.items ?? [];

--- a/packages/frontend/src/components/PageLayout/Search/useSearchAutocompleteDialogs.spec.ts
+++ b/packages/frontend/src/components/PageLayout/Search/useSearchAutocompleteDialogs.spec.ts
@@ -1,142 +1,50 @@
-import type { DialogStatus } from 'bff-types-generated';
-import { SystemLabel } from 'bff-types-generated';
+import type { CountableDialogFieldsFragment, DialogStatus } from 'bff-types-generated';
 import { describe, expect, it } from 'vitest';
-import type { InboxViewType } from '../../../api/hooks/useDialogs.tsx';
 import { organizations } from '../../../mocks/data/base/organizations.ts';
-import type { InboxItemInput } from '../../../pages/Inbox/InboxItemInput.ts';
 import { createSendersForAutocomplete } from './senderSuggestions.tsx';
 
 describe('generateSendersAutocompleteBySearchString', () => {
-  const mockDialogs: InboxItemInput[] = [
+  const mockDialogs: CountableDialogFieldsFragment[] = [
     {
       id: '019241f7-5fa0-7336-934d-716a8e5bbb41',
       party: 'urn:altinn:person:identifier-no:1',
-      title: 'Intro',
-      summary: 'Info om nye Altinn 3.',
-      sender: {
-        name: 'Digitaliseringdirektoratet',
-        type: 'company',
-        imageUrl: 'https://altinncdn.no/orgs/digdir/digdir.png',
-      },
-      recipient: {
-        name: 'Test Testesen',
-        type: 'company',
-      },
-      createdAt: '2023-03-11T07:00:00.000Z',
       status: 'COMPLETED' as DialogStatus,
-      label: [SystemLabel.Default],
       org: 'digdir',
-      hasUnopenedContent: false,
-      fromServiceOwnerTransmissionsCount: 0,
-      fromPartyTransmissionsCount: 0,
       contentUpdatedAt: '2024-11-27T15:36:52.131Z',
-      guiAttachmentCount: 1,
-      seenByOthersCount: 0,
-      seenByLabel: 'Sett av deg',
-      viewType: 'INBOX' as InboxViewType,
       seenSinceLastContentUpdate: [],
-      seenByLog: {
-        collapsible: true,
-        title: 'Sett av deg',
-        items: [],
+      endUserContext: {
+        __typename: undefined,
+        systemLabels: [],
       },
     },
     {
       id: '019241f7-5fa0-7336-934d-716a8e5bbb49',
       party: 'urn:altinn:person:identifier-no:1',
-      title: 'Skatten din for 2022',
-      summary: 'Skatteoppgjøret for 2022 er klart. Du kan fortsatt gjøre endringer.',
-      sender: {
-        name: 'Skatteetaten',
-        type: 'company',
-        imageUrl: 'https://altinncdn.no/orgs/skd/skd.png',
-      },
-      recipient: {
-        name: 'Test Testesen',
-        type: 'company',
-      },
-      createdAt: '2023-03-11T07:00:00.000Z',
       status: 'COMPLETED' as DialogStatus,
-      label: [SystemLabel.Default],
       org: 'skd',
-      hasUnopenedContent: false,
-      fromServiceOwnerTransmissionsCount: 0,
-      fromPartyTransmissionsCount: 0,
       contentUpdatedAt: '2024-11-27T15:36:52.131Z',
-      guiAttachmentCount: 1,
-      seenByOthersCount: 0,
-      seenByLabel: 'Sett av deg',
-      viewType: 'INBOX' as InboxViewType,
       seenSinceLastContentUpdate: [],
-      seenByLog: {
-        collapsible: true,
-        title: 'Sett av deg',
-        items: [
-          {
-            id: '1',
-            type: 'person',
-            name: 'Test Testesen',
-            isEndUser: true,
-            seenAt: '2023-07-15 08:45',
-            seenAtLabel: '15. juli kl 08.45',
-          },
-        ],
+      endUserContext: {
+        __typename: undefined,
+        systemLabels: [],
       },
     },
     {
       id: '019241f7-812c-71c8-8e68-94a0b771fa10',
       party: 'urn:altinn:person:identifier-no:1',
-      title: 'Undersøkelse om levekår',
-      summary:
-        'Du er en av 6.000 personer som er trukket ut fra folkeregisteret til å delta i SSBs undersøkelse om levekår.\n\n',
-      sender: {
-        name: 'Statistisk sentralbyrå',
-        type: 'company',
-        imageUrl: 'https://altinncdn.no/orgs/ssb/ssb_dark.png',
-      },
-      recipient: {
-        name: 'Test Testesen',
-        type: 'company',
-      },
-      createdAt: '2023-05-17T09:30:00.000Z',
       org: 'ssb',
-      hasUnopenedContent: false,
-      fromServiceOwnerTransmissionsCount: 0,
-      fromPartyTransmissionsCount: 0,
       contentUpdatedAt: '2024-11-27T15:36:52.131Z',
-      guiAttachmentCount: 1,
-      seenByOthersCount: 1,
-      seenByLabel: 'Sett av deg',
-      viewType: 'INBOX' as InboxViewType,
       status: 'REQUIRES_ATTENTION' as DialogStatus,
-      label: [SystemLabel.Default],
       seenSinceLastContentUpdate: [],
-      seenByLog: {
-        collapsible: true,
-        title: 'Sett av deg',
-        items: [
-          {
-            id: '1',
-            type: 'person',
-            name: 'Test Testesen',
-            isEndUser: true,
-            seenAt: '2023-05-17 09:30',
-            seenAtLabel: '17. mai kl 09.30',
-          },
-          {
-            id: '2',
-            type: 'person',
-            name: 'Test Bruker',
-            seenAt: '2023-05-18 10:00',
-            seenAtLabel: '18. mai kl 10.00',
-          },
-        ],
+      endUserContext: {
+        __typename: undefined,
+        systemLabels: [],
       },
     },
   ];
 
   it('should return no hits when sender (searchValue) is empty', () => {
-    const result = createSendersForAutocomplete('', mockDialogs as InboxItemInput[]);
+    const result = createSendersForAutocomplete('', mockDialogs);
     expect(result.items).toEqual([]);
     expect(result.groups).toEqual({
       noHits: { title: 'noHits' },
@@ -144,8 +52,8 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return matched sender when search value matches sender name', () => {
-    const resultSKD = createSendersForAutocomplete('skat', mockDialogs as InboxItemInput[], organizations);
-    const resultSSB = createSendersForAutocomplete('sentralby', mockDialogs as InboxItemInput[], organizations);
+    const resultSKD = createSendersForAutocomplete('skat', mockDialogs, organizations);
+    const resultSSB = createSendersForAutocomplete('sentralby', mockDialogs, organizations);
 
     expect(resultSKD.items).toHaveLength(1);
     expect(resultSKD.items[0].title).toBe('Søk etter avsender Skatteetaten');
@@ -157,7 +65,7 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return matched sender and unmatched search string', () => {
-    const resultSKD = createSendersForAutocomplete('skat test1', mockDialogs as InboxItemInput[], organizations);
+    const resultSKD = createSendersForAutocomplete('skat test1', mockDialogs, organizations);
     //@ts-ignore Property 'params' does not exist on type 'AutocompleteItemProps'.
     const searchUnmatechedValue = resultSKD.items[0].params.find((item) => item.type === 'search');
     expect(searchUnmatechedValue?.type === 'search');
@@ -169,14 +77,14 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return matched sender and unmatched for digdir', () => {
-    const results = createSendersForAutocomplete('digdir', mockDialogs as InboxItemInput[], organizations);
+    const results = createSendersForAutocomplete('digdir', mockDialogs, organizations);
     expect(results.items[0].title).toEqual('Søk etter avsender Digitaliseringsdirektoratet');
     expect(results.items[0].params).toEqual([{ type: 'filter', label: 'Digitaliseringsdirektoratet' }]);
     expect(results.groups).toEqual({});
   });
 
   it('should return all matched senders and unmatched search string if provided', () => {
-    const result = createSendersForAutocomplete('skat sentralby test1', mockDialogs as InboxItemInput[], organizations);
+    const result = createSendersForAutocomplete('skat sentralby test1', mockDialogs, organizations);
     //@ts-ignore Property 'params' does not exist on type 'AutocompleteItemProps'.
     const searchUnmatechedValueSKD = result.items[0]?.params?.find((item) => item.type === 'search');
     //@ts-ignore Property 'params' does not exist on type 'AutocompleteItemProps'.
@@ -196,7 +104,7 @@ describe('generateSendersAutocompleteBySearchString', () => {
   });
 
   it('should return no hits when search value does not match any sender name', () => {
-    const result = createSendersForAutocomplete('Nonexistent Sender', mockDialogs as InboxItemInput[]);
+    const result = createSendersForAutocomplete('Nonexistent Sender', mockDialogs);
 
     expect(result.items).toEqual([]);
     expect(result.groups).toEqual({});

--- a/packages/frontend/src/constants/queryKeys.ts
+++ b/packages/frontend/src/constants/queryKeys.ts
@@ -10,7 +10,6 @@ export const QUERY_KEYS = {
   COUNT_DIALOGS: 'countDialogs',
   MAIN_CONTENT_REFERENCE: 'mainContentReference',
   SAVED_SEARCHES: 'savedSearches',
-  AUTOCOMPLETE: 'autocomplete',
   PROFILE: 'profile',
   NOTIFICATIONSETTINGSFORPARTY: 'notificationsettingsforparty',
   PROFILE_PARTIES_WITH_NOTIFICATION_SETTINGS: 'profilePartiesWithNotificationSettings',


### PR DESCRIPTION
Use the same senders as suggestions in autocomplete as in filters.
Added bonus: One less request to Dialogporten

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/2693

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
