### PR TITLE
fix(frontend): use start and stop tracking to avoid timing issues

### DIFF
--- a/packages/frontend/src/hooks/usePageTracking.ts
+++ b/packages/frontend/src/hooks/usePageTracking.ts
@@ -10,12 +10,21 @@ export const usePageTracking = () => {
       console.debug(`Skipping page tracking for route: ${location.pathname}`);
       return;
     }
-    Analytics.trackPageView({
+
+    const pageInfo = {
       url: window.location.href,
       pathname: location.pathname,
       search: location.search,
       hash: location.hash,
       state: location.state ? JSON.stringify(location.state) : '',
-    });
+    };
+
+    // Start tracking when the route component mounts
+    Analytics.startPageTracking(pageInfo);
+
+    // Stop tracking when the route component unmounts or changes
+    return () => {
+      Analytics.stopPageTracking(pageInfo);
+    };
   }, [location]);
 };


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Using (start|stop)PageTracking instead as it seems to be more stable. 

## Related Issue(s)

- #N/A
