### PR TITLE
fix: Map inbox color to match global header, fix icon sizes

### DIFF
--- a/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
@@ -202,7 +202,7 @@ export function buildInboxMenu({
       {
         groupId: 'profile-shortcut',
         id: 'profile',
-        size: 'md',
+        size: 'sm',
         as: createMenuItemComponent({
           to: PageRoutes.profile + pruneSearchQueryParams(currentSearchQuery),
         }),

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/profileMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/profileMenu.tsx
@@ -141,7 +141,7 @@ export function buildProfileMenu({
   const profileMenuItem: MenuItemProps = {
     groupId: 'profile-shortcut',
     id: 'profile',
-    size: 'md',
+    size: 'sm',
     as: createMenuItemComponent({
       to: PageRoutes.profile + pruneSearchQueryParams(currentSearchQuery),
     }),

--- a/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
+++ b/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
@@ -8,7 +8,7 @@ import type { ChangeEvent } from 'react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import type { useParties } from '../../api/hooks/useParties.ts';
+import { useParties } from '../../api/hooks/useParties.ts';
 import { updateLanguage } from '../../api/queries.ts';
 import { createHomeLink } from '../../auth';
 import { useFeatureFlag } from '../../featureFlags';
@@ -51,6 +51,8 @@ export const useHeaderConfig = ({
   const { autocomplete } = useAutocomplete({ selectedParties: selectedParties, searchValue });
 
   const { favoritesGroup, addFavoriteParty, deleteFavoriteParty } = useProfile();
+
+  const { currentEndUser } = useParties();
 
   const handleToggleFavorite = useCallback(
     async (accountUuid: string) => {
@@ -100,7 +102,6 @@ export const useHeaderConfig = ({
     [parties, isProfile, location.pathname, navigate],
   );
 
-  const currentEndUser = parties.find((party) => party.isCurrentEndUser);
   const partyListDTO = mapPartiesToAuthorizedParties(parties);
 
   const favoriteAccountUuids = (favoritesGroup?.parties ?? []).filter(
@@ -118,9 +119,11 @@ export const useHeaderConfig = ({
     return undefined;
   };
 
-  const currentAccountUuid = getCookie('AltinnPartyUuid') ?? selectedParties[0]?.partyUuid ?? currentEndUser?.partyUuid;
-
+  let currentAccountUuid = getCookie('AltinnPartyUuid') ?? selectedParties[0]?.partyUuid ?? currentEndUser?.partyUuid;
   const selfAccountUuid = currentEndUser?.partyUuid;
+  if (allOrganizationsSelected) {
+    currentAccountUuid = selfAccountUuid!;
+  }
 
   const accountSelectorData = useAccountSelector({
     partyListDTO,

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -164,7 +164,7 @@ const useGroupedDialogs = ({
       summary: item.viewType === 'inbox' ? item.summary : undefined,
       state: getDialogState(item.viewType),
       recipient: item.recipient,
-      color: allOrganizationsSelected ? 'company' : undefined,
+      color: item.recipient.type?.toLowerCase() as 'person' | 'company',
       grouped: allOrganizationsSelected,
       attachmentsCount: item.guiAttachmentCount,
       seenByLog: item.seenByLog,

--- a/packages/frontend/tests/stories/common.ts
+++ b/packages/frontend/tests/stories/common.ts
@@ -4,7 +4,7 @@ export const getSidebar = (page: Page) => page.locator('aside');
 export const getSidebarMenuItem = (page: Page, route: string) => getSidebar(page).locator(`a[href*="${route}?"]`);
 export const getSearchbarInput = (page: Page) => page.locator("[name='Søk']");
 
-export async function performSearch(page, query: string, action?: 'clear' | 'click' | 'enter') {
+export async function performSearch(page: Page, query: string, action?: 'clear' | 'click' | 'enter') {
   const endGameAction = action || 'click';
   const searchbarInput = page.locator("[name='Søk']");
   await searchbarInput.click();
@@ -21,7 +21,7 @@ export async function performSearch(page, query: string, action?: 'clear' | 'cli
   }
 }
 
-export async function selectDialogBySearch(page, query: string, action?: 'click' | 'enter' | 'nothing') {
+export async function selectDialogBySearch(page: Page, query: string, action?: 'click' | 'enter' | 'nothing') {
   const endGameAction = action || 'click';
   const searchbarInput = page.locator("[name='Søk']");
 

--- a/packages/frontend/tests/stories/messageNavigation.spec.ts
+++ b/packages/frontend/tests/stories/messageNavigation.spec.ts
@@ -36,7 +36,7 @@ test.describe('Message navigation', () => {
     await page.getByRole('link', { name: 'This is a message 1 for Firma AS' }).click();
     await page.getByRole('link', { name: 'Tilbake', exact: true }).click();
     await expect(page.getByRole('button', { name: 'Alle virksomheter' })).toBeVisible();
-    await expectIsNeutralPage(page);
+    await expectIsPersonPage(page);
   });
 
   test('Back button navigates to previous page the message has been opened from', async ({ page, isMobile }) => {


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

Innlogget bruker:
Grå bakgrunn + grønne lenker.
<Layout color=“person” theme=“neutral”>
- Innboks, for deg selv
- Innboks, grupper (alle virksomheter, osv.)
- Profil.

Company:
<Layout color=“company” theme=“subtle”> 

Annen Person:
<Layout color=“person” theme=“subtle”>

Hver enkelt dialog bør ha color ift mottaker. Dvs. hvis mottaker er et selskap => color: “Company”, hvis mottaker er person => Color: “Person”.
Bruk props fra recipient/avatar.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)
Related to epic: 
https://github.com/Altinn/dialogporten-frontend/issues/3020

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
