### PR TITLE
feat: always display all organizations option from 2 or more orgs

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.46.6",
+    "@altinn/altinn-components": "0.47.3",
     "@microsoft/applicationinsights-react-js": "19.3.7",
     "@microsoft/applicationinsights-web": "3.3.9",
     "@navikt/aksel-icons": "^7.33.3",

--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -30,6 +30,7 @@ interface UsePartiesOutput {
   flattenedParties: FlattenedParty[];
   currentPartyUuid: string | undefined;
   isSelfIdentifiedUser: boolean;
+  organizationLimitReached: boolean;
 }
 
 const stripQueryParamsForParty = (searchParamString: string) => {
@@ -240,5 +241,6 @@ export const useParties = (): UsePartiesOutput => {
     partiesEmptyList,
     currentPartyUuid,
     isSelfIdentifiedUser,
+    organizationLimitReached: selectedParties.length > 20,
   };
 };

--- a/packages/frontend/src/components/Notice/Notice.tsx
+++ b/packages/frontend/src/components/Notice/Notice.tsx
@@ -1,4 +1,4 @@
-import { PageBase, Typography } from '@altinn/altinn-components';
+import { Heading, Section, Typography } from '@altinn/altinn-components';
 import styles from './notice.module.css';
 
 interface NoticeProps {
@@ -12,9 +12,9 @@ interface NoticeProps {
 
 export const Notice = ({ title, description, link }: NoticeProps) => {
   return (
-    <PageBase margin="page">
-      <Typography className={styles.content}>
-        <h1>{title}</h1>
+    <Section spacing={3} margin="section">
+      <Heading size="lg">{title}</Heading>
+      <Typography size="sm">
         {description && <p>{description}</p>}
         {link && (
           <a className={styles.link} href={link.href}>
@@ -22,6 +22,6 @@ export const Notice = ({ title, description, link }: NoticeProps) => {
           </a>
         )}
       </Typography>
-    </PageBase>
+    </Section>
   );
 };

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -333,6 +333,8 @@
   "profile.settings.settings_loading": "Loading settings...",
   "profile.settings.sms": "SMS",
   "profile.settings.sms_notifications": "SMS notifications",
+  "organizationLimitReached.title": "All organisations",
+  "organizationLimitReached.description": "You have access to {count} organisations, but we currently can’t display dialogs for more than 20 at once.",
   "route.archived": "Archive",
   "route.deleted": "Bin",
   "savedSearches.bookmark.item_input_helper": "Give saved search a title",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -335,6 +335,8 @@
   "profile.settings.sms_notifications": "Varslinger på SMS",
   "route.archived": "Arkiv",
   "route.deleted": "Papirkurv",
+  "organizationLimitReached.title": "Alle virksomheter",
+  "organizationLimitReached.description": "Du har tilgang til {count} virksomheter, men vi kan foreløpig ikke vise dialoger for mer enn 20 samtidig.",
   "savedSearches.bookmark.item_input_helper": "Gi bokmerket et navn",
   "savedSearches.bookmark.item_input_label": "Tittel",
   "savedSearches.bookmark.item_input_placeholder": "Uten tittel",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -215,6 +215,8 @@
   "onboarding.finish": "Ferdig",
   "onboarding.next": "Neste",
   "onboarding.previous": "Tilbake",
+  "organizationLimitReached.title": "Alle verksemder",
+  "organizationLimitReached.description": "Du har tilgang til {count} verksemder, men vi kan førebels ikkje vise dialogar for meir enn 20 samtidig.",
   "onboarding.tour.filter.description": "Med den nye filterfunksjonen kan du sjølv velje kva som blir vist – og få betre oversikt.",
   "onboarding.tour.filter.title": "Filter",
   "onboarding.tour.inbox.description": "Vi har byrja å byggje ut innboksen med fleire moglegheiter for å organisere meldingane dine.",

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -55,6 +55,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
     currentPartyUuid,
     isError: unableToLoadParties,
     isLoading: isLoadingParties,
+    organizationLimitReached,
   } = useParties();
   useMockError();
   const location = useLocation();
@@ -166,19 +167,51 @@ export const Inbox = ({ viewType }: InboxProps) => {
 
   if (isSelfIdentifiedUser) {
     return (
-      <Notice
-        title={t('notice.self_identified_warning.title')}
-        description={t('notice.self_identified_warning.description')}
-        link={{
-          href: createMessageBoxLink(currentPartyUuid),
-          label: t('notice.self_identified_warning.button_link'),
-        }}
-      />
+      <PageBase margin="page">
+        <Notice
+          title={t('notice.self_identified_warning.title')}
+          description={t('notice.self_identified_warning.description')}
+          link={{
+            href: createMessageBoxLink(currentPartyUuid),
+            label: t('notice.self_identified_warning.button_link'),
+          }}
+        />
+      </PageBase>
     );
   }
 
   if (partiesEmptyList) {
-    return <Notice title={t('inbox.no_parties_found')} />;
+    return (
+      <PageBase margin="page">
+        <Notice title={t('inbox.no_parties_found')} />
+      </PageBase>
+    );
+  }
+
+  if (organizationLimitReached) {
+    return (
+      <PageBase margin="page">
+        <Section data-testid="inbox-toolbar" style={isGlobalMenuEnabled ? { marginTop: '-1rem' } : undefined}>
+          <Toolbar
+            data-testid="inbox-toolbar"
+            accountMenu={{
+              items: accounts,
+              search: accountSearch,
+              groups: accountGroups,
+              currentAccount: selectedAccount,
+              onSelectAccount: (account: string) => onSelectAccount(account, PageRoutes[viewType]),
+              filterAccount,
+              isVirtualized: true,
+              title: t('parties.change_label'),
+            }}
+          />
+          <Notice
+            title={t('organizationLimitReached.title')}
+            description={t('organizationLimitReached.description', { count: selectedParties.length })}
+          />
+        </Section>
+      </PageBase>
+    );
   }
 
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: 0.46.6
-        version: 0.46.6(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.47.3
+        version: 0.47.3(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@microsoft/applicationinsights-react-js':
         specifier: 19.3.7
         version: 19.3.7(history@4.10.1)(react@19.1.0)(tslib@2.8.1)
@@ -633,8 +633,8 @@ packages:
     resolution: {integrity: sha512-p6t8ue0XZNjcRiqNkb5QAM0qQRAKsCiebZ6n9JjWA+p8fWf8BvnhO55y2fO28g3GW0Imj7PrAuyBuxq8aDVQwQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.46.6':
-    resolution: {integrity: sha512-JmJ/Vo0kAw8sh+4tz5rJIZtCna+85nHfEsCGlEUW8Qz9gXYsX3g9YYU5osaPw7Ubh+8tiPHDjCUn1Rpx8Gx52g==}
+  '@altinn/altinn-components@0.47.3':
+    resolution: {integrity: sha512-7PMFRW0ilL01FD9aWxW4OoNx+YnSdivbv8NIXEZFkofiHmIiNOfDUS2l81yndg1CrSvBMM2F7UG4KdbZZMfpKw==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -10425,7 +10425,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.19.0
 
-  '@altinn/altinn-components@0.46.6(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@altinn/altinn-components@0.47.3(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@digdir/designsystemet-css': 1.0.6
       '@digdir/designsystemet-react': 1.0.6(@types/react@19.1.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
This resolves https://github.com/Altinn/dialogporten-frontend/issues/3129 

Always show option for selecting all organizations with fallback text if max cap is reached.

<img width="1135" height="301" alt="Screenshot 2025-11-21 at 13 14 27" src="https://github.com/user-attachments/assets/979b5a4a-4da8-48bf-9dda-eaba32493e71" />
<img width="1229" height="369" alt="Screenshot 2025-11-21 at 13 14 16" src="https://github.com/user-attachments/assets/2320fb41-61ed-42c6-ab79-3356905a3455" />

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3129

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
