### PR TITLE
fix(frontend): avoid errors from AI calculating page durations

### DIFF
--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -79,6 +79,8 @@ export const trackPageView = (pageInfo: {
     'route.state': pageInfo.state ? JSON.stringify(pageInfo.state) : '',
     'viewport.width': window.innerWidth,
     'viewport.height': window.innerHeight,
+    // Seeing issues with AI failing to calculate duration. Setting this to 0 until we see the need to have this information
+    duration: 0,
   };
 
   applicationInsights.trackPageView({


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Still seeing issues related to page view durations.. Ensuring we always set this to 0 would likely solve the issue once and for all. 

## Related Issue(s)

- #N/A
