### PR TITLE
fix: sendername different than service owner should not be represented with logo 

### DIFF
--- a/packages/docs/docs/notes/Presentational logic/sender-name-and-logo.mdx
+++ b/packages/docs/docs/notes/Presentational logic/sender-name-and-logo.mdx
@@ -1,0 +1,59 @@
+# Sender Name and Service Owner Logo
+
+How Arbeidsflate resolves the display name and logo/avatar for senders across dialog list items, dialog details, transmissions, and activities.
+
+## Dialog level (list and detail views)
+
+| Field | Logic |
+|-------|-------|
+| **Name** | `dialog.content.senderName` → fallback to `serviceOwner.name` from the organization registry (in the user's selected locale) |
+| **Logo** | Shown only if `senderName` is empty OR matches `serviceOwner.name`. Both values are compared using the `nb` locale, trimmed, case-insensitive. When `senderName` differs (i.e. a proxy/custom sender), a first-letter avatar is shown instead. |
+| **Type** | Always `company`. At dialog level there is no `actorType`/`actorId` to determine the sender type, so `company` is a pragmatic default — even though `senderName` may in practice refer to a person (e.g. an employee name on a sick leave notice). |
+
+## Transmission and activity actors (`getActorProps`)
+
+### Actor type resolution
+
+Type is derived from `actorId` URN, not from `actorType` alone:
+
+| `actorId` pattern | Resolved type |
+|---|---|
+| `urn:altinn:systemuser:*` | `system` |
+| `urn:altinn:organization:*` or `actorType = ServiceOwner` | `company` |
+| Everything else | `person` |
+
+### Display name
+
+| Actor type | Name logic |
+|---|---|
+| **ServiceOwner** | `senderName` → fallback `serviceOwner.name`. `actorName`/`actorId` are not permitted when `actorType = ServiceOwner`. |
+| **Other types** | `actorName` (non-localized, e.g. legacy system user or org name that cannot be looked up). Falls back to empty string. |
+
+### Logo
+
+Only shown for `ServiceOwner` actors, using the same gate logic as dialog level:
+
+```
+shouldShowLogo = org.hasLogo && (senderName == null || senderName(nb) == serviceOwner.name(nb))
+```
+
+Background: `senderName` is not associated with a logo, so showing the service owner logo alongside a different sender name would be misleading.
+
+## Other actor types
+
+| Type | Avatar |
+|---|---|
+| Person (party name from registry) | Person icon, no logo |
+| System user | System icon, no logo |
+| Organization without logo in CDN | First-letter avatar, no logo |
+
+## Proxy limitation
+
+`senderName` is set at the dialog level and propagates to all transmissions and activities where `actorType = ServiceOwner`. It is not possible for a service owner (e.g. Skatteetaten) to act as proxy for multiple authorities with different sender names within the same dialog.
+
+## Key source files
+
+- `packages/frontend/src/api/utils/dialog.ts` — `getServiceOwnerLogo`, `mapDialogToToInboxItems`
+- `packages/frontend/src/api/hooks/useDialogById.tsx` — `getActorProps`
+- `packages/frontend/src/api/utils/transmissions.ts` — `createTransmissionItem`
+- `packages/frontend/src/api/utils/activities.tsx` — `createActivityItem`

--- a/packages/frontend/src/api/hooks/useDialogById.spec.ts
+++ b/packages/frontend/src/api/hooks/useDialogById.spec.ts
@@ -1,0 +1,116 @@
+import { ActorType } from 'bff-types-generated';
+import { describe, expect, it } from 'vitest';
+import { getActorProps } from './useDialogById.tsx';
+
+const mkSenderName = (nb: string) => [{ languageCode: 'nb', value: nb }];
+const serviceOwner = { name: 'Skatteetaten', logo: 'https://altinncdn.no/orgs/skd/skd.png' };
+
+describe('getActorProps', () => {
+  describe('ServiceOwner actor', () => {
+    const actor = { actorType: ActorType.ServiceOwner, actorId: null, actorName: null };
+
+    it('uses senderName as display name when provided', () => {
+      const result = getActorProps(actor, false, serviceOwner, mkSenderName('Namsmannen'));
+      expect(result.name).toBe('Namsmannen');
+    });
+
+    it('falls back to serviceOwner.name when senderName is not provided', () => {
+      const result = getActorProps(actor, false, serviceOwner);
+      expect(result.name).toBe('Skatteetaten');
+    });
+
+    it('shows logo when senderName matches serviceOwner name', () => {
+      const result = getActorProps(actor, false, serviceOwner, mkSenderName('Skatteetaten'));
+      expect(result.imageUrl).toBe(serviceOwner.logo);
+    });
+
+    it('hides logo when senderName differs from serviceOwner name (proxy)', () => {
+      const result = getActorProps(actor, false, serviceOwner, mkSenderName('Namsmannen'));
+      expect(result.imageUrl).toBeUndefined();
+    });
+
+    it('returns type company', () => {
+      const result = getActorProps(actor, false, serviceOwner);
+      expect(result.type).toBe('company');
+    });
+
+    it('returns empty name when neither senderName nor serviceOwner is provided', () => {
+      const result = getActorProps(actor, false);
+      expect(result.name).toBe('');
+    });
+  });
+
+  describe('SystemUser actor', () => {
+    const actor = {
+      actorType: ActorType.PartyRepresentative,
+      actorId: 'urn:altinn:systemuser:abc123',
+      actorName: 'Tripletex',
+    };
+
+    it('returns type system', () => {
+      const result = getActorProps(actor, false);
+      expect(result.type).toBe('system');
+    });
+
+    it('uses actorName as display name', () => {
+      const result = getActorProps(actor, false);
+      expect(result.name).toBe('Tripletex');
+    });
+
+    it('never shows logo', () => {
+      const result = getActorProps(actor, false, serviceOwner);
+      expect(result.imageUrl).toBeUndefined();
+    });
+  });
+
+  describe('Organization actor', () => {
+    const actor = {
+      actorType: ActorType.PartyRepresentative,
+      actorId: 'urn:altinn:organization:991825827',
+      actorName: 'Deloitte AS',
+    };
+
+    it('returns type company', () => {
+      const result = getActorProps(actor, false);
+      expect(result.type).toBe('company');
+    });
+
+    it('uses actorName as display name', () => {
+      const result = getActorProps(actor, false);
+      expect(result.name).toBe('Deloitte AS');
+    });
+
+    it('never shows serviceOwner logo', () => {
+      const result = getActorProps(actor, false, serviceOwner);
+      expect(result.imageUrl).toBeUndefined();
+    });
+  });
+
+  describe('Person actor', () => {
+    const actor = {
+      actorType: ActorType.PartyRepresentative,
+      actorId: 'urn:altinn:person:12345678901',
+      actorName: 'Nordmann Ola',
+    };
+
+    it('returns type person', () => {
+      const result = getActorProps(actor, false);
+      expect(result.type).toBe('person');
+    });
+
+    it('reverses name order by default', () => {
+      const result = getActorProps(actor, false);
+      expect(result.name).toBe('Ola Nordmann');
+    });
+
+    it('does not reverse name when stopReversingPersonNameOrder is true', () => {
+      const result = getActorProps(actor, true);
+      expect(result.name).toBe('Nordmann Ola');
+    });
+
+    it('never shows logo', () => {
+      const result = getActorProps(actor, false, serviceOwner);
+      expect(result.imageUrl).toBeUndefined();
+    });
+  });
+});

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -18,7 +18,7 @@ import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import type { DialogActionProps } from '../../components';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useFeatureFlag } from '../../featureFlags';
-import { type ValueType, getPreferredPropertyByLocale } from '../../i18n/property.ts';
+import { type LocalizationObject, type ValueType, getPreferredPropertyByLocale } from '../../i18n/property.ts';
 import type { FormatFunction } from '../../i18n/useDateFnsLocale.tsx';
 import { type Locale, useDateFnsLocale, useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import { getIsUnread } from '../../pages/Inbox/status.ts';
@@ -26,8 +26,8 @@ import { useOrganizations } from '../../pages/Inbox/useOrganizations.ts';
 import { graphQLSDK } from '../queries.ts';
 import { type ActivityLogEntry, getActivityHistory } from '../utils/activities.tsx';
 import { createExpiryBadge, mediaTypeToExt } from '../utils/attachments.ts';
-import { getSeenByLabel } from '../utils/dialog.ts';
-import { type OrganizationOutput, getOrganization } from '../utils/organizations.ts';
+import { getSeenByLabel, getServiceOwnerLogo } from '../utils/dialog.ts';
+import { type OrganizationOutput, getOrganization, getOrganizationByLocale } from '../utils/organizations.ts';
 import { type TimelineSegmentWithTransmissions, getTransmissions } from '../utils/transmissions.ts';
 import { getViewTypes } from '../utils/viewType.ts';
 import type { InboxViewType } from './useDialogs.tsx';
@@ -177,6 +177,8 @@ const getMainContentReference = (
  * @param actor        The actor object describing who performed or sent the action.
  * @param stopReversingPersonNameOrder
  * @param serviceOwner Optional service owner metadata used for name/logo fallback.
+ * @param contentSenderName Overridden sender name. If not supplied, assume service owner as the sender name if actor type is Service owner.
+ * @param serviceOwnerNbName
  * @returns Normalized avatar props (`name`, `type`, `imageUrl`, `imageUrlAlt`).
  */
 
@@ -184,6 +186,8 @@ export const getActorProps = (
   actor: Actor,
   stopReversingPersonNameOrder: boolean,
   serviceOwner?: OrganizationOutput,
+  contentSenderName?: LocalizationObject[] | undefined,
+  serviceOwnerNbName?: string,
 ): AvatarProps => {
   const isServiceOwner = actor.actorType === ActorType.ServiceOwner;
   const isSystemUser = actor?.actorId?.includes('urn:altinn:systemuser:');
@@ -194,15 +198,17 @@ export const getActorProps = (
     type,
     reverseNameOrder: stopReversingPersonNameOrder ? false : !isCompany && !isSystemUser,
   });
-  const senderName = actor.actorName ? actorName : isServiceOwner ? serviceOwner?.name || '' : '';
-  const senderLogo = isServiceOwner ? serviceOwner?.logo : undefined;
-  const senderLogoAlt = senderLogo ? t('dialog.imageAltURL', { companyName: senderName }) : undefined;
+  const preferredSenderName = getPreferredPropertyByLocale(contentSenderName)?.value;
+  const serviceOwnerDisplayName = preferredSenderName || serviceOwner?.name || '';
+  const name = actor.actorName ? actorName : isServiceOwner ? serviceOwnerDisplayName : '';
+  const logo = isServiceOwner ? getServiceOwnerLogo(contentSenderName, serviceOwner, serviceOwnerNbName) : undefined;
+  const logoAlt = logo ? t('dialog.imageAltURL', { companyName: name }) : undefined;
 
   return {
-    name: senderName,
+    name,
     type,
-    imageUrl: senderLogo,
-    imageUrlAlt: senderLogoAlt,
+    imageUrl: logo,
+    imageUrlAlt: logoAlt,
   };
 };
 
@@ -228,6 +234,7 @@ export function mapDialogToToInboxItem(
   const dialogRecipientParty = parties?.find((party) => party.party === item.party);
   const actualRecipientParty = dialogRecipientParty ?? endUserParty;
   const serviceOwner = getOrganization(organizations || [], item.org);
+  const serviceOwnerNbName = getOrganizationByLocale(organizations || [], item.org, 'nb')?.name;
   const senderName = item.content.senderName?.value;
   const extendedStatusObj = item.content.extendedStatus?.value;
   const { seenByLabel } = getSeenByLabel(item.seenSinceLastContentUpdate, t);
@@ -239,6 +246,8 @@ export function mapDialogToToInboxItem(
     serviceOwner,
     selectedProfile,
     locale,
+    senderName,
+    serviceOwnerNbName,
   });
 
   return {
@@ -254,7 +263,7 @@ export function mapDialogToToInboxItem(
     sender: {
       name: getPreferredPropertyByLocale(senderName)?.value || serviceOwner?.name || '',
       type: 'company',
-      imageUrl: serviceOwner?.logo,
+      imageUrl: getServiceOwnerLogo(senderName, serviceOwner, serviceOwnerNbName),
       imageUrlAlt: t('dialog.imageAltURL', { companyName: getPreferredPropertyByLocale(senderName)?.value }),
     },
     receiver: {
@@ -296,7 +305,13 @@ export function mapDialogToToInboxItem(
       title: seenByLabel,
       endUserLabel: t('word.you'),
       items: item.seenSinceLastContentUpdate.map((seen) => {
-        const actorProps = getActorProps(seen.seenBy, stopReversingPersonNameOrder, serviceOwner);
+        const actorProps = getActorProps(
+          seen.seenBy,
+          stopReversingPersonNameOrder,
+          serviceOwner,
+          senderName,
+          serviceOwnerNbName,
+        );
         return {
           name: actorProps.name,
           type: actorProps.type,
@@ -315,6 +330,7 @@ export function mapDialogToToInboxItem(
       serviceOwner,
       selectedProfile,
       locale,
+      serviceOwnerNbName,
     }),
     transmissions,
     createdAt: item.createdAt,
@@ -367,7 +383,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
     isLoading,
     isSuccess,
     dialog: mapDialogToToInboxItem(
-      data?.dialogById.dialog,
+      data?.dialogById?.dialog,
       parties,
       organizations,
       format,

--- a/packages/frontend/src/api/utils/activities.tsx
+++ b/packages/frontend/src/api/utils/activities.tsx
@@ -1,7 +1,7 @@
 import type { ActivityLogItemProps, AvatarProps, TransmissionProps } from '@altinn/altinn-components';
 import { ActivityType, type DialogActivityFragment, type TransmissionFieldsFragment } from 'bff-types-generated';
 import { t } from 'i18next';
-import { getPreferredPropertyByLocale } from '../../i18n/property.ts';
+import { type LocalizationObject, getPreferredPropertyByLocale } from '../../i18n/property.ts';
 import type { FormatFunction, Locale } from '../../i18n/useDateFnsLocale.tsx';
 import { getActorProps } from '../hooks/useDialogById.tsx';
 import type { ProfileType } from '../hooks/useParties.ts';
@@ -70,6 +70,8 @@ export const getDialogHistoryForActivities = (
   transmissions: TransmissionFieldsFragment[],
   stopReversingPersonNameOrder: boolean,
   serviceOwner?: OrganizationOutput,
+  senderName?: LocalizationObject[] | undefined,
+  serviceOwnerNbName?: string,
 ): ActivityLogItemProps[] => {
   return activities.map((activity) => {
     const clockPrefix = t('word.clock_prefix');
@@ -77,7 +79,13 @@ export const getDialogHistoryForActivities = (
     const description = getPreferredPropertyByLocale(activity.description)?.value;
     const relatedTransmission = transmissions.find((transmission) => transmission.id === activity.transmissionId);
     const transmissionTitle = getPreferredPropertyByLocale(relatedTransmission?.content.title.value)?.value;
-    const actorProps: AvatarProps = getActorProps(activity.performedBy, stopReversingPersonNameOrder, serviceOwner);
+    const actorProps: AvatarProps = getActorProps(
+      activity.performedBy,
+      stopReversingPersonNameOrder,
+      serviceOwner,
+      senderName,
+      serviceOwnerNbName,
+    );
     return {
       id: activity.id,
       summary: getActivityText(activity, actorProps, description, transmissionTitle),
@@ -111,6 +119,7 @@ export type ActivityLogEntry =
  * @param serviceOwner - Optional service owner organization details.
  * @param selectedProfile - Optional selected party profile.
  * @param stopReversingPersonNameOrder
+ * @param senderName
  * @param locale
  * @returns An array of activity and transmission log entries, sorted by date (descending).
  */
@@ -121,7 +130,9 @@ export const getActivityHistory = ({
   serviceOwner,
   selectedProfile,
   stopReversingPersonNameOrder,
+  senderName,
   locale,
+  serviceOwnerNbName,
 }: {
   activities: DialogActivityFragment[];
   transmissions: TransmissionFieldsFragment[];
@@ -129,7 +140,9 @@ export const getActivityHistory = ({
   stopReversingPersonNameOrder: boolean;
   serviceOwner?: OrganizationOutput;
   selectedProfile?: ProfileType;
+  senderName?: LocalizationObject[];
   locale: Locale;
+  serviceOwnerNbName?: string;
 }): ActivityLogEntry[] => {
   const dialogHistoryActivities: ActivityLogEntry[] = getDialogHistoryForActivities(
     activities,
@@ -137,6 +150,8 @@ export const getActivityHistory = ({
     transmissions,
     stopReversingPersonNameOrder,
     serviceOwner,
+    senderName,
+    serviceOwnerNbName,
   ).map((activity) => ({
     id: activity.id ?? '',
     type: 'activity',
@@ -152,6 +167,8 @@ export const getActivityHistory = ({
     serviceOwner,
     selectedProfile,
     locale,
+    senderName,
+    serviceOwnerNbName,
   }).map((transmission) => ({
     id: transmission.id ?? '',
     type: 'transmission',

--- a/packages/frontend/src/api/utils/dialog.spec.ts
+++ b/packages/frontend/src/api/utils/dialog.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getServiceOwnerLogo } from './dialog.ts';
+import type { OrganizationOutput } from './organizations.ts';
+
+const mkSenderName = (nb: string, en?: string) => [
+  { languageCode: 'nb', value: nb },
+  ...(en ? [{ languageCode: 'en', value: en }] : []),
+];
+
+const withLogo: OrganizationOutput = { name: 'Skatteetaten', logo: 'https://altinncdn.no/orgs/skd/skd.png' };
+const withoutLogo: OrganizationOutput = { name: 'Skatteetaten', logo: '' };
+
+describe('getServiceOwnerLogo', () => {
+  it('returns logo when senderName is undefined', () => {
+    expect(getServiceOwnerLogo(undefined, withLogo)).toBe(withLogo.logo);
+  });
+
+  it('returns empty string when senderName is undefined and org has no logo', () => {
+    expect(getServiceOwnerLogo(undefined, withoutLogo)).toBe('');
+  });
+
+  it('returns logo when senderName matches serviceOwner name in nb', () => {
+    expect(getServiceOwnerLogo(mkSenderName('Skatteetaten'), withLogo)).toBe(withLogo.logo);
+  });
+
+  it('returns logo when senderName matches with different casing and whitespace', () => {
+    expect(getServiceOwnerLogo(mkSenderName('  skatteetaten  '), withLogo)).toBe(withLogo.logo);
+  });
+
+  it('returns undefined when senderName differs from serviceOwner name (proxy scenario)', () => {
+    expect(getServiceOwnerLogo(mkSenderName('Namsmannen'), withLogo)).toBeUndefined();
+  });
+
+  it('compares against serviceOwnerNbName when provided instead of serviceOwner.name', () => {
+    const ownerInEnglish: OrganizationOutput = {
+      name: 'Tax Administration',
+      logo: 'https://altinncdn.no/orgs/skd/skd.png',
+    };
+    expect(getServiceOwnerLogo(mkSenderName('Skatteetaten'), ownerInEnglish, 'Skatteetaten')).toBe(ownerInEnglish.logo);
+  });
+
+  it('returns undefined when senderName differs from serviceOwnerNbName', () => {
+    const ownerInEnglish: OrganizationOutput = {
+      name: 'Tax Administration',
+      logo: 'https://altinncdn.no/orgs/skd/skd.png',
+    };
+    expect(getServiceOwnerLogo(mkSenderName('Namsmannen'), ownerInEnglish, 'Skatteetaten')).toBeUndefined();
+  });
+
+  it('returns undefined when senderName is empty array', () => {
+    expect(getServiceOwnerLogo([], withLogo)).toBeUndefined();
+  });
+
+  it('returns empty string when both senderName and serviceOwner are undefined', () => {
+    expect(getServiceOwnerLogo(undefined, undefined)).toBe('');
+  });
+});

--- a/packages/frontend/src/api/utils/dialog.ts
+++ b/packages/frontend/src/api/utils/dialog.ts
@@ -7,13 +7,13 @@ import {
   SystemLabel,
 } from 'bff-types-generated';
 import { type TFunction, t } from 'i18next';
-import { getPreferredPropertyByLocale } from '../../i18n/property.ts';
+import { type LocalizationObject, getPreferredPropertyByLocale } from '../../i18n/property.ts';
 import type { FormatFunction } from '../../i18n/useDateFnsLocale.tsx';
 import type { InboxItemInput } from '../../pages/Inbox/InboxItemInput.ts';
 import { getIsUnread } from '../../pages/Inbox/status.ts';
 import { getActorProps } from '../hooks/useDialogById.tsx';
 import type { InboxViewType } from '../hooks/useDialogs.tsx';
-import { getOrganization } from './organizations.ts';
+import { type OrganizationOutput, getOrganization, getOrganizationByLocale } from './organizations.ts';
 import { getViewTypes } from './viewType.ts';
 
 interface SeenByItem {
@@ -77,7 +77,9 @@ export function mapDialogToToInboxItems(
 
     const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
     const serviceOwner = getOrganization(organizations || [], item.org);
+    const serviceOwnerNbName = getOrganizationByLocale(organizations || [], item.org, 'nb')?.name;
     const { isSeenByEndUser, seenByOthersCount, seenByLabel } = getSeenByLabel(item.seenSinceLastContentUpdate, t);
+
     return {
       id: item.id,
       party: item.party,
@@ -87,8 +89,11 @@ export function mapDialogToToInboxItems(
       summary: getPreferredPropertyByLocale(summaryObj)?.value ?? '',
       sender: {
         name: getPreferredPropertyByLocale(senderName)?.value || serviceOwner?.name || '',
+        // At dialog level there is no actorType/actorId to determine the sender type.
+        // senderName can refer to a person (e.g. an employee name on a sick leave notice),
+        // but we default to 'company' as a pragmatic choice since the sender is always an org.
         type: 'company',
-        imageUrl: serviceOwner?.logo,
+        imageUrl: getServiceOwnerLogo(senderName, serviceOwner, serviceOwnerNbName),
         imageUrlAlt: t('dialog.imageAltURL', { companyName: getPreferredPropertyByLocale(senderName)?.value }),
       },
       recipient: {
@@ -116,7 +121,13 @@ export function mapDialogToToInboxItems(
         collapsible: true,
         endUserLabel: t('word.you'),
         items: item.seenSinceLastContentUpdate.map((seenBy) => {
-          const { name, type } = getActorProps(seenBy.seenBy, stopReversingPersonNameOrder, serviceOwner);
+          const { name, type } = getActorProps(
+            seenBy.seenBy,
+            stopReversingPersonNameOrder,
+            serviceOwner,
+            senderName,
+            serviceOwnerNbName,
+          );
           return {
             id: seenBy.id,
             name,
@@ -199,4 +210,18 @@ export const mergeDialogItems = (
   }
 
   return Array.from(byId.values());
+};
+
+export const getServiceOwnerLogo = (
+  senderName: LocalizationObject[] | undefined,
+  serviceOwner: OrganizationOutput | undefined,
+  serviceOwnerNbName?: string,
+): string | undefined => {
+  const actualSender = getPreferredPropertyByLocale(senderName, 'nb')?.value?.trim().toLowerCase();
+  const owner = (serviceOwnerNbName ?? serviceOwner?.name)?.trim().toLowerCase();
+
+  if (senderName && actualSender !== owner) {
+    return undefined;
+  }
+  return serviceOwner?.logo || '';
 };

--- a/packages/frontend/src/api/utils/transmissions.ts
+++ b/packages/frontend/src/api/utils/transmissions.ts
@@ -6,7 +6,7 @@ import {
   TransmissionType,
 } from 'bff-types-generated';
 import { t } from 'i18next';
-import { getPreferredPropertyByLocale } from '../../i18n/property.ts';
+import { type LocalizationObject, getPreferredPropertyByLocale } from '../../i18n/property.ts';
 import type { FormatFunction, Locale } from '../../i18n/useDateFnsLocale.tsx';
 import { getActorProps, getAttachmentLinks } from '../hooks/useDialogById.tsx';
 import type { ProfileType } from '../hooks/useParties.ts';
@@ -105,17 +105,35 @@ const getClockFormatString = () => {
   return `do MMMM yyyy ${clockPrefix ? `'${clockPrefix}' ` : ''}HH.mm`;
 };
 
-const createTransmissionItem = (
-  transmission: TransmissionFieldsFragment,
-  format: FormatFunction,
-  stopReversingPersonNameOrder: boolean,
-  locale: Locale,
-  activities?: DialogActivityFragment[],
-  serviceOwner?: OrganizationOutput,
-  selectedProfile?: ProfileType,
-): TransmissionProps => {
+const createTransmissionItem = ({
+  transmission,
+  format,
+  stopReversingPersonNameOrder,
+  locale,
+  activities,
+  serviceOwner,
+  selectedProfile,
+  senderName,
+  serviceOwnerNbName,
+}: {
+  transmission: TransmissionFieldsFragment;
+  format: FormatFunction;
+  stopReversingPersonNameOrder: boolean;
+  locale: Locale;
+  activities?: DialogActivityFragment[];
+  serviceOwner?: OrganizationOutput;
+  selectedProfile?: ProfileType;
+  senderName?: LocalizationObject[];
+  serviceOwnerNbName?: string;
+}): TransmissionProps => {
   const formatString = getClockFormatString();
-  const sender = getActorProps(transmission.sender, stopReversingPersonNameOrder, serviceOwner);
+  const sender = getActorProps(
+    transmission.sender,
+    stopReversingPersonNameOrder,
+    serviceOwner,
+    senderName,
+    serviceOwnerNbName,
+  );
   const unread = isTransmissionUnread(transmission.id, transmission.type, activities);
 
   return {
@@ -148,6 +166,8 @@ export const getTransmissions = ({
   stopReversingPersonNameOrder,
   selectedProfile,
   locale,
+  senderName,
+  serviceOwnerNbName,
 }: {
   transmissions: TransmissionFieldsFragment[];
   format: FormatFunction;
@@ -156,12 +176,14 @@ export const getTransmissions = ({
   serviceOwner?: OrganizationOutput;
   selectedProfile?: ProfileType;
   locale: Locale;
+  senderName?: LocalizationObject[];
+  serviceOwnerNbName?: string;
 }): TimelineSegmentWithTransmissions[] => {
   return groupTransmissions(transmissions).map((group) => {
     const sortedGroup = [...group].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     const [lastTransmission] = sortedGroup;
     const items: TransmissionProps[] = sortedGroup.map((transmission) =>
-      createTransmissionItem(
+      createTransmissionItem({
         transmission,
         format,
         stopReversingPersonNameOrder,
@@ -169,7 +191,9 @@ export const getTransmissions = ({
         activities,
         serviceOwner,
         selectedProfile,
-      ),
+        senderName,
+        serviceOwnerNbName,
+      }),
     );
 
     return {

--- a/packages/frontend/src/i18n/property.ts
+++ b/packages/frontend/src/i18n/property.ts
@@ -8,17 +8,24 @@ export type LocalizationObject = {
 
 export type ValueType = Array<LocalizationObject> | null | undefined;
 
-/*
- * Returns the preferred property by locale, if it exists.
- * If the preferred locale does not exist, it will return the fallback locale.
- * If the fallback locale does not exist, it will return the first item in the array.
- * If the array is empty, it will return undefined.
+/**
+ * Retrieves a localized object from a list based on the specified or current locale.
+ *
+ * - Returns the object matching the preferred locale if it exists.
+ * - If no match is found, it returns the object matching the fallback locale ('nb').
+ * - If neither is found, it returns the first object in the array.
+ * - If the array is empty, `null`, or `undefined`, it returns `undefined`.
+ *
+ * @param {LocalizationObject[] | null | undefined} value - The array of localized objects to search.
+ * @param {string} [locale] - The preferred locale (e.g., 'en', 'nb'). Defaults to the current `i18n` language if not provided.
+ * @returns {LocalizationObject | undefined} - The matching object, the first object, or `undefined` if none are found.
  */
 export const getPreferredPropertyByLocale = <T extends LocalizationObject>(
   value: Array<T> | null | undefined,
+  locale?: string,
 ): T | undefined => {
   const fallbackLocale = 'nb';
-  const currentLocale = i18n.language;
+  const currentLocale = locale ?? i18n.language;
 
   if (value) {
     return (

--- a/packages/frontend/src/mocks/data/base/dialogs.ts
+++ b/packages/frontend/src/mocks/data/base/dialogs.ts
@@ -459,7 +459,15 @@ export const dialogs: SearchDialogFieldsFragment[] = [
           },
         ],
       },
-      senderName: null,
+      senderName: {
+        "mediaType": "text/plain",
+        "value": [
+          {
+            "value": "Bilgjengen AS",
+            "languageCode": "nb"
+          }
+        ]
+      },
       extendedStatus: null,
     },
   },
@@ -473,7 +481,11 @@ export const dialogs: SearchDialogFieldsFragment[] = [
     party: 'urn:altinn:person:identifier-no:1',
     org: 'svv',
     progress: null,
-    hasUnopenedContent: false, fromServiceOwnerTransmissionsCount: 0, fromPartyTransmissionsCount: 0, contentUpdatedAt: "2001-04-05T22:00:00.000Z", guiAttachmentCount: 0,
+    hasUnopenedContent: false,
+    fromServiceOwnerTransmissionsCount: 0,
+    fromPartyTransmissionsCount: 0,
+    contentUpdatedAt: "2001-04-05T22:00:00.000Z",
+    guiAttachmentCount: 0,
     status: DialogStatus.Draft,
     createdAt: '2001-04-05T22:00:00.000Z',
     seenSinceLastContentUpdate: [],


### PR DESCRIPTION
Logo vises kun dersom senderName er tom eller matcher org-navnet (nb, case-insensitive, trimmet). Ellers vises forbokstav-avatar. Gjelder både dialognivå og transmissions/activities med actorType = ServiceOwner, senderName propageres ned fra dialog.content.

Begrensning: Ikke mulig med ulike avsendernavn per transmisjon for ServiceOwner innenfor samme dialog hvis actorType = SERVICE_OWNER.


## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3757

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
