### PR TITLE
fix: Scope FCE content cache to dialog view for mainContent and more aggressively for transmission FCE

### DIFF
--- a/packages/frontend/src/auth/url.ts
+++ b/packages/frontend/src/auth/url.ts
@@ -299,3 +299,12 @@ export const getFooterLinks = (currentPartyUuid: string, language?: string) => {
     },
   ];
 };
+
+export const isValidURL = (url: string) => {
+  try {
+    const newUrl = new URL(url);
+    return newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
+  } catch (_) {
+    return false;
+  }
+};

--- a/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
+++ b/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
@@ -202,15 +202,16 @@ export const DialogDetails = ({
     /* Add content reference to each item in the transmission - ensure they are not eagerly loaded, will only render on expand */
     return dialog.transmissions.map((transmission) => ({
       ...transmission,
-      items: transmission.items?.map((item, index) => {
+      items: transmission.items?.map((item) => {
         return {
           ...item,
           children: dialog.contentReferenceForTransmissions[item.id as string]
             ? dialogToken && (
                 <MainContentReference
-                  id={item.id ?? `${transmission.id}-${index}`}
+                  id={item.id}
                   content={dialog.contentReferenceForTransmissions[item.id as string]}
                   dialogToken={dialogToken}
+                  dialogId={dialog?.id ?? ''}
                 />
               )
             : null,
@@ -246,6 +247,7 @@ export const DialogDetails = ({
                         id={item.id}
                         content={dialog.contentReferenceForTransmissions[item.id as string]}
                         dialogToken={dialogToken}
+                        dialogId={dialog?.id}
                       />
                     )
                   : null,
@@ -361,7 +363,12 @@ export const DialogDetails = ({
       >
         <p>{dialog.summary}</p>
         {dialogToken && (
-          <MainContentReference content={dialog.mainContentReference} dialogToken={dialogToken} id={dialog.id} />
+          <MainContentReference
+            content={dialog.mainContentReference}
+            dialogToken={dialogToken}
+            id={dialog.id}
+            dialogId={dialog.id}
+          />
         )}
         {dialog.attachments.length > 0 && (
           <DialogAttachments

--- a/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
+++ b/packages/frontend/src/components/MainContentReference/MainContentReference.tsx
@@ -4,17 +4,20 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Analytics } from '../../analytics.ts';
 import { type DialogByIdDetails, EmbeddableMediaType } from '../../api/hooks/useDialogById.tsx';
+import { isValidURL } from '../../auth';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import styles from './mainContentReference.module.css';
 
-const isValidURL = (url: string) => {
-  try {
-    const newUrl = new URL(url);
-    return newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
-  } catch (_) {
-    return false;
-  }
+interface MainContentReferenceProps {
+  content: DialogByIdDetails['mainContentReference'];
+  dialogToken: string;
+  id: string;
+  dialogId: string;
+}
+
+type MainContentError = Error & {
+  status: number;
 };
 
 const getContent = (mediaType: EmbeddableMediaType, data: string) => {
@@ -56,100 +59,92 @@ const getContent = (mediaType: EmbeddableMediaType, data: string) => {
   }
 };
 
-type MainContentError = Error & {
-  status: number;
-};
+export const MainContentReference = memo(({ content, dialogToken, id, dialogId }: MainContentReferenceProps) => {
+  const { t } = useTranslation();
+  const validURL = content?.url ? isValidURL(content.url) : false;
+  const { data, isSuccess, isError, isLoading, refetch, error } = useAuthenticatedQuery<string, MainContentError>({
+    queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, id, dialogId],
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 10 * 1000 * 60,
+    refetchOnMount: false,
+    queryFn: async () => {
+      const response = await fetch(content!.url, {
+        headers: {
+          'Content-Type': 'text/plain',
+          Authorization: `Bearer ${dialogToken}`,
+        },
+      });
+      if (!response.ok) {
+        const error: MainContentError = Object.assign(
+          new Error(`Failed to fetch content: ${response.status} ${response.statusText}`),
+          { status: response.status },
+        );
 
-export const MainContentReference = memo(
-  ({
-    content,
-    dialogToken,
-    id,
-  }: { content: DialogByIdDetails['mainContentReference']; dialogToken: string; id: string }) => {
-    const { t } = useTranslation();
-
-    const validURL = content?.url ? isValidURL(content.url) : false;
-    const { data, isSuccess, isError, isLoading, refetch, error } = useAuthenticatedQuery<string, MainContentError>({
-      queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, id, dialogToken],
-      staleTime: 0,
-      queryFn: async () => {
-        const response = await fetch(content!.url, {
-          headers: {
-            'Content-Type': 'text/plain',
-            Authorization: `Bearer ${dialogToken}`,
+        Analytics.trackException({
+          exception: error,
+          properties: {
+            url: content!.url,
+            status: response.status,
+            statusText: response.statusText,
+            errorType: 'fetch_error',
           },
         });
-        if (!response.ok) {
-          const error: MainContentError = Object.assign(
-            new Error(`Failed to fetch content: ${response.status} ${response.statusText}`),
-            { status: response.status },
-          );
+        throw error;
+      }
+      return response.text();
+    },
+    enabled: validURL && content?.mediaType && Object.values(EmbeddableMediaType).includes(content.mediaType),
+    retry: (failureCount, error) => {
+      if (error?.status === 403 || error?.status === 404) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+    retryDelay: 1000,
+  });
 
-          Analytics.trackException({
-            exception: error,
-            properties: {
-              url: content!.url,
-              status: response.status,
-              statusText: response.statusText,
-              errorType: 'fetch_error',
-            },
-          });
-          throw error;
-        }
-        return response.text();
-      },
-      enabled: validURL && content?.mediaType && Object.values(EmbeddableMediaType).includes(content.mediaType),
-      retry: (failureCount, error) => {
-        if (error?.status === 403 || error?.status === 404) {
-          return false;
-        }
-        return failureCount < 2;
-      },
-      retryDelay: 1000,
-    });
-    const isForbidden = isError && error?.status === 403;
+  const isForbidden = isError && error?.status === 403;
 
-    if (!content) {
-      return null;
-    }
+  if (!content) {
+    return null;
+  }
 
-    if (isLoading) {
-      return (
-        <Typography loading>
-          Loading data, <br /> Lorem ipsum dolor sit amet <br />
-          consectetur adipiscing elit. Curabitur erat.
-        </Typography>
-      );
-    }
+  if (isLoading) {
+    return (
+      <Typography loading>
+        Loading data, <br /> Lorem ipsum dolor sit amet <br />
+        consectetur adipiscing elit. Curabitur erat.
+      </Typography>
+    );
+  }
 
-    if (isForbidden) {
-      return (
-        <Alert
-          variant="info"
-          heading={t('main_content_reference.unauthorized_heading')}
-          message={t('main_content_reference.unauthorized_message')}
-        />
-      );
-    }
+  if (isForbidden) {
+    return (
+      <Alert
+        variant="info"
+        heading={t('main_content_reference.unauthorized_heading')}
+        message={t('main_content_reference.unauthorized_message')}
+      />
+    );
+  }
 
-    if (isError) {
-      return (
-        <Alert
-          variant="danger"
-          heading={t('main_content_reference.error')}
-          message={t('main_content_reference.error_message')}
-        >
-          <Button color="neutral" variant="outline" onClick={() => refetch()}>
-            {t('main_content_reference.refetch')}
-          </Button>
-        </Alert>
-      );
-    }
+  if (isError) {
+    return (
+      <Alert
+        variant="danger"
+        heading={t('main_content_reference.error')}
+        message={t('main_content_reference.error_message')}
+      >
+        <Button color="neutral" variant="outline" onClick={() => refetch()}>
+          {t('main_content_reference.refetch')}
+        </Button>
+      </Alert>
+    );
+  }
 
-    if (!isSuccess) {
-      return null;
-    }
+  if (!isSuccess) {
+    return null;
+  }
 
-    return <Typography className={styles.mainContentReference}>{getContent(content.mediaType, data)}</Typography>;
-  },
-);
+  return <Typography className={styles.mainContentReference}>{getContent(content.mediaType, data)}</Typography>;
+});

--- a/packages/frontend/src/components/MainContentReference/mainContentReference.spec.tsx
+++ b/packages/frontend/src/components/MainContentReference/mainContentReference.spec.tsx
@@ -32,9 +32,12 @@ describe('MainContentReference Component', () => {
     );
 
     const { asFragment } = await waitFor(() =>
-      customRender(<MainContentReference content={mockContent} dialogToken={mockDialogToken} id="test" />, {
-        wrapper,
-      } as RenderOptions),
+      customRender(
+        <MainContentReference content={mockContent} dialogToken={mockDialogToken} id="test" dialogId="test" />,
+        {
+          wrapper,
+        } as RenderOptions,
+      ),
     );
     expect(asFragment()).toMatchSnapshot();
   });
@@ -52,9 +55,12 @@ describe('MainContentReference Component', () => {
     );
 
     const { asFragment } = await waitFor(() =>
-      customRender(<MainContentReference content={mockContent} dialogToken={mockDialogToken} id="test" />, {
-        wrapper,
-      } as RenderOptions),
+      customRender(
+        <MainContentReference content={mockContent} dialogToken={mockDialogToken} id="test" dialogId="test" />,
+        {
+          wrapper,
+        } as RenderOptions,
+      ),
     );
 
     expect(asFragment()).toMatchSnapshot();

--- a/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
@@ -1,5 +1,6 @@
 import { type Color, type ContextMenuProps, DialogLayout } from '@altinn/altinn-components';
 import { ClockDashedIcon } from '@navikt/aksel-icons';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps, useLocation, useParams } from 'react-router-dom';
@@ -7,6 +8,7 @@ import { useDialogById } from '../../api/hooks/useDialogById.tsx';
 import { useDialogByIdSubscription } from '../../api/hooks/useDialogByIdSubscription.ts';
 import { useParties } from '../../api/hooks/useParties.ts';
 import { DialogDetails } from '../../components';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { usePageTitle } from '../../hooks/usePageTitle.tsx';
 import { useDialogActions } from './useDialogActions.tsx';
 
@@ -16,6 +18,7 @@ export const DialogDetailsPage = () => {
   const { parties } = useParties();
   const { t } = useTranslation();
   const location = useLocation();
+  const qc = useQueryClient();
   const {
     dialog,
     isLoading: isLoadingDialog,
@@ -51,6 +54,20 @@ export const DialogDetailsPage = () => {
   useEffect(() => {
     mountAtRef.current = Date.now();
   }, []);
+
+  // We intentionally clear all cached main content reference queries for this dialog when leaving `/inbox/:dialogId`.
+  // Reason: the expandable content is fetched lazily and keyed by (dialogId, itemId). If we keep it across navigations,
+  // it can survive for `gcTime` and be reused on re-entry. For FCE we want each dialog visit to start clean and refetch
+  // while still avoiding re-fetches during expand/collapse within the same visit for transmissions.
+  useEffect(() => {
+    return () => {
+      if (!dialogId) return;
+      qc.removeQueries({
+        queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, dialogId, dialogId],
+        exact: false,
+      });
+    };
+  }, [qc, dialogId]);
 
   const dialogTokenIsFreshAfterMount = dataUpdatedAt > mountAtRef.current ? dialog?.dialogToken : undefined;
   const { onMessageEvent } = useDialogByIdSubscription(dialog?.id, dialogTokenIsFreshAfterMount);


### PR DESCRIPTION
Make FCE loading scoped to a single dialog view instead of reacting to intermediate dialog updates by removing `dialogToken` as cache key.

Cached FCE for mainContent is cleared when leaving /inbox/:id, ensuring a fresh fetch on re-entry while avoiding duplicate loads, unnecessary traffic, and fetch loops for transmissions FCE.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3599

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
