### PR TITLE
fix(account): cookie from initialization only overrides selected account first

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,24 +13,11 @@ import { RedirectPage } from './pages/RedirectPage/RedirectPage.tsx';
 import { SavedSearchesPage } from './pages/SavedSearches';
 import { PageRoutes } from './pages/routes.ts';
 import './app.css';
-import { useEffect } from 'react';
-import { QUERY_KEYS } from './constants/queryKeys.ts';
-import { getPartyFromCookie } from './cookie.ts';
 import { usePageTracking } from './hooks/usePageTracking.ts';
-import { useGlobalStringState } from './useGlobalState.ts';
 
 function App() {
   // Add page tracking
   usePageTracking();
-  const [_, setCookiePartyUuid] = useGlobalStringState(QUERY_KEYS.ALTINN_COOKIE, '');
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-  useEffect(() => {
-    const partyUuidFromCookie = getPartyFromCookie('AltinnPartyUuid');
-    if (partyUuidFromCookie) {
-      setCookiePartyUuid(partyUuidFromCookie ?? '');
-    }
-  }, []);
 
   return (
     <div className="app">

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -1,5 +1,6 @@
 import type { AttachmentLinkProps, AvatarProps, SeenByLogProps } from '@altinn/altinn-components';
 import { formatDisplayName } from '@altinn/altinn-components';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   type Actor,
   ActorType,
@@ -22,7 +23,6 @@ import type { FormatFunction } from '../../i18n/useDateFnsLocale.tsx';
 import { type Locale, useDateFnsLocale, useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import { getIsUnread } from '../../pages/Inbox/status.ts';
 import { useOrganizations } from '../../pages/Inbox/useOrganizations.ts';
-import { useGlobalState } from '../../useGlobalState.ts';
 import { graphQLSDK } from '../queries.ts';
 import { type ActivityLogEntry, getActivityHistory } from '../utils/activities.tsx';
 import { createExpiryBadge, mediaTypeToExt } from '../utils/attachments.ts';
@@ -330,7 +330,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   const format = useFormat();
   const { locale } = useDateFnsLocale();
   const { organizations, isLoading: isOrganizationsLoading } = useOrganizations();
-  const [_, setCurrentDialogTitle] = useGlobalState(QUERY_KEYS.CURRENT_DIALOG_TITLE, '');
+  const queryClient = useQueryClient();
   const disableFlipNamesPatch = useFeatureFlag<boolean>('dialogporten.disableFlipNamesPatch');
   const { selectedProfile } = useParties();
   const partyURIs = parties.map((party) => party.party);
@@ -351,7 +351,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
       const dialogTitle = getPreferredPropertyByLocale(dialogTitles)?.value;
 
       if (dialogTitle) {
-        setCurrentDialogTitle(dialogTitle);
+        queryClient.setQueryData([QUERY_KEYS.CURRENT_DIALOG_TITLE], dialogTitle);
       }
 
       return response;

--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -1,6 +1,7 @@
+import { useQueryClient } from '@tanstack/react-query';
 import type { PartyFieldsFragment } from 'bff-types-generated';
 import { useEffect, useMemo } from 'react';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { updatePartyCookies } from '../../cookie.ts';
@@ -9,7 +10,7 @@ import {
   getSelectedAllPartiesFromQueryParams,
   getSelectedPartyFromQueryParams,
 } from '../../pages/Inbox/queryParams.ts';
-import { useGlobalState, useGlobalStringState } from '../../useGlobalState.ts';
+import { useGlobalState } from '../../useGlobalState.ts';
 import { graphQLSDK } from '../queries.ts';
 import { normalizeFlattenParties } from '../utils/normalizeFlattenParties.ts';
 
@@ -55,12 +56,9 @@ const createPartyParams = (searchParamString: string, key: string, value: string
 };
 
 export const useParties = (): UsePartiesOutput => {
-  const location = useLocation();
-  const [cookiePartyUuid] = useGlobalStringState(QUERY_KEYS.ALTINN_COOKIE, '');
-  const [hasInitializedFromCookie, setHasInitializedFromCookie] = useGlobalState<boolean>(
-    'hasInitializedFromCookie',
-    false,
-  );
+  const queryClient = useQueryClient();
+  const [cookiePartyUuid] = useGlobalState(QUERY_KEYS.ALTINN_COOKIE, '');
+
   const [searchParams, setSearchParams] = useSearchParams();
   const [allOrganizationsSelected, setAllOrganizationsSelected] = useGlobalState<boolean>(
     QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED,
@@ -73,10 +71,10 @@ export const useParties = (): UsePartiesOutput => {
     false,
   );
 
-  const handleChangSearchParams = (searchParams: URLSearchParams) => {
-    /* Avoid setting search params if they are the same as the current ones */
-    if (searchParams.toString() !== new URLSearchParams(location.search).toString()) {
-      setSearchParams(searchParams, { replace: true });
+  const handleChangSearchParams = (newParams: URLSearchParams) => {
+    /* Compare against actual current URL to avoid redundant updates */
+    if (newParams.toString() !== new URLSearchParams(window.location.search).toString()) {
+      setSearchParams(newParams, { replace: true });
     }
   };
 
@@ -145,49 +143,36 @@ export const useParties = (): UsePartiesOutput => {
     return undefined;
   };
 
-  const getEndUserParty = () => {
-    return data?.find((party) => party.isCurrentEndUser);
-  };
+  const currentEndUser = useMemo(() => data?.find((party) => party.isCurrentEndUser), [data]);
 
   const initializePartySelection = () => {
-    if (getSelectedAllPartiesFromQueryParams(searchParams)) {
-      selectAllOrganizations();
-      setHasInitializedFromCookie(true);
+    // Synchronous guard — prevents multiple hook instances from initializing
+    if (queryClient.getQueryData(['hasInitializedPartySelection'])) {
       return;
     }
+    queryClient.setQueryData(['hasInitializedPartySelection'], true);
 
-    const partyFromCookie = data?.find((party) => party.partyUuid === cookiePartyUuid);
-
-    // Cookie override – applied only once
-    if (!hasInitializedFromCookie && cookiePartyUuid && data?.length) {
-      if (partyFromCookie) {
-        const partyFromQuery = getSelectedPartyFromQueryParams(searchParams);
-        if (!partyFromQuery) {
-          setSelectedPartyIds([partyFromCookie.party], false);
-        }
-      }
-      setHasInitializedFromCookie(true);
-    }
-
-    const orgFromURL = getPartyFromURL();
-    const currentEndUser = getEndUserParty();
-    const selectedPartyIsPerson = selectedParties.some((party) => party.party.includes('person'));
-
-    if (orgFromURL) {
-      setSelectedPartyIds([orgFromURL.party], false);
-    } else if (selectedPartyIsPerson) {
-      setSelectedPartyIds(
-        selectedParties.map((party) => party.party),
-        false,
-      );
-    } else if (currentEndUser) {
-      if (cookiePartyUuid && partyFromCookie?.party && currentEndUser?.partyUuid !== cookiePartyUuid) {
-        setSelectedPartyIds([partyFromCookie.party], false);
-      } else {
-        setSelectedPartyIds([currentEndUser.party], false);
-      }
+    if (getSelectedAllPartiesFromQueryParams(searchParams)) {
+      selectAllOrganizations();
     } else {
-      console.warn('No current end user found, unable to select default parties.');
+      const partyFromQuery = getSelectedPartyFromQueryParams(searchParams);
+      const partyFromCookie = cookiePartyUuid ? data?.find((party) => party.partyUuid === cookiePartyUuid) : undefined;
+
+      if (partyFromQuery) {
+        // URL takes highest precedence
+        const orgFromURL = getPartyFromURL();
+        if (orgFromURL) {
+          setSelectedPartyIds([orgFromURL.party], false);
+        }
+      } else if (partyFromCookie) {
+        // Cookie takes precedence over default
+        setSelectedPartyIds([partyFromCookie.party], false);
+      } else if (currentEndUser) {
+        // Fallback to logged-in user
+        setSelectedPartyIds([currentEndUser.party], false);
+      } else {
+        console.warn('No current end user found, unable to select default parties.');
+      }
     }
   };
 
@@ -210,7 +195,29 @@ export const useParties = (): UsePartiesOutput => {
         setIsSelfIdentifiedUser(true);
       }
     }
-  }, [isSuccess, data, location.search]);
+  }, [isSuccess, data]);
+
+  // Handle URL-driven account switching (after initialization)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only react to searchParams changes
+  useEffect(() => {
+    if (!isSuccess || !data?.length || !queryClient.getQueryData(['hasInitializedPartySelection'])) {
+      return;
+    }
+
+    // Read actual current URL to avoid acting on stale searchParams from closure
+    const currentParams = new URLSearchParams(window.location.search);
+    const allPartiesParam = currentParams.get(FixedGlobalQueryParams.allParties) === 'true';
+    const partyParam = currentParams.get(FixedGlobalQueryParams.party);
+
+    if (allPartiesParam) {
+      selectAllOrganizations();
+    } else if (partyParam) {
+      const party = data?.find((p) => p.party === partyParam);
+      if (party) {
+        setSelectedPartyIds([party.party], false);
+      }
+    }
+  }, [searchParams]);
 
   const isCompanyProfile =
     isCompanyFromParams || allOrganizationsSelected || selectedParties?.[0]?.partyType === 'Organization';
@@ -226,11 +233,6 @@ export const useParties = (): UsePartiesOutput => {
         parentId: party.partyUuid,
       })) ?? []),
     ]) as FlattenedParty[];
-  }, [data]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-  const currentEndUser = useMemo(() => {
-    return getEndUserParty();
   }, [data]);
 
   const currentPartyUuid = useMemo(() => {

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -41,7 +41,7 @@ export const PageLayout: React.FC = () => {
   const [searchParams] = useSearchParams();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const [docTitle, _] = useGlobalState<string>(QUERY_KEYS.CURRENT_DIALOG_TITLE, '');
+  const [docTitle] = useGlobalState<string>(QUERY_KEYS.CURRENT_DIALOG_TITLE, '');
   const { selectedProfile, selectedParties, allOrganizationsSelected, currentEndUser, currentPartyUuid } = useParties();
   const [isErrorState] = useGlobalState<boolean>(QUERY_KEYS.ERROR_STATE, false);
   const { headerProps } = useHeaderConfig();

--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -7,7 +7,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import App from './App.tsx';
 import { AuthProvider } from './components/Login/AuthContext.tsx';
+import { QUERY_KEYS } from './constants/queryKeys.ts';
 import { LoggerContextProvider } from './contexts/LoggerContext.tsx';
+import { getPartyFromCookie } from './cookie.ts';
 import { FeatureFlagProvider, loadFeatureFlags } from './featureFlags';
 import { OnboardingTourProvider } from './onboardingTour';
 
@@ -50,6 +52,8 @@ const RootProvider = ({ children }: { children: React.ReactNode }) => {
 if (element) {
   const root = ReactDOM.createRoot(element);
   const queryClient = new QueryClient();
+  queryClient.setQueryData([QUERY_KEYS.ALTINN_COOKIE], getPartyFromCookie('AltinnPartyUuid') ?? '');
+
   Promise.all([enableMocking(), loadFeatures()]).then(([_, initialFlags]) => {
     root.render(
       <React.StrictMode>

--- a/packages/frontend/src/mocks/handlers.ts
+++ b/packages/frontend/src/mocks/handlers.ts
@@ -347,7 +347,7 @@ const mutateUpdateLanguageMock = graphql.mutation('UpdateLanguage', (req) => {
   });
 });
 
-const mutateUpdateProfileSettingPreferenceMock = graphql.mutation('UpdateProfileSettingPreference', (req) => {
+const mutateUpdateProfileSettingPreferenceMock = graphql.mutation("setShouldShowSubEntities", (req) => {
   const { shouldShowDeletedEntities } = req.variables;
 
   if (inMemoryStore.profile?.user?.profileSettingPreference) {

--- a/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
@@ -87,10 +87,7 @@ export const DialogDetailsPage = () => {
         queryKey: [QUERY_KEYS.MAIN_CONTENT_REFERENCE, dialogId, dialogId],
         exact: false,
       });
-      qc.removeQueries({
-        queryKey: [QUERY_KEYS.CURRENT_DIALOG_TITLE],
-        exact: false,
-      });
+      qc.setQueryData([QUERY_KEYS.CURRENT_DIALOG_TITLE], '');
     };
   }, [qc, dialogId]);
 


### PR DESCRIPTION
This made me aware of more general problem:

When loading the app with no query parameters but a party ID stored in the cookie, the current end user (person) was briefly selected before being switched to the cookie party. This caused a race condition where selectedParties and currentPartyUuid were set to the wrong value before initializePartySelection completed. Additionally, multiple hook instances of useParties could fight over initialization, causing infinite render loops.

Changes
useParties.ts — Refactored party initialization logic:

Synchronous init guard: Replaced the hasInitializedFromCookie global state flag with a queryClient.getQueryData/setQueryData guard (hasInitializedPartySelection). This is synchronous and immediately visible across all hook instances, preventing multiple instances from racing to initialize.

Clear priority chain: Rewrote initializePartySelection with explicit precedence: URL params → cookie → current end user → warn. Only one setSelectedPartyIds call per initialization (no fall-through).

currentEndUser as useMemo: Changed from local useState (only set in the winning hook instance) to a useMemo derived from data, so all hook instances see it.

Separated init from URL-driven switching: Split into two effects — one for initialization ([isSuccess, data]) and one for reacting to account switches via URL changes ([searchParams]).
Stale closure fixes: handleChangSearchParams compares against window.location.search instead of the closure's location.search. The URL-switching effect reads window.location.search directly instead of stale searchParams.
Removed useLocation dependency (was causing the feedback loop via location.search in effect deps).
main.tsx — Cookie read moved earlier:

Cookie value (AltinnPartyUuid) is now read synchronously at app startup and seeded into the query client before any React render, ensuring it's available when initializePartySelection first runs.
App.tsx — Removed async cookie effect:

Removed the useEffect that read the cookie and set it via useGlobalStringState, since this is now handled in main.tsx.
mocks/handlers.ts — Minor fix:

Updated a mock mutation name from UpdateProfileSettingPreference to setShouldShowSubEntities.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3878

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
