### PR TITLE
fix: remove goto url for receipt standalone apps

### DIFF
--- a/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
+++ b/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
@@ -86,25 +86,6 @@ export interface DialogActionProps {
   hidden?: boolean;
 }
 
-const addReceiptReturnUrl = (url: string, param = 'returnUrl') => {
-  const receiptURL = new URL(url);
-  const gotoParam = receiptURL.searchParams.get('goto');
-
-  if (!gotoParam) {
-    // more future-safe when redirect with goto no longer is necessary
-    receiptURL.searchParams.set(param, encodeURIComponent(location.href));
-    return receiptURL.toString();
-  }
-
-  const innerUrl = new URL(decodeURIComponent(gotoParam));
-  innerUrl.searchParams.set(param, location.href);
-
-  const encodedInner = encodeURIComponent(innerUrl.toString());
-  receiptURL.search = receiptURL.search.replace(/(goto=)[^&]+/, `$1${encodedInner}`);
-
-  return receiptURL.toString();
-};
-
 const handleDialogActionClick = async (
   props: DialogActionProps,
   dialogToken: string,
@@ -122,7 +103,7 @@ const handleDialogActionClick = async (
 
   if (httpMethod === 'GET') {
     responseFinished();
-    window.location.href = isApp ? createChangeReporteeAndRedirect(currentPartyUuid, addReceiptReturnUrl(url)) : url;
+    window.location.href = isApp ? createChangeReporteeAndRedirect(currentPartyUuid, url) : url;
   } else {
     try {
       const response = await Analytics.trackFetchDependency(


### PR DESCRIPTION
Do not merge before receipt app (by Studio) has been merged to tt02 / prod.

This removes the return url which was needed in order to have correct redirect from the receipt app back to Arbeidsflate.
 

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3436

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
