### PR TITLE
fix(frontend): remove pageview calculations

### DIFF
--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -128,6 +128,8 @@ if (applicationInsightsEnabled) {
         enableAjaxPerfTracking: false,
         enablePerfMgr: false,
         disableCookiesUsage: false,
+        // To avoid issue where AI tries to calculate duration of page view, and throws an error
+        overridePageViewDuration: true,
         samplingPercentage: 100,
         appId: 'arbeidsflate-frontend',
         enableDebug: true,


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

This will most likely fix the issue we are seeing where AI fails to compute timing on page views: https://digdir.slack.com/archives/C08E82KME9Y/p1758176755699829

We disable it until we actually use this data. Might be something related to SPAs and page view timings. 

## Related Issue(s)

- #N/A
