### PR TITLE
chore(azure): add shared finops tags for resources

### DIFF
--- a/.azure/applications/bff-migration-job/main.bicep
+++ b/.azure/applications/bff-migration-job/main.bicep
@@ -1,4 +1,5 @@
 targetScope = 'resourceGroup'
+import { baseTags } from '../../functions/baseTags.bicep'
 
 @minLength(3)
 param imageTag string
@@ -22,10 +23,7 @@ param workloadProfileName string = 'Consumption'
 var namePrefix = 'dp-fe-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-frontend-'
 var containerAppJobName = '${namePrefix}-bff-migration-job'
-var tags = {
-  Environment: environment
-  Product: 'Arbeidsflate'
-}
+var tags = baseTags({}, environment)
 
 resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
   name: containerAppEnvironmentName

--- a/.azure/applications/bff/main.bicep
+++ b/.azure/applications/bff/main.bicep
@@ -1,4 +1,5 @@
 targetScope = 'resourceGroup'
+import { baseTags } from '../../functions/baseTags.bicep'
 
 @minLength(3)
 param imageTag string
@@ -56,10 +57,7 @@ param workloadProfileName string = 'Consumption'
 var namePrefix = 'dp-fe-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-frontend-'
 var containerAppName = '${namePrefix}-bff'
-var tags = {
-  Environment: environment
-  Product: 'Arbeidsflate'
-}
+var tags = baseTags({}, environment)
 
 resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
   name: containerAppEnvironmentName

--- a/.azure/applications/frontend/main.bicep
+++ b/.azure/applications/frontend/main.bicep
@@ -1,4 +1,5 @@
 targetScope = 'resourceGroup'
+import { baseTags } from '../../functions/baseTags.bicep'
 
 @minLength(3)
 param imageTag string
@@ -30,10 +31,7 @@ var namePrefix = 'dp-fe-${environment}'
 var baseImageUrl = 'ghcr.io/altinn/dialogporten-frontend-'
 var serviceName = 'frontend'
 var containerAppName = '${namePrefix}-${serviceName}'
-var tags = {
-  Environment: environment
-  Product: 'Arbeidsflate'
-}
+var tags = baseTags({}, environment)
 
 resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-03-01' existing = {
   name: containerAppEnvironmentName

--- a/.azure/functions/baseTags.bicep
+++ b/.azure/functions/baseTags.bicep
@@ -1,0 +1,21 @@
+@description('Returns merged FinOps tags for the provided environment')
+@export()
+func baseTags(existingTags object, environment string) object => union(existingTags, {
+  finops_environment: finopsEnvironment(environment)
+  finops_product: 'Arbeidsflate'
+  Environment: environment
+  Product: 'Arbeidsflate'
+  repository: 'https://github.com/Altinn/dialogporten-frontend'
+})
+
+@description('Maps deployment environment to FinOps environment')
+@export()
+func finopsEnvironment(environment string) string => environment == 'test'
+  ? 'dev'
+  : (environment == 'staging'
+    ? 'test'
+    : (environment == 'yt01'
+      ? 'test'
+      : (environment == 'prod'
+        ? 'prod'
+        : environment)))

--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -1,4 +1,5 @@
 targetScope = 'subscription'
+import { baseTags } from '../functions/baseTags.bicep'
 
 param environment string
 param location string
@@ -81,10 +82,7 @@ var srcKeyVault = {
   resourceGroupName: secrets.sourceKeyVaultResourceGroup
 }
 
-var tags = {
-  Environment: environment
-  Product: 'Arbeidsflate'
-}
+var tags = baseTags({}, environment)
 
 var namePrefix = 'dp-fe-${environment}'
 


### PR DESCRIPTION
Extends resource tags with FinOps fields and repository traceability

## What has changed?
- Added a shared `baseTags` function that sets `Environment`, `Product`, `finops_environment`, `finops_product`, and `repository`.
- Infrastructure deployment now uses `baseTags`, so foundational resources receive the same extended tags.
- Application deployments for `bff`, `frontend`, and `bff-migration-job` now use the same tag function.
- The product tag remains `Arbeidsflate` across all updated resources.

## Related Issue(s)

- N/A

### Documentation / test coverage

- [x] Documentation is updated, or not relevant / required.
- [x] New tests were added / existing tests were extended, or tests are not relevant.

### Screenshots or GIFs (optional)

- Not relevant for this change.