### PR TITLE
fix: add authenticated query hooks and improve token handling

### DIFF
--- a/packages/bff/src/auth/oidc.ts
+++ b/packages/bff/src/auth/oidc.ts
@@ -350,7 +350,7 @@ const plugin: FastifyPluginAsync<CustomOICDPluginOptions> = async (fastify, opti
       const stateIsAMatch = storedStateTruth === receivedState && storedStateTruth !== '';
 
       if (!stateIsAMatch) {
-        reply.status(401).send('State mismatch');
+        reply.redirect('/api/login');
         return;
       }
 

--- a/packages/bff/src/auth/verifyToken.ts
+++ b/packages/bff/src/auth/verifyToken.ts
@@ -48,7 +48,12 @@ export const refreshToken = async (request: FastifyRequest) => {
   }
 };
 
-type ValidationStatus = 'refresh_token_expired' | 'refreshed' | 'missing_token' | 'access_token_valid';
+type ValidationStatus =
+  | 'refresh_token_expired'
+  | 'refreshed'
+  | 'missing_token'
+  | 'access_token_valid'
+  | 'access_token_invalid';
 
 /**
  * Checks the validity of the session token in the request and optionally refreshes the token if necessary.
@@ -93,7 +98,7 @@ const getIsTokenValid = async (
     }
   }
 
-  return isAccessTokenValid ? 'access_token_valid' : 'refresh_token_expired';
+  return isAccessTokenValid ? 'access_token_valid' : 'access_token_invalid';
 };
 
 const plugin: FastifyPluginAsync = async (fastify, _) => {

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -1,5 +1,4 @@
 import type { AttachmentLinkProps, AvatarProps, SeenByLogProps } from '@altinn/altinn-components';
-import { useQuery } from '@tanstack/react-query';
 import {
   type Actor,
   ActorType,
@@ -13,13 +12,14 @@ import {
   SystemLabel,
 } from 'bff-types-generated';
 import { t } from 'i18next';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import type { DialogActionProps } from '../../components';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { type ValueType, getPreferredPropertyByLocale } from '../../i18n/property.ts';
 import type { FormatFunction } from '../../i18n/useDateFnsLocale.tsx';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import { useOrganizations } from '../../pages/Inbox/useOrganizations.ts';
-import { toTitleCase } from '../../pages/Profile/index.ts';
+import { toTitleCase } from '../../pages/Profile';
 import { graphQLSDK } from '../queries.ts';
 import { type ActivityLogEntry, getActivityHistory } from '../utils/activities.tsx';
 import { getSeenByLabel } from '../utils/dialog.ts';
@@ -285,7 +285,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   const { organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const { selectedProfile } = useParties();
   const partyURIs = parties.map((party) => party.party);
-  const { data, isSuccess, isLoading, isError } = useQuery<GetDialogByIdQuery>({
+  const { data, isSuccess, isLoading, isError } = useAuthenticatedQuery<GetDialogByIdQuery>({
     queryKey: [QUERY_KEYS.DIALOG_BY_ID, id, organizations],
     staleTime: 1000 * 60 * 30,
     refetchInterval: 1000 * 60 * 10,

--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -1,7 +1,8 @@
 import type { FilterState } from '@altinn/altinn-components/dist/types/lib/components/Toolbar/Toolbar';
-import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
+import { keepPreviousData } from '@tanstack/react-query';
 import type { DialogStatus, GetAllDialogsForPartiesQuery, PartyFieldsFragment, SystemLabel } from 'bff-types-generated';
 import { useRef } from 'react';
+import { useAuthenticatedInfiniteQuery } from '../../auth/useAuthenticatedInfiniteQuery.tsx';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import type { InboxItemInput } from '../../pages/Inbox/InboxItemInput.ts';
 import { normalizeFilterDefaults } from '../../pages/Inbox/filters.ts';
@@ -53,7 +54,7 @@ export const useDialogs = ({ parties, viewType, filterState, search, queryKey }:
     searchQuery: search,
   });
 
-  const query = useInfiniteQuery<GetAllDialogsForPartiesQuery>({
+  const query = useAuthenticatedInfiniteQuery<GetAllDialogsForPartiesQuery>({
     queryKey: [queryKey, partyIds, viewTypeKey, queryVariables, search],
     staleTime: 1000 * 60 * 10,
     retry: 3,

--- a/packages/frontend/src/api/hooks/useDialogsCount.tsx
+++ b/packages/frontend/src/api/hooks/useDialogsCount.tsx
@@ -1,10 +1,11 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData } from '@tanstack/react-query';
 import type {
   CountableDialogFieldsFragment,
   GetAllDialogsForCountQuery,
   PartyFieldsFragment,
 } from 'bff-types-generated';
 import { useMemo } from 'react';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { graphQLSDK } from '../queries.ts';
 import { getPartyIds, getQueryVariables } from '../utils/dialog.ts';
@@ -24,7 +25,7 @@ export const useDialogsCount = (parties?: PartyFieldsFragment[], viewType?: Inbo
   const partiesToUse = parties ? parties : selectedParties;
   const partyIds = getPartyIds(partiesToUse);
 
-  const { data } = useQuery<GetAllDialogsForCountQuery>({
+  const { data } = useAuthenticatedQuery<GetAllDialogsForCountQuery>({
     queryKey: [QUERY_KEYS.COUNT_DIALOGS, partyIds, viewType],
     staleTime: 1000 * 60 * 10,
     retry: 3,

--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
 import type { PartyFieldsFragment } from 'bff-types-generated';
 import { useEffect, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import {
   getSelectedAllPartiesFromQueryParams,
@@ -76,7 +76,7 @@ export const useParties = (): UsePartiesOutput => {
     }
   };
 
-  const { data, isLoading, isSuccess, isError } = useQuery<PartiesResult>({
+  const { data, isLoading, isSuccess, isError } = useAuthenticatedQuery<PartiesResult>({
     queryKey: [QUERY_KEYS.PARTIES],
     queryFn: fetchParties,
     staleTime: Number.POSITIVE_INFINITY,

--- a/packages/frontend/src/auth/api.ts
+++ b/packages/frontend/src/auth/api.ts
@@ -6,7 +6,6 @@ export const getIsAuthenticated = async (): Promise<boolean> => {
     });
     return response.ok;
   } catch (error) {
-    console.error('error', error);
     return false;
   }
 };

--- a/packages/frontend/src/auth/useAuthenticatedInfiniteQuery.tsx
+++ b/packages/frontend/src/auth/useAuthenticatedInfiniteQuery.tsx
@@ -1,0 +1,26 @@
+import {
+  type DefaultError,
+  type InfiniteData,
+  type QueryKey,
+  type UseInfiniteQueryOptions,
+  type UseInfiniteQueryResult,
+  useInfiniteQuery,
+} from '@tanstack/react-query';
+import { useAuth } from '../components/Login/AuthContext.tsx';
+
+export function useAuthenticatedInfiniteQuery<
+  TQueryFnData,
+  TError = DefaultError,
+  TData = InfiniteData<TQueryFnData>,
+  TQueryKey extends QueryKey = QueryKey,
+  TPageParam = unknown,
+>(
+  options: UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>,
+): UseInfiniteQueryResult<TData, TError> {
+  const { isAuthenticated } = useAuth();
+
+  return useInfiniteQuery({
+    ...options,
+    enabled: isAuthenticated && (options.enabled ?? true),
+  });
+}

--- a/packages/frontend/src/auth/useAuthenticatedQuery.tsx
+++ b/packages/frontend/src/auth/useAuthenticatedQuery.tsx
@@ -1,0 +1,16 @@
+import { type UseQueryOptions, type UseQueryResult, useQuery } from '@tanstack/react-query';
+import { useAuth } from '../components/Login/AuthContext.tsx';
+
+export function useAuthenticatedQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends readonly unknown[] = unknown[],
+>(options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>): UseQueryResult<TData, TError> {
+  const { isAuthenticated } = useAuth();
+
+  return useQuery({
+    ...options,
+    enabled: isAuthenticated && (options.enabled ?? true),
+  });
+}

--- a/packages/frontend/src/components/Login/AuthContext.tsx
+++ b/packages/frontend/src/components/Login/AuthContext.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import type React from 'react';
-import { useRef } from 'react';
 import { createContext, useContext, useEffect } from 'react';
 import { getCurrentURL, getIsAuthenticated, getStoredURL, removeStoredURL, saveURL } from '../../auth';
 
@@ -11,19 +10,10 @@ interface AuthContextProps {
 const AuthContext = createContext<AuthContextProps | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const lastFocusRef = useRef(0);
   const { data: isAuthenticated, isFetchedAfterMount } = useQuery({
     queryKey: ['isAuthenticated'],
     queryFn: async () => getIsAuthenticated(),
     refetchInterval: 30 * 1000,
-    refetchOnWindowFocus: () => {
-      const now = Date.now();
-      if (now - lastFocusRef.current > 10 * 1000) {
-        lastFocusRef.current = now;
-        return true;
-      }
-      return false;
-    },
     retry: 3,
   });
 

--- a/packages/frontend/src/components/PageLayout/Search/useAutocomplete.tsx
+++ b/packages/frontend/src/components/PageLayout/Search/useAutocomplete.tsx
@@ -1,5 +1,4 @@
 import type { AutocompleteItemProps, AutocompleteProps } from '@altinn/altinn-components';
-import { useQuery } from '@tanstack/react-query';
 import type { DialogStatus, GetSearchAutocompleteDialogsQuery, PartyFieldsFragment } from 'bff-types-generated';
 import { t } from 'i18next';
 import { useMemo } from 'react';
@@ -12,6 +11,7 @@ import {
   mapAutocompleteDialogsDtoToInboxItem,
 } from '../../../api/utils/autcomplete.ts';
 import { getPartyIds } from '../../../api/utils/dialog.ts';
+import { useAuthenticatedQuery } from '../../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { pruneSearchQueryParams } from '../../../pages/Inbox/queryParams.ts';
 import { useOrganizations } from '../../../pages/Inbox/useOrganizations.ts';
@@ -120,7 +120,7 @@ export const useAutocomplete = ({ selectedParties, searchValue }: searchDialogsP
     isSuccess,
     isLoading,
     isFetching,
-  } = useQuery<GetSearchAutocompleteDialogsQuery>({
+  } = useAuthenticatedQuery<GetSearchAutocompleteDialogsQuery>({
     queryKey: [QUERY_KEYS.SEARCH_AUTOCOMPLETE_DIALOGS, partyURIs, debouncedSearchString],
     queryFn: () => searchAutocompleteDialogs(partyURIs, debouncedSearchString),
     staleTime: 1000 * 60 * 10,

--- a/packages/frontend/src/pages/Inbox/useOrganizations.ts
+++ b/packages/frontend/src/pages/Inbox/useOrganizations.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import type { OrganizationFieldsFragment, OrganizationsQuery } from 'bff-types-generated';
 import { fetchOrganizations } from '../../api/queries.ts';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 
 interface UseOrganizationsOutput {
@@ -10,7 +10,7 @@ interface UseOrganizationsOutput {
 }
 
 export const useOrganizations = (): UseOrganizationsOutput => {
-  const { data, isLoading, isSuccess } = useQuery<OrganizationsQuery>({
+  const { data, isLoading, isSuccess } = useAuthenticatedQuery<OrganizationsQuery>({
     queryKey: [QUERY_KEYS.ORGANIZATIONS],
     queryFn: fetchOrganizations,
     retry: 3,

--- a/packages/frontend/src/pages/Profile/useNotificationSettingsForParty.tsx
+++ b/packages/frontend/src/pages/Profile/useNotificationSettingsForParty.tsx
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
 import type { NotificationSettingsResponse, NotificationsettingsByUuidQuery } from 'bff-types-generated';
 import { getNotificationsettingsByUuid, updateNotificationsetting } from '../../api/queries.ts';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 
 export const useNotificationSettingsForParty = (partyUuid?: string) => {
@@ -12,7 +12,7 @@ export const useNotificationSettingsForParty = (partyUuid?: string) => {
     };
   }
 
-  const { data, isLoading } = useQuery<NotificationsettingsByUuidQuery>({
+  const { data, isLoading } = useAuthenticatedQuery<NotificationsettingsByUuidQuery>({
     queryKey: [QUERY_KEYS.NOTIFICATIONSETTINGSFORPARTY, partyUuid],
     queryFn: () => getNotificationsettingsByUuid(partyUuid),
     refetchOnWindowFocus: false,

--- a/packages/frontend/src/pages/Profile/useProfile.tsx
+++ b/packages/frontend/src/pages/Profile/useProfile.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import type { GroupObject, ProfileQuery, User } from 'bff-types-generated';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -9,10 +9,11 @@ import {
   getNotificationsettingsByUuid,
   profile,
 } from '../../api/queries.ts';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 
 export const useProfile = () => {
-  const { data, isLoading } = useQuery<ProfileQuery>({
+  const { data, isLoading } = useAuthenticatedQuery<ProfileQuery>({
     queryKey: [QUERY_KEYS.PROFILE],
     queryFn: () => profile(),
     refetchOnWindowFocus: false,

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
@@ -6,7 +6,7 @@ import {
 } from '@altinn/altinn-components';
 import type { QueryItemProps } from '@altinn/altinn-components';
 import type { EditableBookmarkProps } from '@altinn/altinn-components/dist/types/lib/components';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   DialogStatus,
   type SavedSearchData,
@@ -21,6 +21,7 @@ import { Link, type LinkProps } from 'react-router-dom';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
 import { createSavedSearch, deleteSavedSearch, fetchSavedSearches, updateSavedSearch } from '../../api/queries.ts';
 import { getOrganization } from '../../api/utils/organizations.ts';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useFormatDistance } from '../../i18n/useDateFnsLocale.tsx';
 import { DateFilterOption } from '../Inbox/filters.ts';
@@ -142,7 +143,7 @@ export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesO
   const queryClient = useQueryClient();
   const { openSnackbar } = useSnackbar();
 
-  const { data, isLoading, isSuccess } = useQuery<SavedSearchesQuery>({
+  const { data, isLoading, isSuccess } = useAuthenticatedQuery<SavedSearchesQuery>({
     queryKey: [QUERY_KEYS.SAVED_SEARCHES, selectedPartyIds],
     queryFn: fetchSavedSearches,
     retry: 3,


### PR DESCRIPTION
- Add `useAuthenticatedQuery` and `useAuthenticatedInfiniteQuery` hooks
  that only run when `isAuthenticated` is true
- Replace direct useQuery/useInfiniteQuery calls with the new hooks
  to avoid running API calls before tokens are refreshed
- BFF: redirect to /api/login on OIDC state mismatch
- BFF: introduce explicit `access_token_invalid` status



## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/2763

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
