### PR TITLE
fix(infra): remove zones from application gateway in staging

### DIFF
--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -43,8 +43,6 @@ param applicationGatewayConfiguration = {
     }
   ]
   sslCertificateKeyVaultName: readEnvironmentVariable('CERTIFICATE_KEY_VAULT_NAME')
-  // remove after testing
-  zones: ['1', '2']
 }
 
 // PostgreSQL Configuration


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

As we do not have a zonal Public IP, we revert the HA for application gateway in staging. Later we can add a public ip which is zonal, and then add a DNS record for that before upgrading the application gateway. 

## Related Issue(s)

- #2632 