### PR TITLE
fix(bff): avoid sending unnecessary gql spans to OTEL

### DIFF
--- a/packages/bff/src/instrumentation.ts
+++ b/packages/bff/src/instrumentation.ts
@@ -38,6 +38,7 @@ const instrumentations = [
   new IORedisInstrumentation(),
   new FastifyOtelInstrumentation(),
   new GraphQLInstrumentation({
+    ignoreResolveSpans: true,
     ignoreTrivialResolveSpans: true,
     mergeItems: true,
   }),


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

To avoid increasing cost in AI, remove tracing of spans for resolvers. 

<img width="502" height="397" alt="CleanShot 2025-12-15 at 11 17 43" src="https://github.com/user-attachments/assets/7edd4516-c694-4770-a649-f8c45a700031" />

## Related Issue(s)

- #N/A
