### PR TITLE
feat: Settings page + other profile improvements

### DIFF
--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -310,6 +310,7 @@
   "word.and": "and",
   "word.back": "Back",
   "word.beta": "Beta",
+  "word.change": "Change",
   "word.moreThan": "More than ",
   "word.clock_prefix": "",
   "word.close": "Close",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -310,6 +310,7 @@
   "word.and": "og",
   "word.moreThan": "Mer enn ",
   "word.back": "Tilbake",
+  "word.change": "Endre",
   "word.beta": "Beta",
   "word.clock_prefix": "kl.",
   "word.close": "Lukk",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -310,6 +310,7 @@
   "word.and": "og",
   "word.back": "Tilbake",
   "word.beta": "Beta",
+  "word.change": "Endre",
   "word.moreThan": "Meir enn ",
   "word.clock_prefix": "kl.",
   "word.close": "Lukk",

--- a/packages/frontend/src/pages/About/About.tsx
+++ b/packages/frontend/src/pages/About/About.tsx
@@ -1,27 +1,30 @@
-import { Article, Breadcrumbs, Heading, PageBase, Typography } from '@altinn/altinn-components';
+import { Article, Breadcrumbs, type BreadcrumbsProps, Heading, PageBase, Typography } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { createMessageBoxLink } from '../../auth';
 import { usePageTitle } from '../../hooks/usePageTitle.tsx';
+import { pruneSearchQueryParams } from '../Inbox/queryParams.ts';
 import { PageRoutes } from '../routes';
 
 export const AboutPage = () => {
   const { t } = useTranslation();
-
+  const { search } = useLocation();
   usePageTitle({ baseTitle: t('altinn.beta.about') });
 
   return (
     <PageBase>
       <Breadcrumbs
-        items={[
-          {
-            label: t('altinn.beta.inbox'),
-            as: (props) => <Link {...props} to={PageRoutes.inbox} />,
-          },
-          {
-            label: t('altinn.beta.about'),
-          },
-        ]}
+        items={
+          [
+            {
+              label: t('altinn.beta.inbox'),
+              as: (props) => <Link {...props} to={PageRoutes.inbox + pruneSearchQueryParams(search)} />,
+            },
+            {
+              label: t('altinn.beta.about'),
+            },
+          ] as BreadcrumbsProps['items']
+        }
       />
       <Article>
         <Heading size="xl">{t('about.inbox.title')}</Heading>

--- a/packages/frontend/src/pages/Profile/NotificationsPage/NotificationsPage.tsx
+++ b/packages/frontend/src/pages/Profile/NotificationsPage/NotificationsPage.tsx
@@ -1,5 +1,6 @@
 import {
   type AvatarProps,
+  type BreadcrumbsProps,
   Heading,
   List,
   PageBase,
@@ -17,8 +18,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { NotificationSettingsResponse, PartyFieldsFragment } from 'bff-types-generated';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
 import { QUERY_KEYS } from '../../../constants/queryKeys';
 import { usePageTitle } from '../../../hooks/usePageTitle';
+import { pruneSearchQueryParams } from '../../Inbox/queryParams';
 import { PageRoutes } from '../../routes';
 import {
   type NotificationType,
@@ -35,6 +38,7 @@ export interface NotificationAccountsType extends PartyFieldsFragment {
 }
 
 export const NotificationsPage = () => {
+  const { search } = useLocation();
   const [showNotificationModal, setShowNotificationModal] = useState<NotificationType>('none');
   const [searchValue, setSearchValue] = useState('');
   const { t } = useTranslation();
@@ -44,7 +48,6 @@ export const NotificationsPage = () => {
   const { partiesWithNotificationSettings, isLoading: isLoadingPartiesWithNotificationSettings } =
     usePartiesWithNotificationSettings();
   const queryClient = useQueryClient();
-
   const onSave = () => {
     queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.NOTIFICATION_SETTINGS_FOR_CURRENT_USER] });
   };
@@ -65,7 +68,7 @@ export const NotificationsPage = () => {
     return [
       {
         label: t('word.frontpage'),
-        href: PageRoutes.inbox,
+        as: (props) => <Link {...props} to={PageRoutes.inbox + pruneSearchQueryParams(search)} />,
       },
       {
         label: formatDisplayName({
@@ -79,7 +82,7 @@ export const NotificationsPage = () => {
         label: t('sidebar.profile.notifications'),
         href: PageRoutes.partiesOverview,
       },
-    ];
+    ] as BreadcrumbsProps['items'];
   };
 
   const filteredParties = partiesWithNotificationSettings.filter((party) => {
@@ -101,8 +104,13 @@ export const NotificationsPage = () => {
       badge: {
         color: 'company',
         label: t('profile.parties', {
-          count: partiesWithNotificationSettings.filter((party) =>
-            party.notificationSettings?.phoneNumber?.includes(user?.phoneNumber || ''),
+          count: partiesWithNotificationSettings.filter(
+            (party) =>
+              party.notificationSettings?.phoneNumber?.length &&
+              party.notificationSettings?.phoneNumber?.length > 3 &&
+              user?.phoneNumber?.length &&
+              user?.phoneNumber?.length > 3 &&
+              party.notificationSettings?.phoneNumber?.includes(user?.phoneNumber || ''),
           ).length,
         }),
       },
@@ -117,8 +125,13 @@ export const NotificationsPage = () => {
       badge: {
         color: 'company',
         label: t('profile.parties', {
-          count: partiesWithNotificationSettings.filter((party) =>
-            party.notificationSettings?.emailAddress?.includes(user?.email || ''),
+          count: partiesWithNotificationSettings.filter(
+            (party) =>
+              party.notificationSettings?.emailAddress?.length &&
+              party.notificationSettings?.emailAddress?.length > 3 &&
+              user?.email?.length &&
+              user?.email?.length > 3 &&
+              party.notificationSettings?.emailAddress?.includes(user?.email || ''),
           ).length,
         }),
       },

--- a/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
+++ b/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
@@ -1,6 +1,7 @@
 import {
   AccountList,
   type AvatarProps,
+  type BreadcrumbsProps,
   type FilterState,
   Heading,
   PageBase,
@@ -15,18 +16,19 @@ import type { PartyFieldsFragment } from 'bff-types-generated';
 import React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useProfile } from '..';
 import { useParties } from '../../../api/hooks/useParties';
 import { FeatureFlagKeys, useFeatureFlag } from '../../../featureFlags';
 import { usePageTitle } from '../../../hooks/usePageTitle';
+import { pruneSearchQueryParams } from '../../Inbox/queryParams';
 import { PageRoutes } from '../../routes';
 import styles from './partiesOverviewPage.module.css';
 import { partyFieldFragmentToAccountListItem } from './partyFieldToAccountList';
 
 export const PartiesOverviewPage = () => {
   const { t } = useTranslation();
-
+  const { search } = useLocation();
   const FILTER_VALUES = {
     PERSONS: t('parties.filter.persons'),
     COMPANIES: t('parties.filter.companies'),
@@ -71,7 +73,11 @@ export const PartiesOverviewPage = () => {
       filteredParties = [...filteredParties, ...deletedParties];
     }
     if (searchValue) {
-      return filteredParties.filter((party) => party.name.toLowerCase().includes(searchValue.toLowerCase()));
+      return filteredParties.filter(
+        (party) =>
+          party.name.toLowerCase().includes(searchValue.toLowerCase()) ||
+          party.party.toLowerCase().includes(searchValue.toLowerCase()),
+      );
     }
     return filteredParties;
   }, [
@@ -97,7 +103,7 @@ export const PartiesOverviewPage = () => {
     return [
       {
         label: t('word.frontpage'),
-        href: PageRoutes.inbox,
+        as: (props) => <Link {...props} to={PageRoutes.inbox + pruneSearchQueryParams(search)} />,
       },
       {
         label: formatDisplayName({
@@ -111,7 +117,7 @@ export const PartiesOverviewPage = () => {
         label: t('sidebar.profile.parties'),
         href: PageRoutes.partiesOverview,
       },
-    ];
+    ] as BreadcrumbsProps['items'];
   };
 
   if (isLoadingParties) {

--- a/packages/frontend/src/pages/Profile/Settings/Settings.tsx
+++ b/packages/frontend/src/pages/Profile/Settings/Settings.tsx
@@ -1,22 +1,17 @@
 import {
-  Divider,
+  type AvatarProps,
+  type BreadcrumbsProps,
   Heading,
   List,
   PageBase,
   PageNav,
   SettingsItem,
+  type SettingsItemProps,
   SettingsSection,
-  Typography,
+  Toolbar,
+  formatDisplayName,
 } from '@altinn/altinn-components';
-import {
-  BellIcon,
-  GlobeIcon,
-  HouseHeartIcon,
-  MobileIcon,
-  PaperplaneIcon,
-  PersonRectangleIcon,
-  SunIcon,
-} from '@navikt/aksel-icons';
+import { BellIcon, MobileIcon, PaperplaneIcon } from '@navikt/aksel-icons';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
@@ -25,102 +20,164 @@ import { useParties } from '../../../api/hooks/useParties';
 import { usePageTitle } from '../../../hooks/usePageTitle';
 import { pruneSearchQueryParams } from '../../Inbox/queryParams.ts';
 import { PageRoutes } from '../../routes';
+import {
+  type NotificationType,
+  UserNotificationSettingsModal,
+} from '../PartiesOverviewPage/UserNotificationSettingsModal';
 import { flattenParties } from '../PartiesOverviewPage/partyFieldToNotificationsList';
-import { buildAddressString } from '../buildAddressString';
 
 export const Settings = () => {
   const { user } = useProfile();
+  const { search } = useLocation();
+  const [showNotificationModal, setShowNotificationModal] = useState<NotificationType>('none');
+  const [searchValue, setSearchValue] = useState('');
   const { parties: normalParties } = useParties();
   const { search: currentSearchQuery } = useLocation();
   const flattenedParties = flattenParties(normalParties);
   const flattenedPartiesCount = flattenedParties?.filter((party) => party.partyType === 'Organization')?.length || 0;
 
-  const [expandedElement, setExpandedElement] = useState<boolean>(false);
-
   const { t } = useTranslation();
   usePageTitle({ baseTitle: t('component.settings') });
+
+  const getBreadcrumbs = (person?: AvatarProps, reverseNameOrder?: boolean) => {
+    if (!person) return [];
+    return [
+      {
+        label: t('word.frontpage'),
+        as: (props) => <Link {...props} to={PageRoutes.inbox + pruneSearchQueryParams(search)} />,
+      },
+      {
+        label: formatDisplayName({
+          fullName: person.name,
+          type: person.type as 'person' | 'company',
+          reverseNameOrder,
+        }),
+        href: PageRoutes.profile,
+      },
+      {
+        label: t('sidebar.profile.notifications'),
+        href: PageRoutes.partiesOverview,
+      },
+    ] as BreadcrumbsProps['items'];
+  };
+
+  const personalNotificationSettings: SettingsItemProps[] = [
+    {
+      icon: { svgElement: MobileIcon, theme: 'default' },
+      title: t('profile.settings.sms_notifications'),
+      value: user?.phoneNumber || 'Ingen telefonnummer registrert',
+      badge: {
+        color: 'company',
+        label: t('word.change'),
+      },
+      onClick: () => setShowNotificationModal('phoneNumber'),
+      linkIcon: true,
+      as: 'button',
+    },
+    {
+      icon: { svgElement: PaperplaneIcon, theme: 'default' },
+      title: t('profile.notifications.email_for_alerts'),
+      value: user?.email || '',
+      badge: {
+        color: 'company',
+        label: t('word.change'),
+      },
+      onClick: () => setShowNotificationModal('email'),
+      linkIcon: true,
+      as: 'button',
+    },
+    {
+      icon: { svgElement: PaperplaneIcon, theme: 'default' },
+      title: t('profile.notifications.email_for_alerts'),
+      value: user?.email || '',
+      badge: {
+        color: 'company',
+        label: t('word.change'),
+      },
+      onClick: () => setShowNotificationModal('email'),
+      linkIcon: true,
+      as: 'button',
+    },
+  ];
+
+  const personalNotificationSettingsFiltered = personalNotificationSettings.filter(
+    (setting) =>
+      String(setting.value || '')
+        .toLowerCase()
+        .includes(searchValue.toLowerCase()) ||
+      String(setting.title || '')
+        .toLowerCase()
+        .includes(searchValue.toLowerCase()),
+  );
+
+  const otherSettings: SettingsItemProps[] = [
+    {
+      icon: BellIcon,
+      title: t('profile.settings.notification_settings'),
+      badge: !!flattenedPartiesCount && { label: `${flattenedPartiesCount} aktører`, color: 'company' },
+      as: (props) => <Link to={PageRoutes.notifications + pruneSearchQueryParams(currentSearchQuery)} {...props} />,
+      linkIcon: true,
+    },
+  ];
+
+  const otherSettingsFiltered = otherSettings.filter(
+    (setting) =>
+      String(setting.value || '')
+        .toLowerCase()
+        .includes(searchValue.toLowerCase()) ||
+      String(setting.title || '')
+        .toLowerCase()
+        .includes(searchValue.toLowerCase()),
+  );
 
   return (
     <PageBase>
       <PageNav
-        breadcrumbs={[
-          {
-            label: t('word.frontpage'),
-            href: PageRoutes.inbox,
-          },
-          {
-            label: t('sidebar.profile'),
-            href: PageRoutes.profile,
-          },
-          {
-            label: t('sidebar.profile.settings'),
-            href: PageRoutes.settings,
-          },
-        ]}
+        breadcrumbs={getBreadcrumbs({
+          name: user?.party?.name ?? '',
+          type: 'person',
+        })}
       />
+      <Heading size="xl">{t('sidebar.profile.settings')}</Heading>
 
-      <Heading size="xl">{t('profile.settings.contact_settings')}</Heading>
-      <SettingsSection>
-        <List size="sm">
-          <SettingsItem
-            icon={{ svgElement: PaperplaneIcon }}
-            title={t('profile.settings.main_email')}
-            value={user?.email || '-'}
-            badge={<Typography size="xs">{t('profile.settings.change_in_register_centre')}</Typography>}
-            linkIcon
-          />
-          <Divider />
-          <SettingsItem
-            icon={{ svgElement: MobileIcon }}
-            title={t('profile.settings.sms_notifications')}
-            value={user?.party?.person?.mobileNumber || '-'}
-            badge={<Typography size="xs">{t('profile.settings.change_in_register_centre')}</Typography>}
-            linkIcon
-          />
-          <Divider />
-          <SettingsItem
-            icon={{ svgElement: HouseHeartIcon }}
-            title={t('profile.settings.postal_address')}
-            value={buildAddressString(user?.party?.person) || '-'}
-            badge={<Typography size="xs">{t('profile.settings.change_in_population_register')}</Typography>}
-            linkIcon
-          />
-        </List>
-      </SettingsSection>
-      <Heading size="xl">{t('profile.settings.more_contact_settings')}</Heading>
-      <SettingsSection>
-        <List>
-          <SettingsItem
-            as={(props) => (
-              <Link to={PageRoutes.notifications + pruneSearchQueryParams(currentSearchQuery)} {...props} />
-            )}
-            icon={BellIcon}
-            title={t('profile.settings.notification_settings')}
-            badge={!!flattenedPartiesCount && { label: `${flattenedPartiesCount} aktører` }}
-            linkIcon
-          />
-          <Divider as="li" />
-          <SettingsItem
-            icon={PersonRectangleIcon}
-            title={t('profile.settings.contact_profiles')}
-            badge={{ label: 'x antall profiler' }}
-            linkIcon
-          />
-          <Divider as="li" />
-          <SettingsItem as="button" icon={SunIcon} title="Modus: Lys" linkIcon />
-          <Divider />
-          <SettingsItem
-            as="button"
-            icon={GlobeIcon}
-            title="Språk/language:"
-            linkIcon
-            onClick={() => setExpandedElement(!expandedElement)}
-            expanded={expandedElement}
-          >
-            <p>Some content here</p>
-          </SettingsItem>
-        </List>
-      </SettingsSection>
+      <Toolbar
+        search={{
+          name: 'party-search',
+          placeholder: t('parties.search.placeholder'),
+          value: searchValue,
+          onChange: (e) => setSearchValue((e.target as HTMLInputElement).value),
+          onClear: () => setSearchValue(''),
+        }}
+      />
+      <Heading size="md">{t('profile.settings.contact_settings')}</Heading>
+      {personalNotificationSettingsFiltered.length > 0 ? (
+        <>
+          <SettingsSection>
+            <List>
+              {personalNotificationSettingsFiltered.map((setting, index) => (
+                <SettingsItem key={index} {...setting} />
+              ))}
+            </List>
+          </SettingsSection>
+        </>
+      ) : (
+        <span>{t('emptyState.noHits.title')}</span>
+      )}
+      <Heading size="md">{t('profile.settings.more_contact_settings')}</Heading>
+      {otherSettingsFiltered.length > 0 ? (
+        <>
+          <SettingsSection>
+            <List>
+              {otherSettingsFiltered.map((setting, index) => (
+                <SettingsItem key={index} {...setting} />
+              ))}
+            </List>
+          </SettingsSection>
+        </>
+      ) : (
+        <span>{t('emptyState.noHits.title')}</span>
+      )}
+      <UserNotificationSettingsModal notificationType={showNotificationModal} setShowModal={setShowNotificationModal} />
     </PageBase>
   );
 };


### PR DESCRIPTION
In this PR:
- "Mine aktører" search now includes org nr/p-nr
- "Mine varsler" counter, added check that the comparison values must be of more than 3 characters in order to prevent "no phone number" to equal "no phone number".
- "Innstillinger page"
  - Search functionality, includes setting value and setting title.
  - Added user settings for email, phone number and address and their modals
  - Removed settings that will not be part of first release
  - All settings are rewritten into objects so that they are searchable.

Demo:
![CleanShot 2025-10-01 at 21 03 26](https://github.com/user-attachments/assets/8d9a61de-dfbb-47c4-8c25-569956f46be8)

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #2080

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
