### PR TITLE
test(e2e): fix saved-searches test and disable should enable notifications test

### DIFF
--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   use: {
+    screenshot: 'only-on-failure',
     baseURL: process.env.E2E_BASE_URL || 'https://af.tt02.altinn.no',
     trace: 'on-first-retry',
   },

--- a/packages/e2e/tests/profile-smoke.spec.ts
+++ b/packages/e2e/tests/profile-smoke.spec.ts
@@ -23,7 +23,8 @@ test.describe('Profile smoke tests', () => {
     await expect(page.getByText('Fødselsnr.: 159152')).toBeVisible();
   });
 
-  test('should enable notifications', async ({ page, baseURL }) => {
+  /* TODO: We need to find a better test case */
+  test.skip('should enable notifications', async ({ page, baseURL }) => {
     await page.goto(`${baseURL}/profile`);
     const closeButton = page.getByRole('button', { name: 'Lukk' });
     if (await closeButton.isVisible({ timeout: 2000 }).catch(() => false)) {

--- a/packages/e2e/tests/saved-searches.spec.ts
+++ b/packages/e2e/tests/saved-searches.spec.ts
@@ -12,14 +12,13 @@ test.describe('Saved Searches', () => {
 
   test('should save, edit, and delete a search', async ({ page, baseURL }) => {
     const toolbarArea = page.getByTestId('inbox-toolbar');
-
     // Step 1: Open the add filter dropdown
     const addButton = toolbarArea.getByRole('button', { name: /legg til/i });
     await expect(addButton).toBeVisible();
     await addButton.click();
 
     // Step 2: Select sender filter option
-    const senderOption = toolbarArea.getByRole('menuitem', { name: /velg (tjenesteeier|avsender)/i }).first();
+    const senderOption = toolbarArea.getByRole('menuitem', { name: /(Tjenesteeier|Avsender)/i }).first();
     await expect(senderOption).toBeVisible();
     await senderOption.click();
 
@@ -32,9 +31,9 @@ test.describe('Saved Searches', () => {
     await page.keyboard.press('Escape');
 
     // Wait for save button to appear (indicates filter state has updated)
-    const saveButton = toolbarArea.getByRole('button', { name: 'Lagre søk' });
+    const saveButton = page.getByRole('button', { name: 'Lagre søk' });
     // Wait for save button to appear (indicates filter state has updated)
-    const undoSaveButton = toolbarArea.getByRole('button', { name: 'Lagret søk' });
+    const undoSaveButton = page.getByRole('button', { name: 'Lagret søk' });
 
     // Step 5: Check button state and handle accordingly
     try {


### PR DESCRIPTION
Fixes e2e test for saved searches after the button was moved out of the toolbar.
Should enable notifications, however, has a completely different flow, so we should reconsider what to smoke here.
Maybe test other things instead?


<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
