### PR TITLE
fix: Set correct sender name for sub parties

### DIFF
--- a/packages/frontend/src/api/utils/dialog.ts
+++ b/packages/frontend/src/api/utils/dialog.ts
@@ -62,9 +62,9 @@ export function mapDialogToToInboxItems(
     const senderName = item.content.senderName?.value;
 
     const dialogReceiverParty = parties?.find((party) => party.party === item.party);
-    const dialogReceiverSubParty = parties?.find((party) =>
-      (party.subParties ?? []).some((subParty) => subParty.party === item.party),
-    );
+    const dialogReceiverSubParty = parties
+      ?.flatMap((party) => party.subParties ?? [])
+      .find((subParty) => subParty.party === item.party);
 
     const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
     const serviceOwner = getOrganization(organizations || [], item.org);
@@ -87,7 +87,9 @@ export function mapDialogToToInboxItems(
         name: actualReceiverParty?.name ?? dialogReceiverSubParty?.name ?? '',
         type: actualReceiverParty?.partyType as AvatarType,
         variant:
-          !actualReceiverParty?.subParties && actualReceiverParty?.partyType === 'Organization' ? 'outline' : 'solid',
+          dialogReceiverParty && !dialogReceiverParty.subParties && actualReceiverParty?.partyType === 'Organization'
+            ? 'outline'
+            : 'solid',
       },
       color: actualReceiverParty?.partyType === 'Organization' ? 'company' : 'person',
       contentUpdatedAt: item.contentUpdatedAt,


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

  Get all subParties from all parties (flatMap) and find the actual subParty that matches the dialog's party ID
  Example:
  - Main party: "Acme Corp" (has subParties)
  - Sub party: "Acme Oslo Branch"
  - Dialog belongs to: "Acme Oslo Branch"

  Before: dialogReceiverSubParty = "Acme Corp"
  After: dialogReceiverSubParty = "Acme Oslo Branch" 

https://github.com/Altinn/dialogporten-frontend/issues/3007

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
