### PR TITLE
fix: remove disabled postgres ha

### DIFF
--- a/.azure/infrastructure/prod.bicepparam
+++ b/.azure/infrastructure/prod.bicepparam
@@ -56,10 +56,6 @@ param postgresConfiguration = {
     autoGrow: 'Enabled'
     type: 'Premium_LRS'
   }
-  highAvailability: {
-    mode: 'ZoneRedundant'
-    standbyAvailabilityZone: '1'
-  }
   backupRetentionDays: 32
   availabilityZone: '2'
   version: '15'

--- a/.azure/infrastructure/staging.bicepparam
+++ b/.azure/infrastructure/staging.bicepparam
@@ -51,9 +51,6 @@ param postgresConfiguration = {
     autoGrow: 'Enabled'
     type: 'Premium_LRS'
   }
-  highAvailability: {
-    mode: 'Disabled'
-  }
   backupRetentionDays: 7
   availabilityZone: '1'
   version: '15'

--- a/.azure/infrastructure/test.bicepparam
+++ b/.azure/infrastructure/test.bicepparam
@@ -50,9 +50,6 @@ param postgresConfiguration = {
     autoGrow: 'Enabled'
     type: 'Premium_LRS'
   }
-  highAvailability: {
-    mode: 'Disabled'
-  }
   backupRetentionDays: 7
   availabilityZone: '3'
   version: '15'

--- a/.azure/infrastructure/yt01.bicepparam
+++ b/.azure/infrastructure/yt01.bicepparam
@@ -50,9 +50,6 @@ param postgresConfiguration = {
     autoGrow: 'Enabled'
     type: 'Premium_LRS'
   }
-  highAvailability: {
-    mode: 'Disabled'
-  }
   backupRetentionDays: 7
   availabilityZone: '1'
   version: '15'

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -46,7 +46,7 @@ param storage StorageConfiguration
 
 @export()
 type HighAvailabilityConfiguration = {
-  mode: 'ZoneRedundant' | 'SameZone' | 'Disabled'
+  mode: 'ZoneRedundant' | 'SameZone'
   standbyAvailabilityZone: string?
 }
 


### PR DESCRIPTION
Summary:
- remove Disabled option from PostgreSQL HA type
- omit HA blocks in env bicepparams to disable HA
- keep direct HA property mapping in postgres module

ref: https://digdir.slack.com/archives/C07A822E9PT/p1770640222200729

Await decision in architecture forum tomorrow. 