### PR TITLE
chore(azure): disable application insights auto-instrumentation in staging/yt01/prod

### DIFF
--- a/.azure/applications/bff/prod.bicepparam
+++ b/.azure/applications/bff/prod.bicepparam
@@ -38,6 +38,10 @@ param additionalEnvironmentVariables = [
     value: 'false'
   }
   {
+    name: 'APPLICATIONINSIGHTS_ENABLED'
+    value: 'false'
+  }
+  {
     name: 'OTEL_TRACES_SAMPLER_ARG'
     value: '0.05'
   }

--- a/.azure/applications/bff/staging.bicepparam
+++ b/.azure/applications/bff/staging.bicepparam
@@ -32,6 +32,10 @@ param additionalEnvironmentVariables = [
     value: 'true'
   }
   {
+    name: 'APPLICATIONINSIGHTS_ENABLED'
+    value: 'false'
+  }
+  {
     name: 'OTEL_TRACES_SAMPLER_ARG'
     value: '0.05'
   }

--- a/.azure/applications/bff/yt01.bicepparam
+++ b/.azure/applications/bff/yt01.bicepparam
@@ -31,6 +31,10 @@ param additionalEnvironmentVariables = [
     value: 'true'
   }
   {
+    name: 'APPLICATIONINSIGHTS_ENABLED'
+    value: 'false'
+  }
+  {
     name: 'OTEL_TRACES_SAMPLER_ARG'
     value: '0.05'
   }


### PR DESCRIPTION
## Hva er endret?

- Disables Azure Container Apps platform-level Application Insights auto-instrumentation in staging, yt01, and prod environments
- Prevents duplicate unfiltered telemetry collection that was bypassing the BFF's AppConfig trace filtering
- All environments now consistently rely on BFF's OTEL SDK with SpanNameFilteringProcessor, which properly filters AppConfiguration API spans

## Related Issue(s)

The issue was that AppConfiguration requests appeared in Application Insights traces in staging/yt01/prod but were properly filtered in test. This was due to two parallel telemetry pipelines:
1. App's OTEL SDK with SpanNameFilteringProcessor (filters AppConfig spans)
2. Azure auto-instrumentation (captured all HTTP traffic unfiltered)

Setting `APPLICATIONINSIGHTS_ENABLED=false` disables the redundant auto-instrumentation pipeline.

### Dokumentasjon / testdekning

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig. (Infrastructure configuration only)
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant. (No test changes needed)