### PR TITLE
fix: format name and type of avatar of party representative based on actorId

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -167,8 +167,8 @@ export const getActorProps = (actor: Actor, serviceOwner?: OrganizationOutput): 
   const type: AvatarProps['type'] = isCompany ? 'company' : 'person';
   const actorName = formatDisplayName({
     fullName: actor.actorName ?? '',
-    type: 'person',
-    reverseNameOrder: true,
+    type,
+    reverseNameOrder: !isCompany,
   });
   const senderName = actor.actorName ? actorName : isServiceOwner ? serviceOwner?.name || '' : '';
   const senderLogo = isServiceOwner ? serviceOwner?.logo : undefined;


### PR DESCRIPTION
<img width="2000" height="324" alt="Image" src="https://github.com/user-attachments/assets/128168eb-cf0d-4c81-8e8b-1a324beb0754" />

Er nå løst ved at avatar-type og formatering for `partyRepresentative` tar hensyn til at `actorId` kan representere en en bedrift. 

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3018

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
