### PR TITLE
fix: disable fetching a2 messages for SI users since this always will result in 401

### DIFF
--- a/packages/frontend/src/api/hooks/useAltinn2Messages.tsx
+++ b/packages/frontend/src/api/hooks/useAltinn2Messages.tsx
@@ -3,15 +3,13 @@ import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useFeatureFlag } from '../../featureFlags';
 import { fetchAltinn2Messages } from '../queries.ts';
-import { useParties } from './useParties.ts';
 
 export const useAltinn2Messages = (selectedAccountIdentifier?: string) => {
-  const { isSelfIdentifiedUser } = useParties();
-  const enabled =
-    useFeatureFlag<boolean>('inbox.enableAltinn2Messages') && (isSelfIdentifiedUser || !!selectedAccountIdentifier);
+  /* Note: Upstream A2 API does not support self-identified users */
+  const enabled = useFeatureFlag<boolean>('inbox.enableAltinn2Messages') && !!selectedAccountIdentifier;
   const { data, isLoading, isSuccess } = useAuthenticatedQuery<Altinn2messagesQuery>({
     queryKey: [QUERY_KEYS.ALTINN2_MESSAGES, selectedAccountIdentifier],
-    queryFn: () => fetchAltinn2Messages(selectedAccountIdentifier ?? '', isSelfIdentifiedUser),
+    queryFn: () => fetchAltinn2Messages(selectedAccountIdentifier ?? '', false),
     retry: 3,
     staleTime: 1000 * 60 * 10,
     enabled,


### PR DESCRIPTION
Semi-revert https://github.com/Altinn/dialogporten-frontend/issues/3725 because of lack of support upstream 

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
