### PR TITLE
fix(frontend): ensure enough ajax calls are tracked per session

### DIFF
--- a/packages/frontend/src/analytics.ts
+++ b/packages/frontend/src/analytics.ts
@@ -175,6 +175,7 @@ if (applicationInsightsEnabled) {
         samplingPercentage: 100,
         appId: 'arbeidsflate-frontend',
         enableDebug: true,
+        maxAjaxCallsPerView: 2000,
       },
     });
     applicationInsights.loadAppInsights();


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Getting an issue: 
Maximum ajax per page view limit reached, ajax monitoring is paused until the next trackPageView(). In order to increase the limit set the maxAjaxCallsPerView configuration parameter

Some sessions last a long time and would be beneficial to see more calls per view. Default for maxAjaxCallsPerView is 500, increasing to 2000. 

We will be adjusting sampling for application insights to counter excessive amounts of data soon.