### PR TITLE
fix: always refetch dialog on mount to ensure correct content is loaded

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -98,6 +98,7 @@ interface UseDialogByIdOutput {
   isSuccess: boolean;
   isError: boolean;
   isLoading: boolean;
+  dataUpdatedAt: number;
   dialog?: DialogByIdDetails;
   isAuthLevelTooLow?: boolean;
 }
@@ -315,10 +316,11 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   const stopReversingPersonNameOrder = useFeatureFlag<boolean>('party.stopReversingPersonNameOrder');
   const { selectedProfile } = useParties();
   const partyURIs = parties.map((party) => party.party);
-  const { data, isSuccess, isLoading, isError } = useAuthenticatedQuery<GetDialogByIdQuery>({
+  const { data, isSuccess, isLoading, isError, dataUpdatedAt } = useAuthenticatedQuery<GetDialogByIdQuery>({
     queryKey: [QUERY_KEYS.DIALOG_BY_ID, id, organizations],
     staleTime: 1000 * 60 * 30,
     refetchInterval: 1000 * 60 * 10,
+    refetchOnMount: 'always',
     refetchOnWindowFocus: false,
     retry: 3,
     queryFn: () =>
@@ -329,7 +331,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   });
 
   if (isOrganizationsLoading) {
-    return { isLoading: true, isError: false, isSuccess: false };
+    return { isLoading: true, isError: false, isSuccess: false, dataUpdatedAt: Date.now() };
   }
 
   return {
@@ -343,6 +345,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
       stopReversingPersonNameOrder,
       selectedProfile,
     ),
+    dataUpdatedAt,
     isError,
     isAuthLevelTooLow:
       data?.dialogById?.errors?.some((error) => error.__typename === 'DialogByIdForbiddenAuthLevelTooLow') ?? false,

--- a/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
+++ b/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
@@ -41,6 +41,7 @@ interface DialogDetailsProps {
   isAuthLevelTooLow?: boolean;
   isLoading?: boolean;
   subscriptionOpened?: boolean;
+  dialogToken?: string;
 }
 
 /**
@@ -167,6 +168,7 @@ export const DialogDetails = ({
   isLoading,
   isAuthLevelTooLow,
   activityModalProps,
+  dialogToken,
   subscriptionOpened,
 }: DialogDetailsProps): ReactElement => {
   const { t } = useTranslation();
@@ -187,17 +189,19 @@ export const DialogDetails = ({
       items: transmission.items?.map((item, index) => {
         return {
           ...item,
-          children: dialog.contentReferenceForTransmissions[item.id as string] ? (
-            <MainContentReference
-              id={item.id ?? `${transmission.id}-${index}`}
-              content={dialog.contentReferenceForTransmissions[item.id as string]}
-              dialogToken={dialog.dialogToken}
-            />
-          ) : null,
+          children: dialog.contentReferenceForTransmissions[item.id as string]
+            ? dialogToken && (
+                <MainContentReference
+                  id={item.id ?? `${transmission.id}-${index}`}
+                  content={dialog.contentReferenceForTransmissions[item.id as string]}
+                  dialogToken={dialogToken}
+                />
+              )
+            : null,
         };
       }),
     }));
-  }, [dialog]);
+  }, [dialog, dialogToken]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: no need with format
   const activityHistoryItems: ActivityLogSegmentProps[] = useMemo(() => {
@@ -220,19 +224,21 @@ export const DialogDetails = ({
             <TransmissionList
               items={dialogHistoryItem.items.map((item) => ({
                 ...item,
-                children: dialog.contentReferenceForTransmissions[item.id as string] ? (
-                  <MainContentReference
-                    id={item.id}
-                    content={dialog.contentReferenceForTransmissions[item.id as string]}
-                    dialogToken={dialog.dialogToken}
-                  />
-                ) : null,
+                children: dialog.contentReferenceForTransmissions[item.id as string]
+                  ? dialogToken && (
+                      <MainContentReference
+                        id={item.id}
+                        content={dialog.contentReferenceForTransmissions[item.id as string]}
+                        dialogToken={dialogToken}
+                      />
+                    )
+                  : null,
               }))}
             />
           ) : null,
       };
     });
-  }, [dialog]);
+  }, [dialog, dialogToken]);
 
   if (isLoading) {
     return (
@@ -287,7 +293,7 @@ export const DialogDetails = ({
     hidden: action.hidden,
     onClick: () => {
       setActionIdLoading(action.id);
-      void handleDialogActionClick(action, dialog.dialogToken, () => setActionIdLoading(''), logError, isApp);
+      dialogToken && void handleDialogActionClick(action, dialogToken, () => setActionIdLoading(''), logError, isApp);
     },
   }));
 
@@ -329,8 +335,8 @@ export const DialogDetails = ({
         seenByLog={dialog.seenByLog}
       >
         <p>{dialog.summary}</p>
-        {subscriptionOpened && (
-          <MainContentReference content={dialog.mainContentReference} dialogToken={dialog.dialogToken} id={dialog.id} />
+        {subscriptionOpened && dialogToken && (
+          <MainContentReference content={dialog.mainContentReference} dialogToken={dialogToken} id={dialog.id} />
         )}
         {dialog.attachments.length > 0 && (
           <DialogAttachments

--- a/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
+++ b/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
@@ -66,7 +66,7 @@ export const MainContentReference = memo(
 
     const validURL = content?.url ? isValidURL(content.url) : false;
     const { data, isSuccess, isError, isLoading, refetch } = useQuery({
-      queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, id],
+      queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, id, dialogToken],
       staleTime: 1000 * 60 * 10,
       queryFn: async () => {
         const response = await fetch(content!.url, {


### PR DESCRIPTION
cf. https://github.com/Altinn/dialogporten-frontend/issues/3086

We should always refetch the dialog on mount or else FCE wont be downloaded and it risks using an expired token and also wait till the new dialog token is retrieved

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
