### PR TITLE
ci: increase timeout for revision verifier

### DIFF
--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -215,7 +215,7 @@ jobs:
         uses: azure/CLI@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2.1.0
         if: ${{!inputs.dryRun}}
         id: verify-deployment
-        timeout-minutes: 3
+        timeout-minutes: 6
         with:
           inlineScript: |
             ./.github/tools/revisionVerifier.sh ${{ steps.deploy.outputs.revisionName }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

The production deploys are timing out. Takes more than 3 minutes because of the amount of replicas. 

## Related Issue(s)

- #N/A