### PR TITLE
fix(frontend): avoid duplicate page view tracking

### DIFF
--- a/packages/frontend/src/hooks/usePageTracking.ts
+++ b/packages/frontend/src/hooks/usePageTracking.ts
@@ -5,6 +5,7 @@ import { Analytics } from '../analytics';
 export const usePageTracking = () => {
   const location = useLocation();
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Intentionally track only on pathname changes (avoid duplicate page views caused by query/state churn).
   useEffect(() => {
     if (!Analytics.isValidTrackablePage(location.pathname)) {
       console.debug(`Skipping page tracking for route: ${location.pathname}`);
@@ -26,5 +27,5 @@ export const usePageTracking = () => {
     return () => {
       Analytics.stopPageTracking(pageInfo);
     };
-  }, [location]);
+  }, [location.pathname]);
 };


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

Getting instances of "duplicate" page views. When we use location as the dependency for useEffect, it will trigger a re-execution of the useEffect function whenever state, search, hash or pathname is changed. Added pathname as the dependency so it will only execute whenever there is an actual page change. 

What we gain:
- Ensure no duplicate page views in sequence

What we lose:
- Page view changes where the user searches for something etc. Something that changes the state, for example query strings. (but this can be deduced from the API requests as well..)

## Related Issue(s)

- #3568 
