### PR TITLE
fix: Fix data parties data structure for Global Header

### DIFF
--- a/packages/frontend/src/mocks/data/base/parties.ts
+++ b/packages/frontend/src/mocks/data/base/parties.ts
@@ -10,7 +10,7 @@ export const parties: PartyFieldsFragment[] = [
     name: 'TESTESEN TEST',
     isCurrentEndUser: true,
     isDeleted: false,
-    partyUuid: 'urn:altinn:person:identifier-no:1337',
+    partyUuid: 'urn:altinn:person:uuid:test-testesen',
     hasOnlyAccessToSubParties: false,
   },
   {
@@ -22,7 +22,7 @@ export const parties: PartyFieldsFragment[] = [
     name: 'Firma AS',
     isCurrentEndUser: true,
     isDeleted: false,
-    partyUuid: 'urn:altinn:person:identifier-no:1337',
+    partyUuid: 'urn:altinn:organization:uuid:firma-as',
     hasOnlyAccessToSubParties: false,
   },
   {
@@ -36,7 +36,7 @@ export const parties: PartyFieldsFragment[] = [
         isMainAdministrator: true,
         name: 'TESTBEDRIFT AS AVD SUB',
         isCurrentEndUser: false,
-        partyUuid: 'urn:altinn:person:identifier-no:1337',
+        partyUuid: 'urn:altinn:organization:uuid:testbedrift-avd-sub',
         isDeleted: false,
       },
       {
@@ -46,7 +46,7 @@ export const parties: PartyFieldsFragment[] = [
         isMainAdministrator: true,
         name: 'TESTBEDRIFT AS AVD OSLO',
         isCurrentEndUser: false,
-        partyUuid: 'urn:altinn:person:identifier-no:1337',
+        partyUuid: 'urn:altinn:organization:uuid:testbedrift-avd-oslo',
         isDeleted: false,
       },
       {
@@ -56,7 +56,7 @@ export const parties: PartyFieldsFragment[] = [
         isMainAdministrator: true,
         name: 'TESTBEDRIFT AS',
         isCurrentEndUser: false,
-        partyUuid: 'urn:altinn:person:identifier-no:1337',
+        partyUuid: 'urn:altinn:organization:uuid:testbedrift-sub',
         isDeleted: false,
       },
     ],
@@ -65,7 +65,7 @@ export const parties: PartyFieldsFragment[] = [
     name: 'TESTBEDRIFT AS',
     isCurrentEndUser: false,
     isDeleted: false,
-      partyUuid: 'urn:altinn:person:identifier-no:1337',
+      partyUuid: 'urn:altinn:organization:uuid:testbedrift-main',
     hasOnlyAccessToSubParties: false,
   },
 ];


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Fix data structure for useAccountSelector (filter out sub-parties) from top level array: 

  Before:
  [
    { uuid: "A", name: "Parent Org", subParties: [{ uuid: "B", name: "Subunit" }] },
    { uuid: "B", name: "Subunit" }, // to be deleted, already a sub of "A"
    { uuid: "C", name: "Person" }
  ]
  
  After: 
  [
    { uuid: "A", name: "Parent Org", subunits: [{ uuid: "B", name: "Subunit" }] },
    { uuid: "C", name: "Person" }
  ]


## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/3149


### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
