### PR TITLE
fix: performance parties

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -27,7 +27,7 @@
     "@microsoft/applicationinsights-web": "3.3.9",
     "@navikt/aksel-icons": "^7.37.0",
     "@reactour/tour": "^3.8.0",
-    "@tanstack/react-query": "^5.85.9",
+    "@tanstack/react-query": "5.95.2",
     "@tanstack/react-virtual": "^3.13.22",
     "bff-types-generated": "workspace:*",
     "classnames": "^2.5.1",

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -28,6 +28,7 @@ import { type ActivityLogEntry, getActivityHistory } from '../utils/activities.t
 import { createExpiryBadge, mediaTypeToExt } from '../utils/attachments.ts';
 import { getSeenByLabel, getServiceOwnerLogo } from '../utils/dialog.ts';
 import { type OrganizationOutput, getOrganization, getOrganizationByLocale } from '../utils/organizations.ts';
+import type { PartyGraph } from '../utils/partyGraph.ts';
 import { type TimelineSegmentWithTransmissions, getTransmissions } from '../utils/transmissions.ts';
 import { getViewTypes } from '../utils/viewType.ts';
 import type { InboxViewType } from './useDialogs.tsx';
@@ -220,6 +221,7 @@ export function mapDialogToToInboxItem(
   stopReversingPersonNameOrder: boolean,
   selectedProfile: ProfileType,
   locale: Locale,
+  partyGraph?: PartyGraph,
 ): DialogByIdDetails | undefined {
   if (!item) {
     return undefined;
@@ -230,8 +232,11 @@ export function mapDialogToToInboxItem(
   const additionalInfoObj = item?.content?.additionalInfo?.value;
   const summaryObj = item?.content?.summary?.value;
   const mainContentReference = item?.content?.mainContentReference;
-  const endUserParty = parties?.find((party) => party.isCurrentEndUser);
-  const dialogRecipientParty = parties?.find((party) => party.party === item.party);
+
+  // Resolve receiver party — O(1) with partyGraph, O(n) legacy fallback
+  const endUserParty = partyGraph?.currentEndUser ?? parties?.find((party) => party.isCurrentEndUser);
+  const dialogRecipientParty =
+    partyGraph?.partyByUrn.get(item.party) ?? parties?.find((party) => party.party === item.party);
   const actualRecipientParty = dialogRecipientParty ?? endUserParty;
   const serviceOwner = getOrganization(organizations || [], item.org);
   const serviceOwnerNbName = getOrganizationByLocale(organizations || [], item.org, 'nb')?.name;
@@ -348,7 +353,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   const { organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const queryClient = useQueryClient();
   const disableFlipNamesPatch = useFeatureFlag<boolean>('dialogporten.disableFlipNamesPatch');
-  const { selectedProfile } = useParties();
+  const { selectedProfile, partyGraph } = useParties();
   const partyURIs = parties.map((party) => party.party);
   const { data, isSuccess, isLoading, isError, dataUpdatedAt } = useAuthenticatedQuery<GetDialogByIdQuery>({
     queryKey: [QUERY_KEYS.DIALOG_BY_ID, id],
@@ -390,6 +395,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
       disableFlipNamesPatch,
       selectedProfile,
       locale,
+      partyGraph,
     ),
     dataUpdatedAt,
     isError,

--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -81,7 +81,7 @@ export const useDialogs = ({
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
   const enableSubAccountsMenu = useFeatureFlag<boolean>('filters.enableSubAccountsMenu');
   const { shouldShowDeletedEntities } = useProfile();
-  const { selectedParties, parties: allParties, allOrganizationsSelected } = useParties();
+  const { selectedParties, partyGraph, allOrganizationsSelected } = useParties();
   const format = useFormat();
 
   const shouldExcludeDeleted = isDeletedUnitsFilterEnabled && !shouldShowDeletedEntities;
@@ -195,7 +195,14 @@ export const useDialogs = ({
     hasNextPage: lastPage?.searchDialogs?.hasNextPage === true,
     itemsIsNull: lastPage?.searchDialogs?.items === null,
   });
-  const dialogs = mapDialogToToInboxItems(content, allParties, organizations, format, disableFlipNamesPatch);
+  const dialogs = mapDialogToToInboxItems(
+    content,
+    partyGraph.parties,
+    organizations,
+    format,
+    disableFlipNamesPatch,
+    partyGraph,
+  );
   /*  isFetching && isPlaceholderData is used to determine if we are fetching the initial data for the query key */
   const isActuallyLoading = isLoading || (isFetching && isPlaceholderData);
 

--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -13,12 +13,14 @@ import {
 import { useGlobalState } from '../../useGlobalState.ts';
 import { graphQLSDK } from '../queries.ts';
 import { normalizeFlattenParties } from '../utils/normalizeFlattenParties.ts';
+import { type PartyGraph, buildPartyGraph } from '../utils/partyGraph.ts';
 import { MAX_DIALOG_PARTY_SIZE } from './useDialogs.tsx';
+import { stripQueryParamsForPersonParty } from './usePartiesSelectors.ts';
 
 export type ProfileType = 'company' | 'person' | 'neutral';
 
 interface UsePartiesOutput {
-  parties: PartyFieldsFragment[];
+  partyGraph: PartyGraph;
   isSuccess: boolean;
   isError: boolean;
   isLoading: boolean;
@@ -30,23 +32,10 @@ interface UsePartiesOutput {
   allOrganizationsSelected: boolean;
   selectedProfile: ProfileType;
   partiesEmptyList: boolean;
-  flattenedParties: FlattenedParty[];
   currentPartyUuid: string | undefined;
   isSelfIdentifiedUser: boolean;
   organizationLimitReached: boolean;
 }
-
-const stripQueryParamsForPersonParty = (searchParamString: string) => {
-  const params = new URLSearchParams(searchParamString);
-  params.delete(FixedGlobalQueryParams.party);
-  params.delete(FixedGlobalQueryParams.allParties);
-  params.delete(FixedGlobalQueryParams.subAccounts);
-  return params.toString();
-};
-
-type FlattenedParty = PartyFieldsFragment & {
-  parentId?: string;
-};
 
 const createPartyParams = (searchParamString: string, key: string, value: string): URLSearchParams => {
   const params = new URLSearchParams(searchParamString);
@@ -90,6 +79,11 @@ export const useParties = (): UsePartiesOutput => {
     retry: 2,
     retryDelay: 500,
   });
+
+  const partyGraph = useMemo<PartyGraph>(() => {
+    if (!data) return { parties: [], partyByUrn: new Map(), partyByUuid: new Map(), currentEndUser: undefined };
+    return buildPartyGraph(data);
+  }, [data]);
 
   const handleSetSelectedParties = (parties: PartyFieldsFragment[] | null) => {
     if (parties?.length) {
@@ -225,17 +219,6 @@ export const useParties = (): UsePartiesOutput => {
 
   const selectedProfile: ProfileType = allOrganizationsSelected ? 'neutral' : isCompanyProfile ? 'company' : 'person';
 
-  const flattenedParties = useMemo(() => {
-    if (!data) return [];
-    return data.flatMap((party) => [
-      party,
-      ...(party.subParties?.map((subParty) => ({
-        ...subParty,
-        parentId: party.partyUuid,
-      })) ?? []),
-    ]) as FlattenedParty[];
-  }, [data]);
-
   const currentPartyUuid = useMemo(() => {
     return allOrganizationsSelected ? currentEndUser?.partyUuid : selectedParties[0]?.partyUuid;
   }, [selectedParties, currentEndUser, allOrganizationsSelected]);
@@ -244,12 +227,11 @@ export const useParties = (): UsePartiesOutput => {
     isLoading,
     isSuccess,
     isError,
-    flattenedParties,
     selectedParties,
     selectedPartyIds: selectedParties.map((party) => party.party) ?? [],
     setSelectedParties: handleSetSelectedParties,
     setSelectedPartyIds,
-    parties: data ?? [],
+    partyGraph,
     currentEndUser,
     allOrganizationsSelected,
     selectedProfile,

--- a/packages/frontend/src/api/hooks/usePartiesSelectors.ts
+++ b/packages/frontend/src/api/hooks/usePartiesSelectors.ts
@@ -1,0 +1,227 @@
+/**
+ * Fine-grained hooks that subscribe to only a slice of party state.
+ *
+ * `useParties()` subscribes to 7 separate state sources (5 global states,
+ * 1 query, 1 searchParams).  Every consumer re-renders when *any* of them
+ * changes.  These focused hooks let components subscribe only to what they
+ * need, drastically reducing unnecessary re-renders (especially for the
+ * 8+ components that only need `currentPartyUuid`).
+ */
+
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
+import { updatePartyCookies } from '../../cookie.ts';
+import { FixedGlobalQueryParams } from '../../pages/Inbox/queryParams.ts';
+import { useGlobalState } from '../../useGlobalState.ts';
+import { graphQLSDK } from '../queries.ts';
+import { normalizeFlattenParties } from '../utils/normalizeFlattenParties.ts';
+import { type PartyGraph, buildPartyGraph } from '../utils/partyGraph.ts';
+import type { ProfileType } from './useParties.ts';
+
+const emptyGraph: PartyGraph = {
+  parties: [],
+  partyByUrn: new Map(),
+  partyByUuid: new Map(),
+  currentEndUser: undefined,
+};
+
+const partiesQueryOptions = {
+  queryKey: [QUERY_KEYS.PARTIES],
+  queryFn: async () => {
+    const response = await graphQLSDK.parties();
+    return normalizeFlattenParties(response.parties);
+  },
+  staleTime: Number.POSITIVE_INFINITY,
+  gcTime: Number.POSITIVE_INFINITY,
+  retry: 2,
+  retryDelay: 500,
+};
+
+/**
+ * Returns the precomputed `PartyGraph` with O(1) lookup maps.
+ *
+ * Only re-renders when the underlying parties data changes (effectively
+ * never after initial load because of `staleTime: Infinity`).
+ *
+ * Use this instead of `useParties()` when you only need `partyGraph`.
+ */
+export const usePartyGraph = (): PartyGraph => {
+  const { data } = useAuthenticatedQuery<PartyFieldsFragment[]>(partiesQueryOptions);
+
+  return useMemo<PartyGraph>(() => {
+    if (!data) return emptyGraph;
+    return buildPartyGraph(data);
+  }, [data]);
+};
+
+/**
+ * Returns just the current party UUID string.
+ *
+ * Only re-renders when the selected party or allOrganizationsSelected
+ * changes — NOT when search input, filters, or other unrelated state
+ * changes.
+ *
+ * Use this instead of `useParties()` in components like Footer,
+ * BetaModal, EmptyState, FloatingDropdown, AlertBanner.
+ */
+export const useCurrentPartyUuid = (): string | undefined => {
+  const { data } = useAuthenticatedQuery<PartyFieldsFragment[]>(partiesQueryOptions);
+  const [selectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
+  const [allOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
+
+  return useMemo(() => {
+    const currentEndUser = data?.find((party) => party.isCurrentEndUser);
+    return allOrganizationsSelected ? currentEndUser?.partyUuid : selectedParties[0]?.partyUuid;
+  }, [data, selectedParties, allOrganizationsSelected]);
+};
+
+/**
+ * Returns just the profile type ('company' | 'person' | 'neutral').
+ *
+ * Use this instead of `useParties()` in OnboardingPopover etc.
+ */
+export const useSelectedProfile = (): ProfileType => {
+  const [selectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
+  const [allOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
+  const [searchParams] = useSearchParams();
+
+  return useMemo(() => {
+    const party = searchParams.get('party');
+    const allParties = searchParams.get('allParties');
+    const isCompanyFromParams = Boolean(party || allParties);
+    const isCompanyProfile =
+      isCompanyFromParams || allOrganizationsSelected || selectedParties?.[0]?.partyType === 'Organization';
+    return allOrganizationsSelected ? 'neutral' : isCompanyProfile ? 'company' : 'person';
+  }, [selectedParties, allOrganizationsSelected, searchParams]);
+};
+
+/**
+ * Returns just the selected party ID strings.
+ *
+ * Use this instead of `useParties()` in SaveSearchButton etc.
+ */
+export const useSelectedPartyIds = (): string[] => {
+  const [selectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
+
+  return useMemo(() => selectedParties.map((party) => party.party) ?? [], [selectedParties]);
+};
+
+/**
+ * Returns just the allOrganizationsSelected boolean.
+ *
+ * Use this instead of `useParties()` in useGroupedDialogs etc.
+ */
+export const useAllOrganizationsSelected = (): boolean => {
+  const [allOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
+  return allOrganizationsSelected;
+};
+
+/**
+ * Returns just the current end-user party.
+ *
+ * Only re-renders when the underlying parties data changes (effectively
+ * never after initial load because of `staleTime: Infinity`).
+ *
+ * Use this instead of `useParties()` in useGlobalMenu etc.
+ */
+export const useCurrentEndUser = (): PartyFieldsFragment | undefined => {
+  const { data } = useAuthenticatedQuery<PartyFieldsFragment[]>(partiesQueryOptions);
+  return useMemo(() => data?.find((party) => party.isCurrentEndUser), [data]);
+};
+
+/**
+ * Returns the full selected parties array.
+ *
+ * Only re-renders when the selected parties change — NOT when search
+ * input, filters, or other unrelated state changes.
+ */
+export const useSelectedParties = (): PartyFieldsFragment[] => {
+  const [selectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
+  return selectedParties;
+};
+
+/**
+ * Returns just the loading state of the parties query.
+ *
+ * Only re-renders when the loading state changes (once, on initial load).
+ */
+export const usePartiesLoading = (): boolean => {
+  const { isLoading } = useAuthenticatedQuery<PartyFieldsFragment[]>(partiesQueryOptions);
+  return isLoading;
+};
+
+export const stripQueryParamsForPersonParty = (searchParamString: string) => {
+  const params = new URLSearchParams(searchParamString);
+  params.delete(FixedGlobalQueryParams.party);
+  params.delete(FixedGlobalQueryParams.allParties);
+  params.delete(FixedGlobalQueryParams.subAccounts);
+  return params.toString();
+};
+
+const createPartyParams = (searchParamString: string, key: string, value: string): URLSearchParams => {
+  const params = new URLSearchParams(searchParamString);
+  params.delete(FixedGlobalQueryParams.allParties);
+  params.delete(FixedGlobalQueryParams.party);
+  params.set(key, value);
+  return params;
+};
+
+/**
+ * Returns just the `setSelectedPartyIds` setter function.
+ *
+ * Subscribes to: parties query, searchParams, SELECTED_PARTIES,
+ * ALL_ORGANIZATIONS_SELECTED, IS_SELF_IDENTIFIED_USER.
+ *
+ * Does NOT subscribe to: ALTINN_COOKIE, PARTIES_EMPTY_LIST — the two
+ * "noisy" state sources that caused unnecessary re-renders in the full
+ * `useParties()` hook.
+ */
+export const useSetSelectedPartyIds = (): ((partyIds: string[], allOrgSelected: boolean) => void) => {
+  const { data } = useAuthenticatedQuery<PartyFieldsFragment[]>(partiesQueryOptions);
+  const [, setSearchParams] = useSearchParams();
+  const [, setSelectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
+  const [, setAllOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
+  const [isSelfIdentifiedUser] = useGlobalState<boolean>(QUERY_KEYS.IS_SELF_IDENTIFIED_USER, false);
+
+  return useCallback(
+    (partyIds: string[], allOrgSelected: boolean) => {
+      setAllOrganizationsSelected(allOrgSelected);
+      const partyIsPerson = partyIds.some((partyId) => partyId.includes('person')) || isSelfIdentifiedUser;
+      const searchParamsString = new URLSearchParams(window.location.search).toString();
+
+      const handleChangeSearchParams = (newParams: URLSearchParams) => {
+        if (newParams.toString() !== new URLSearchParams(window.location.search).toString()) {
+          setSearchParams(newParams, { replace: true });
+        }
+      };
+
+      if (allOrgSelected) {
+        const allPartiesParams = createPartyParams(searchParamsString, FixedGlobalQueryParams.allParties, 'true');
+        handleChangeSearchParams(allPartiesParams);
+      } else if (partyIsPerson) {
+        const personParams = new URLSearchParams(stripQueryParamsForPersonParty(searchParamsString));
+        handleChangeSearchParams(personParams);
+      } else {
+        const params = createPartyParams(searchParamsString, FixedGlobalQueryParams.party, partyIds[0]);
+        handleChangeSearchParams(params);
+      }
+
+      const matchedParties = data?.filter((party) => partyIds.includes(party.party)) ?? [];
+      if (matchedParties.length) {
+        setSelectedParties(matchedParties);
+      }
+
+      const selectedParty = matchedParties[0];
+      if (selectedParty?.partyUuid) {
+        updatePartyCookies({
+          partyUuid: selectedParty.partyUuid,
+          partyId: selectedParty.partyId,
+        });
+      }
+    },
+    [data, setSearchParams, setSelectedParties, setAllOrganizationsSelected, isSelfIdentifiedUser],
+  );
+};

--- a/packages/frontend/src/api/utils/dialog.ts
+++ b/packages/frontend/src/api/utils/dialog.ts
@@ -14,6 +14,7 @@ import { getIsUnread } from '../../pages/Inbox/status.ts';
 import { getActorProps } from '../hooks/useDialogById.tsx';
 import type { InboxViewType } from '../hooks/useDialogs.tsx';
 import { type OrganizationOutput, getOrganization, getOrganizationByLocale } from './organizations.ts';
+import type { PartyGraph } from './partyGraph.ts';
 import { getViewTypes } from './viewType.ts';
 
 interface SeenByItem {
@@ -56,27 +57,106 @@ export const getSeenByLabel = (
   return { isSeenByEndUser, seenByOthersCount, seenByLabel };
 };
 
+/** Minimal party shape shared by PartyFieldsFragment, SubPartyFieldsFragment, and Party. */
+interface ResolvedParty {
+  party: string;
+  partyType: string;
+  name: string;
+  subParties?: unknown;
+  parentParty?: unknown;
+}
+
+/**
+ * Resolves the receiver party for a dialog item.
+ *
+ * When a PartyGraph is provided, all lookups are O(1) map gets.
+ * Falls back to linear scans over the PartyFieldsFragment[] array when no graph is available.
+ */
+function resolveReceiverParty(
+  dialogPartyUrn: string,
+  parties: PartyFieldsFragment[],
+  partyGraph?: PartyGraph,
+): {
+  endUserParty: ResolvedParty | undefined;
+  dialogReceiverParty: ResolvedParty | undefined;
+  dialogReceiverSubParty: ResolvedParty | undefined;
+  actualReceiverParty: ResolvedParty | undefined;
+} {
+  if (partyGraph) {
+    const endUserParty = partyGraph.currentEndUser;
+    const resolved = partyGraph.partyByUrn.get(dialogPartyUrn);
+    // A "dialogReceiverParty" is a top-level match; a "dialogReceiverSubParty" is one with a parent.
+    const dialogReceiverParty = resolved && !resolved.parentParty ? resolved : undefined;
+    const dialogReceiverSubParty = resolved?.parentParty ? resolved : undefined;
+    const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
+    return { endUserParty, dialogReceiverParty, dialogReceiverSubParty, actualReceiverParty };
+  }
+
+  // Legacy path — linear scans
+  const endUserParty = parties?.find((party) => party.isCurrentEndUser);
+  const dialogReceiverParty = parties?.find((party) => party.party === dialogPartyUrn);
+  const dialogReceiverSubParty = parties
+    ?.flatMap((party) => party.subParties ?? [])
+    .find((subParty) => subParty.party === dialogPartyUrn);
+  const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
+  return { endUserParty, dialogReceiverParty, dialogReceiverSubParty, actualReceiverParty };
+}
+
+/**
+ * Returns true if the receiver should use the "outline" avatar variant.
+ * This happens when the dialog's party is a sub-party (child org), not a parent org.
+ *
+ * Works with both the old PartyFieldsFragment and the new Party type.
+ *
+ * Legacy path: `dialogReceiverParty` is the top-level match; if it exists but has
+ * no `subParties` field, it's a promoted sub-party → outline.
+ *
+ * PartyGraph path: `dialogReceiverSubParty` is set when the resolved party has a parent → outline.
+ */
+function shouldUseOutlineVariant(
+  dialogReceiverParty: ResolvedParty | undefined,
+  dialogReceiverSubParty: ResolvedParty | undefined,
+  actualReceiverParty: ResolvedParty | undefined,
+): boolean {
+  if (actualReceiverParty?.partyType !== 'Organization') return false;
+
+  // PartyGraph path: if the match was classified as a sub-party, use outline
+  if (dialogReceiverSubParty && !dialogReceiverParty) return true;
+
+  // Legacy path: top-level match without subParties field → promoted sub-party
+  if (dialogReceiverParty && !dialogReceiverParty.subParties) return true;
+
+  return false;
+}
+
 export function mapDialogToToInboxItems(
   input: SearchDialogFieldsFragment[],
   parties: PartyFieldsFragment[],
   organizations: OrganizationFieldsFragment[],
   format: FormatFunction,
   stopReversingPersonNameOrder: boolean,
+  partyGraph?: PartyGraph,
 ): InboxItemInput[] {
+  // Pre-index organizations by id for O(1) lookup per dialog item
+  const orgById = new Map<string, OrganizationFieldsFragment>();
+  for (const o of organizations ?? []) {
+    if (o.id) orgById.set(o.id, o);
+  }
+  const getOrgCached = (org: string) => getOrganization(orgById, org);
+
   return input.map((item) => {
     const titleObj = item.content.title.value;
     const summaryObj = item.content.summary?.value;
-    const endUserParty = parties?.find((party) => party.isCurrentEndUser);
     const senderName = item.content.senderName?.value;
     const extendedStatusObj = item.content.extendedStatus?.value;
 
-    const dialogReceiverParty = parties?.find((party) => party.party === item.party);
-    const dialogReceiverSubParty = parties
-      ?.flatMap((party) => party.subParties ?? [])
-      .find((subParty) => subParty.party === item.party);
+    const { dialogReceiverParty, dialogReceiverSubParty, actualReceiverParty } = resolveReceiverParty(
+      item.party,
+      parties,
+      partyGraph,
+    );
 
-    const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
-    const serviceOwner = getOrganization(organizations || [], item.org);
+    const serviceOwner = getOrgCached(item.org);
     const serviceOwnerNbName = getOrganizationByLocale(organizations || [], item.org, 'nb')?.name;
     const { isSeenByEndUser, seenByOthersCount, seenByLabel } = getSeenByLabel(item.seenSinceLastContentUpdate, t);
 
@@ -99,10 +179,9 @@ export function mapDialogToToInboxItems(
       recipient: {
         name: actualReceiverParty?.name ?? dialogReceiverSubParty?.name ?? '',
         type: actualReceiverParty?.partyType === 'Organization' ? 'company' : 'person',
-        variant:
-          dialogReceiverParty && !dialogReceiverParty.subParties && actualReceiverParty?.partyType === 'Organization'
-            ? 'outline'
-            : 'solid',
+        variant: shouldUseOutlineVariant(dialogReceiverParty, dialogReceiverSubParty, actualReceiverParty)
+          ? 'outline'
+          : 'solid',
       },
       serviceResourceType: item.serviceResourceType,
       color: actualReceiverParty?.partyType === 'Organization' ? 'company' : 'person',

--- a/packages/frontend/src/api/utils/mapDialogToInboxItems.spec.ts
+++ b/packages/frontend/src/api/utils/mapDialogToInboxItems.spec.ts
@@ -1,0 +1,410 @@
+import {
+  DialogStatus,
+  type PartyFieldsFragment,
+  type SearchDialogFieldsFragment,
+  SystemLabel,
+} from 'bff-types-generated';
+import { describe, expect, it, vi } from 'vitest';
+import type { FormatFunction } from '../../i18n/useDateFnsLocale.tsx';
+import { getPartyIds, mapDialogToToInboxItems } from './dialog.ts';
+
+vi.mock('../../i18n/config.ts', () => ({
+  i18n: { language: 'nb' },
+}));
+
+const format: FormatFunction = (date: Date | string, _formatStr: string) => String(date);
+
+// ----- Test parties -----
+const endUser: PartyFieldsFragment = {
+  party: 'urn:altinn:person:identifier-no:12345678901',
+  partyType: 'Person',
+  name: 'Ola Nordmann',
+  isCurrentEndUser: true,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-person-1',
+  partyId: 1,
+  subParties: [],
+};
+
+const parentOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000001',
+  partyType: 'Organization',
+  name: 'Stor Bedrift AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-org-parent',
+  partyId: 2,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:910000002',
+      partyType: 'Organization',
+      name: 'Stor Bedrift Avd Oslo',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-org-sub',
+      partyId: 3,
+    },
+  ],
+};
+
+const standaloneOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000099',
+  partyType: 'Organization',
+  name: 'Frittstående AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-org-standalone',
+  partyId: 4,
+  subParties: [],
+};
+
+const parties: PartyFieldsFragment[] = [endUser, parentOrg, standaloneOrg];
+
+// ----- Helper to build a minimal SearchDialogFieldsFragment -----
+function makeDialog(overrides: Partial<SearchDialogFieldsFragment> & { party: string }): SearchDialogFieldsFragment {
+  return {
+    id: overrides.id ?? 'dialog-1',
+    party: overrides.party,
+    org: overrides.org ?? 'skd',
+    status: overrides.status ?? DialogStatus.InProgress,
+    createdAt: overrides.createdAt ?? '2025-01-01T00:00:00Z',
+    contentUpdatedAt: overrides.contentUpdatedAt ?? '2025-01-01T00:00:00Z',
+    hasUnopenedContent: overrides.hasUnopenedContent ?? false,
+    serviceResourceType: overrides.serviceResourceType ?? 'GenericAccessResource',
+    serviceResource: overrides.serviceResource ?? 'urn:altinn:resource:test',
+    fromServiceOwnerTransmissionsCount: overrides.fromServiceOwnerTransmissionsCount ?? 0,
+    fromPartyTransmissionsCount: overrides.fromPartyTransmissionsCount ?? 0,
+    guiAttachmentCount: overrides.guiAttachmentCount ?? 0,
+    dueAt: overrides.dueAt ?? undefined,
+    progress: overrides.progress ?? null,
+    seenSinceLastContentUpdate: overrides.seenSinceLastContentUpdate ?? [],
+    endUserContext: overrides.endUserContext ?? { systemLabels: [SystemLabel.Default] },
+    content: overrides.content ?? {
+      title: { mediaType: 'text/plain', value: [{ languageCode: 'nb', value: 'Test tittel' }] },
+      summary: { mediaType: 'text/plain', value: [{ languageCode: 'nb', value: 'Test sammendrag' }] },
+      senderName: null,
+      extendedStatus: null,
+    },
+  } as SearchDialogFieldsFragment;
+}
+
+// ----- Tests -----
+describe('mapDialogToToInboxItems — recipient resolution', () => {
+  it('resolves recipient when dialog party matches a top-level party', () => {
+    const dialog = makeDialog({ party: standaloneOrg.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.recipient.name).toBe('Frittstående AS');
+    expect(result.recipient.type).toBe('company');
+  });
+
+  it('resolves recipient when dialog party matches the end user (person)', () => {
+    const dialog = makeDialog({ party: endUser.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.recipient.name).toBe('Ola Nordmann');
+    expect(result.recipient.type).toBe('person');
+  });
+
+  it('resolves recipient when dialog party matches a subParty (not a top-level entry)', () => {
+    const subPartyUrn = 'urn:altinn:organization:identifier-no:910000002';
+    const dialog = makeDialog({ party: subPartyUrn });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.recipient.name).toBe('Stor Bedrift Avd Oslo');
+    expect(result.recipient.type).toBe('company');
+  });
+
+  it('falls back to endUserParty when dialog party matches no party or subParty', () => {
+    const dialog = makeDialog({ party: 'urn:altinn:organization:identifier-no:999999999' });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.recipient.name).toBe('Ola Nordmann');
+    expect(result.recipient.type).toBe('person');
+  });
+
+  it('returns empty name when dialog party matches nothing and there is no end user', () => {
+    const partiesWithoutEndUser = parties.map((p) => ({ ...p, isCurrentEndUser: false }));
+    const dialog = makeDialog({ party: 'urn:altinn:organization:identifier-no:999999999' });
+    const [result] = mapDialogToToInboxItems([dialog], partiesWithoutEndUser, [], format, false);
+
+    expect(result.recipient.name).toBe('');
+  });
+});
+
+describe('mapDialogToToInboxItems — recipient variant (solid vs outline)', () => {
+  it('returns "solid" for a parent org (has subParties array)', () => {
+    const dialog = makeDialog({ party: parentOrg.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.recipient.variant).toBe('solid');
+  });
+
+  it('returns "solid" for a person recipient', () => {
+    const dialog = makeDialog({ party: endUser.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.recipient.variant).toBe('solid');
+  });
+
+  it('returns "outline" for an org that is a promoted subParty in the flat list (no own subParties)', () => {
+    // Simulate the flat list that normalizeFlattenParties produces:
+    // The promoted subParty appears as a top-level entry without subParties.
+    const promotedSubParty: PartyFieldsFragment = {
+      party: 'urn:altinn:organization:identifier-no:910000002',
+      partyType: 'Organization',
+      name: 'Stor Bedrift Avd Oslo',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      hasOnlyAccessToSubParties: false,
+      partyUuid: 'uuid-org-sub',
+      partyId: 3,
+      // No subParties — this is how promoted subParties look in the flat list
+    };
+
+    const flatParties: PartyFieldsFragment[] = [endUser, parentOrg, promotedSubParty, standaloneOrg];
+    const dialog = makeDialog({ party: promotedSubParty.party });
+    const [result] = mapDialogToToInboxItems([dialog], flatParties, [], format, false);
+
+    // Matches as dialogReceiverParty (top-level find), has no subParties, is Organization → outline
+    expect(result.recipient.variant).toBe('outline');
+  });
+
+  it('returns "solid" for a standalone org (no subParties, but also not a child)', () => {
+    const dialog = makeDialog({ party: standaloneOrg.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    // standaloneOrg has subParties: [] (truthy array), so !dialogReceiverParty.subParties is false → solid
+    expect(result.recipient.variant).toBe('solid');
+  });
+});
+
+describe('mapDialogToToInboxItems — basic field mapping', () => {
+  it('maps id, party, status, and dates from the dialog', () => {
+    const dialog = makeDialog({
+      id: 'abc-123',
+      party: endUser.party,
+      status: DialogStatus.Completed,
+      createdAt: '2025-06-01T12:00:00Z',
+      contentUpdatedAt: '2025-06-02T12:00:00Z',
+    });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.id).toBe('abc-123');
+    expect(result.party).toBe(endUser.party);
+    expect(result.status).toBe(DialogStatus.Completed);
+    expect(result.createdAt).toBe('2025-06-01T12:00:00Z');
+    expect(result.contentUpdatedAt).toBe('2025-06-02T12:00:00Z');
+  });
+
+  it('maps title and summary from localized content', () => {
+    const dialog = makeDialog({
+      party: endUser.party,
+      content: {
+        title: { mediaType: 'text/plain', value: [{ languageCode: 'nb', value: 'Min tittel' }] },
+        summary: { mediaType: 'text/plain', value: [{ languageCode: 'nb', value: 'Min oppsummering' }] },
+        senderName: null,
+        extendedStatus: null,
+      },
+    } as Partial<SearchDialogFieldsFragment> & { party: string });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false);
+
+    expect(result.title).toBe('Min tittel');
+    expect(result.summary).toBe('Min oppsummering');
+  });
+
+  it('handles multiple dialogs and resolves each independently', () => {
+    const dialogs = [
+      makeDialog({ id: 'd1', party: endUser.party }),
+      makeDialog({ id: 'd2', party: standaloneOrg.party }),
+      makeDialog({ id: 'd3', party: 'urn:altinn:organization:identifier-no:910000002' }),
+    ];
+    const results = mapDialogToToInboxItems(dialogs, parties, [], format, false);
+
+    expect(results).toHaveLength(3);
+    expect(results[0].recipient.name).toBe('Ola Nordmann');
+    expect(results[1].recipient.name).toBe('Frittstående AS');
+    expect(results[2].recipient.name).toBe('Stor Bedrift Avd Oslo');
+  });
+});
+
+// ----- getPartyIds tests -----
+
+describe('getPartyIds', () => {
+  it('returns top-level party URIs', () => {
+    const result = getPartyIds([endUser, standaloneOrg]);
+
+    expect(result).toContain(endUser.party);
+    expect(result).toContain(standaloneOrg.party);
+  });
+
+  it('includes subParty URIs alongside parent URIs', () => {
+    const result = getPartyIds([parentOrg]);
+
+    expect(result).toContain(parentOrg.party);
+    expect(result).toContain('urn:altinn:organization:identifier-no:910000002');
+  });
+
+  it('excludes top-level party when hasOnlyAccessToSubParties is true', () => {
+    const disabledParent: PartyFieldsFragment = {
+      ...parentOrg,
+      hasOnlyAccessToSubParties: true,
+    };
+    const result = getPartyIds([disabledParent]);
+
+    expect(result).not.toContain(disabledParent.party);
+    // subParties should still be included
+    expect(result).toContain('urn:altinn:organization:identifier-no:910000002');
+  });
+
+  it('deduplicates URIs when a subParty also appears as a top-level party', () => {
+    // Simulates the flattened list where a promoted subParty also exists at top level
+    const promotedSub: PartyFieldsFragment = {
+      party: 'urn:altinn:organization:identifier-no:910000002',
+      partyType: 'Organization',
+      name: 'Stor Bedrift Avd Oslo',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      hasOnlyAccessToSubParties: false,
+      partyUuid: 'uuid-org-sub',
+      partyId: 3,
+      subParties: [],
+    };
+    const result = getPartyIds([parentOrg, promotedSub]);
+
+    const subPartyOccurrences = result.filter((uri) => uri === 'urn:altinn:organization:identifier-no:910000002');
+    expect(subPartyOccurrences).toHaveLength(1);
+  });
+
+  it('with includeOnlySubPartiesWithSameName, only includes subParties whose name matches parent', () => {
+    const orgWithMixedSubs: PartyFieldsFragment = {
+      party: 'urn:altinn:organization:identifier-no:800000001',
+      partyType: 'Organization',
+      name: 'Same Name Corp',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      hasOnlyAccessToSubParties: false,
+      partyUuid: 'uuid-mixed',
+      partyId: 50,
+      subParties: [
+        {
+          party: 'urn:altinn:organization:identifier-no:800000010',
+          partyType: 'Organization',
+          name: 'Same Name Corp',
+          isCurrentEndUser: false,
+          isDeleted: false,
+          partyUuid: 'uuid-same-name-sub',
+          partyId: 51,
+        },
+        {
+          party: 'urn:altinn:organization:identifier-no:800000011',
+          partyType: 'Organization',
+          name: 'Different Avd',
+          isCurrentEndUser: false,
+          isDeleted: false,
+          partyUuid: 'uuid-diff-name-sub',
+          partyId: 52,
+        },
+      ],
+    };
+    const result = getPartyIds([orgWithMixedSubs], true);
+
+    expect(result).toContain('urn:altinn:organization:identifier-no:800000010');
+    expect(result).not.toContain('urn:altinn:organization:identifier-no:800000011');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(getPartyIds([])).toEqual([]);
+  });
+
+  it('handles parties with no subParties (undefined)', () => {
+    const noSubs: PartyFieldsFragment = {
+      party: 'urn:altinn:person:identifier-no:99999999999',
+      partyType: 'Person',
+      name: 'No Subs',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      hasOnlyAccessToSubParties: false,
+      partyUuid: 'uuid-nosubs',
+      partyId: 99,
+      // subParties intentionally omitted (undefined)
+    };
+    const result = getPartyIds([noSubs]);
+
+    expect(result).toEqual([noSubs.party]);
+  });
+});
+
+// ----- PartyGraph path tests -----
+// Verify that passing a PartyGraph produces identical results to the legacy path.
+
+import { buildPartyGraph } from './partyGraph.ts';
+
+const partyGraph = buildPartyGraph(parties);
+
+describe('mapDialogToToInboxItems with PartyGraph — recipient resolution', () => {
+  it('resolves recipient when dialog party matches a top-level party', () => {
+    const dialog = makeDialog({ party: standaloneOrg.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false, partyGraph);
+
+    expect(result.recipient.name).toBe('Frittstående AS');
+    expect(result.recipient.type).toBe('company');
+  });
+
+  it('resolves recipient when dialog party matches the end user (person)', () => {
+    const dialog = makeDialog({ party: endUser.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false, partyGraph);
+
+    expect(result.recipient.name).toBe('Ola Nordmann');
+    expect(result.recipient.type).toBe('person');
+  });
+
+  it('resolves recipient when dialog party matches a subParty', () => {
+    const subPartyUrn = 'urn:altinn:organization:identifier-no:910000002';
+    const dialog = makeDialog({ party: subPartyUrn });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false, partyGraph);
+
+    expect(result.recipient.name).toBe('Stor Bedrift Avd Oslo');
+    expect(result.recipient.type).toBe('company');
+  });
+
+  it('falls back to endUserParty when dialog party matches nothing', () => {
+    const dialog = makeDialog({ party: 'urn:altinn:organization:identifier-no:999999999' });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false, partyGraph);
+
+    expect(result.recipient.name).toBe('Ola Nordmann');
+    expect(result.recipient.type).toBe('person');
+  });
+
+  it('subParty recipient gets outline variant', () => {
+    const subPartyUrn = 'urn:altinn:organization:identifier-no:910000002';
+    const dialog = makeDialog({ party: subPartyUrn });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false, partyGraph);
+
+    expect(result.recipient.variant).toBe('outline');
+  });
+
+  it('parent org recipient gets solid variant', () => {
+    const dialog = makeDialog({ party: parentOrg.party });
+    const [result] = mapDialogToToInboxItems([dialog], parties, [], format, false, partyGraph);
+
+    expect(result.recipient.variant).toBe('solid');
+  });
+
+  it('handles multiple dialogs resolved via PartyGraph', () => {
+    const dialogs = [
+      makeDialog({ id: 'd1', party: endUser.party }),
+      makeDialog({ id: 'd2', party: standaloneOrg.party }),
+      makeDialog({ id: 'd3', party: 'urn:altinn:organization:identifier-no:910000002' }),
+    ];
+    const results = mapDialogToToInboxItems(dialogs, parties, [], format, false, partyGraph);
+
+    expect(results).toHaveLength(3);
+    expect(results[0].recipient.name).toBe('Ola Nordmann');
+    expect(results[1].recipient.name).toBe('Frittstående AS');
+    expect(results[2].recipient.name).toBe('Stor Bedrift Avd Oslo');
+  });
+});

--- a/packages/frontend/src/api/utils/normalizeParties.spec.ts
+++ b/packages/frontend/src/api/utils/normalizeParties.spec.ts
@@ -52,4 +52,120 @@ describe('normalizeParties', () => {
     expect(result[2].isDeleted).toBe(false);
     expect(result[2].isCurrentEndUser).toBe(false);
   });
+
+  it('promoted subParties appear as top-level entries in the flat list', () => {
+    const result = normalizeFlattenParties(parties);
+    // Index 0: person, Index 1: parent org, Index 2: promoted subParty
+    expect(result[2].party).toBe('urn:altinn:organization:identifier-no:2');
+    // Promoted entry should be top-level (not nested under parent)
+    expect(result.filter((p) => p.party === 'urn:altinn:organization:identifier-no:2')).toHaveLength(1);
+  });
+
+  it('parent retains its subParties array after flattening', () => {
+    const result = normalizeFlattenParties(parties);
+    const parent = result.find((p) => p.party === 'urn:altinn:organization:identifier-no:1');
+    expect(parent?.subParties).toBeDefined();
+    expect(parent?.subParties).toHaveLength(1);
+    expect(parent?.subParties?.[0]?.party).toBe('urn:altinn:organization:identifier-no:2');
+  });
+
+  it('promoted subParty does NOT have a subParties array (distinguishes parent from child)', () => {
+    const result = normalizeFlattenParties(parties);
+    const promoted = result[2];
+    // SubPartyFieldsFragment has no subParties field — this is the key distinction
+    // used by useAccounts to tell parents from promoted children
+    expect(promoted.subParties).toBeUndefined();
+  });
+
+  it('preserves ordering: parent appears before its promoted children', () => {
+    const result = normalizeFlattenParties(parties);
+    const parentIdx = result.findIndex((p) => p.party === 'urn:altinn:organization:identifier-no:1');
+    const childIdx = result.findIndex((p) => p.party === 'urn:altinn:organization:identifier-no:2');
+    expect(parentIdx).toBeLessThan(childIdx);
+  });
+
+  it('handles party with no subParties', () => {
+    const personOnly: PartyFieldsFragment[] = [
+      {
+        party: 'urn:altinn:person:identifier-no:9999',
+        partyType: 'Person',
+        subParties: [],
+        hasOnlyAccessToSubParties: false,
+        name: 'BARE PERSON',
+        isCurrentEndUser: true,
+        isDeleted: false,
+        partyUuid: 'uuid-bare',
+        partyId: 99,
+      },
+    ];
+    const result = normalizeFlattenParties(personOnly);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Bare Person');
+  });
+
+  it('handles multiple parents with multiple subParties each', () => {
+    const multiParent: PartyFieldsFragment[] = [
+      {
+        party: 'urn:altinn:organization:identifier-no:A',
+        partyType: 'Organization',
+        hasOnlyAccessToSubParties: false,
+        subParties: [
+          {
+            party: 'urn:altinn:organization:identifier-no:A1',
+            partyType: 'Organization',
+            name: 'SUB A1',
+            isCurrentEndUser: false,
+            partyUuid: 'uuid-a1',
+            isDeleted: false,
+            partyId: 10,
+          },
+          {
+            party: 'urn:altinn:organization:identifier-no:A2',
+            partyType: 'Organization',
+            name: 'SUB A2',
+            isCurrentEndUser: false,
+            partyUuid: 'uuid-a2',
+            isDeleted: false,
+            partyId: 11,
+          },
+        ],
+        name: 'PARENT A',
+        isCurrentEndUser: false,
+        isDeleted: false,
+        partyUuid: 'uuid-a',
+        partyId: 1,
+      },
+      {
+        party: 'urn:altinn:organization:identifier-no:B',
+        partyType: 'Organization',
+        hasOnlyAccessToSubParties: false,
+        subParties: [
+          {
+            party: 'urn:altinn:organization:identifier-no:B1',
+            partyType: 'Organization',
+            name: 'SUB B1',
+            isCurrentEndUser: false,
+            partyUuid: 'uuid-b1',
+            isDeleted: false,
+            partyId: 20,
+          },
+        ],
+        name: 'PARENT B',
+        isCurrentEndUser: false,
+        isDeleted: false,
+        partyUuid: 'uuid-b',
+        partyId: 2,
+      },
+    ];
+    const result = normalizeFlattenParties(multiParent);
+    // Parent A, Sub A1, Sub A2, Parent B, Sub B1
+    expect(result).toHaveLength(5);
+    expect(result.map((p) => p.party)).toEqual([
+      'urn:altinn:organization:identifier-no:A',
+      'urn:altinn:organization:identifier-no:A1',
+      'urn:altinn:organization:identifier-no:A2',
+      'urn:altinn:organization:identifier-no:B',
+      'urn:altinn:organization:identifier-no:B1',
+    ]);
+  });
 });

--- a/packages/frontend/src/api/utils/organizations.ts
+++ b/packages/frontend/src/api/utils/organizations.ts
@@ -6,12 +6,19 @@ export interface OrganizationOutput {
   logo: string;
 }
 
+type OrgLookup = OrganizationFieldsFragment[] | Map<string, OrganizationFieldsFragment>;
+
+const findOrg = (organizations: OrgLookup, id: string): OrganizationFieldsFragment | undefined => {
+  if (organizations instanceof Map) return organizations.get(id);
+  return organizations.find((o) => o.id === id);
+};
+
 export const getOrganizationByLocale = (
-  organizations: OrganizationFieldsFragment[],
+  organizations: OrgLookup,
   org: string,
   locale: string,
 ): OrganizationOutput | undefined => {
-  const currentOrg = organizations?.find((o) => o.id === (org as string));
+  const currentOrg = findOrg(organizations, org);
   const name = currentOrg?.name && (currentOrg.name[locale as keyof typeof currentOrg.name] ?? '');
   const logo = currentOrg?.logo ?? '';
   return {
@@ -20,9 +27,6 @@ export const getOrganizationByLocale = (
   };
 };
 
-export const getOrganization = (
-  organizations: OrganizationFieldsFragment[],
-  org: string,
-): OrganizationOutput | undefined => {
+export const getOrganization = (organizations: OrgLookup, org: string): OrganizationOutput | undefined => {
   return getOrganizationByLocale(organizations, org, i18n.language);
 };

--- a/packages/frontend/src/api/utils/partyGraph.spec.ts
+++ b/packages/frontend/src/api/utils/partyGraph.spec.ts
@@ -1,0 +1,270 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { describe, expect, it } from 'vitest';
+import { buildPartyGraph } from './partyGraph.ts';
+
+/**
+ * Fixtures simulate the output of normalizeFlattenParties:
+ * - Parents appear with their subParties array intact
+ * - SubParties are promoted to top-level entries (without subParties field)
+ */
+
+const endUser: PartyFieldsFragment = {
+  party: 'urn:altinn:person:identifier-no:12345678901',
+  partyType: 'Person',
+  name: 'Ola Nordmann',
+  isCurrentEndUser: true,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-person-1',
+  partyId: 1,
+  subParties: [],
+};
+
+const parentOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000001',
+  partyType: 'Organization',
+  name: 'Stor Bedrift AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-org-parent',
+  partyId: 2,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:910000002',
+      partyType: 'Organization',
+      name: 'Stor Bedrift Avd Oslo',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-org-sub-1',
+      partyId: 3,
+    },
+    {
+      party: 'urn:altinn:organization:identifier-no:910000003',
+      partyType: 'Organization',
+      name: 'Stor Bedrift Avd Bergen',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-org-sub-2',
+      partyId: 4,
+    },
+  ],
+};
+
+// Promoted sub-parties (as normalizeFlattenParties produces)
+const promotedSub1: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000002',
+  partyType: 'Organization',
+  name: 'Stor Bedrift Avd Oslo',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-org-sub-1',
+  partyId: 3,
+};
+
+const promotedSub2: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000003',
+  partyType: 'Organization',
+  name: 'Stor Bedrift Avd Bergen',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-org-sub-2',
+  partyId: 4,
+};
+
+const standaloneOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:920000001',
+  partyType: 'Organization',
+  name: 'Standalone AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-standalone',
+  partyId: 5,
+  subParties: [],
+};
+
+const disabledParent: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:930000001',
+  partyType: 'Organization',
+  name: 'Disabled Parent AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: true,
+  partyUuid: 'uuid-disabled',
+  partyId: 6,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:930000002',
+      partyType: 'Organization',
+      name: 'Only Child',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-only-child',
+      partyId: 7,
+    },
+  ],
+};
+
+const promotedOnlyChild: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:930000002',
+  partyType: 'Organization',
+  name: 'Only Child',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-only-child',
+  partyId: 7,
+};
+
+// Full flat list as normalizeFlattenParties would produce
+const flatList: PartyFieldsFragment[] = [
+  endUser,
+  parentOrg,
+  promotedSub1,
+  promotedSub2,
+  standaloneOrg,
+  disabledParent,
+  promotedOnlyChild,
+];
+
+describe('buildPartyGraph', () => {
+  const graph = buildPartyGraph(flatList);
+
+  describe('deduplication', () => {
+    it('deduplicates promoted sub-parties that share URN with nested entries', () => {
+      // parentOrg has 2 subs, disabledParent has 1. Plus endUser, parentOrg, standaloneOrg, disabledParent = 7 unique
+      expect(graph.parties).toHaveLength(7);
+    });
+
+    it('partyByUrn has one entry per unique URN', () => {
+      expect(graph.partyByUrn.size).toBe(7);
+    });
+  });
+
+  describe('lookup maps', () => {
+    it('finds party by URN', () => {
+      const p = graph.partyByUrn.get('urn:altinn:organization:identifier-no:910000002');
+      expect(p).toBeDefined();
+      expect(p!.name).toBe('Stor Bedrift Avd Oslo');
+    });
+
+    it('finds party by UUID', () => {
+      const p = graph.partyByUuid.get('uuid-org-parent');
+      expect(p).toBeDefined();
+      expect(p!.name).toBe('Stor Bedrift AS');
+    });
+
+    it('returns undefined for unknown URN', () => {
+      expect(graph.partyByUrn.get('urn:altinn:organization:identifier-no:999999999')).toBeUndefined();
+    });
+  });
+
+  describe('currentEndUser', () => {
+    it('identifies the current end user', () => {
+      expect(graph.currentEndUser).toBeDefined();
+      expect(graph.currentEndUser!.name).toBe('Ola Nordmann');
+      expect(graph.currentEndUser!.isCurrentEndUser).toBe(true);
+    });
+  });
+
+  describe('parent/child relationships', () => {
+    it('marks parent org as isParent: true', () => {
+      const p = graph.partyByUrn.get(parentOrg.party)!;
+      expect(p.isParent).toBe(true);
+    });
+
+    it('parent has correct subParties references', () => {
+      const p = graph.partyByUrn.get(parentOrg.party)!;
+      expect(p.subParties).toHaveLength(2);
+      expect(p.subParties.map((s) => s.name).sort()).toEqual(['Stor Bedrift Avd Bergen', 'Stor Bedrift Avd Oslo']);
+    });
+
+    it('children reference their parent', () => {
+      const child = graph.partyByUrn.get('urn:altinn:organization:identifier-no:910000002')!;
+      expect(child.parentParty).toBeDefined();
+      expect(child.parentParty!.party).toBe(parentOrg.party);
+    });
+
+    it('children are not marked as parents', () => {
+      const child = graph.partyByUrn.get('urn:altinn:organization:identifier-no:910000002')!;
+      expect(child.isParent).toBe(false);
+      expect(child.subParties).toEqual([]);
+    });
+
+    it('standalone org with empty subParties is NOT a parent', () => {
+      const p = graph.partyByUrn.get(standaloneOrg.party)!;
+      expect(p.isParent).toBe(false);
+      expect(p.parentParty).toBeUndefined();
+      expect(p.subParties).toEqual([]);
+    });
+
+    it('disabled parent (hasOnlyAccessToSubParties) is still marked as parent', () => {
+      const p = graph.partyByUrn.get(disabledParent.party)!;
+      expect(p.isParent).toBe(true);
+      expect(p.hasOnlyAccessToSubParties).toBe(true);
+      expect(p.subParties).toHaveLength(1);
+    });
+
+    it('child of disabled parent references back', () => {
+      const child = graph.partyByUrn.get('urn:altinn:organization:identifier-no:930000002')!;
+      expect(child.parentParty).toBeDefined();
+      expect(child.parentParty!.party).toBe(disabledParent.party);
+    });
+  });
+
+  describe('derived fields', () => {
+    it('sets isPerson for Person type', () => {
+      expect(graph.currentEndUser!.isPerson).toBe(true);
+      expect(graph.currentEndUser!.isOrganization).toBe(false);
+    });
+
+    it('sets isOrganization for Organization type', () => {
+      const org = graph.partyByUrn.get(parentOrg.party)!;
+      expect(org.isOrganization).toBe(true);
+      expect(org.isPerson).toBe(false);
+    });
+
+    it('sets isPerson for SelfIdentified type', () => {
+      const selfId: PartyFieldsFragment = {
+        party: 'urn:altinn:person:identifier-no:99999999999',
+        partyType: 'SelfIdentified',
+        name: 'Self User',
+        isCurrentEndUser: true,
+        isDeleted: false,
+        hasOnlyAccessToSubParties: false,
+        partyUuid: 'uuid-self',
+        partyId: 99,
+      };
+      const g = buildPartyGraph([selfId]);
+      expect(g.parties[0].isPerson).toBe(true);
+      expect(g.parties[0].isOrganization).toBe(false);
+    });
+  });
+
+  describe('referential integrity', () => {
+    it('parent.subParties[i] is the same object as partyByUrn.get(urn)', () => {
+      const parent = graph.partyByUrn.get(parentOrg.party)!;
+      for (const child of parent.subParties) {
+        expect(child).toBe(graph.partyByUrn.get(child.party));
+      }
+    });
+
+    it('child.parentParty is the same object as partyByUrn.get(parentUrn)', () => {
+      const child = graph.partyByUrn.get('urn:altinn:organization:identifier-no:910000002')!;
+      expect(child.parentParty).toBe(graph.partyByUrn.get(parentOrg.party));
+    });
+  });
+
+  describe('empty input', () => {
+    it('handles empty party list', () => {
+      const g = buildPartyGraph([]);
+      expect(g.parties).toEqual([]);
+      expect(g.partyByUrn.size).toBe(0);
+      expect(g.partyByUuid.size).toBe(0);
+      expect(g.currentEndUser).toBeUndefined();
+    });
+  });
+});

--- a/packages/frontend/src/api/utils/partyGraph.ts
+++ b/packages/frontend/src/api/utils/partyGraph.ts
@@ -1,0 +1,153 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+
+/**
+ * Enriched party type that precomputes all relationships and derived fields.
+ * Built once in a single O(n) pass by `buildPartyGraph`, cached by React Query.
+ *
+ * Replaces `PartyFieldsFragment` in all downstream consumers — no more
+ * repeated `.find()` / `.some()` scans to resolve parent-child relationships.
+ */
+export interface Party {
+  /** URN identifier, e.g. "urn:altinn:organization:identifier-no:910000001" */
+  party: string;
+  partyType: string;
+  name: string;
+  partyUuid: string;
+  partyId: number;
+  isCurrentEndUser: boolean;
+  isDeleted: boolean;
+  hasOnlyAccessToSubParties: boolean;
+  dateOfBirth?: string | null;
+
+  // --- Precomputed relationships ---
+
+  /** True if this party has child sub-parties (non-empty subParties). */
+  isParent: boolean;
+  /** Direct reference to the parent party, or undefined if top-level. */
+  parentParty: Party | undefined;
+  /** Direct child sub-parties. Empty array if leaf node. */
+  subParties: Party[];
+
+  // --- Precomputed derived fields ---
+
+  isPerson: boolean;
+  isOrganization: boolean;
+}
+
+export interface PartyGraph {
+  /** Flat list of all parties (parents + promoted sub-parties). */
+  parties: Party[];
+  /** O(1) lookup by party URN (e.g. "urn:altinn:organization:identifier-no:..."). */
+  partyByUrn: Map<string, Party>;
+  /** O(1) lookup by partyUuid. */
+  partyByUuid: Map<string, Party>;
+  /** The logged-in user's own party (isCurrentEndUser). */
+  currentEndUser: Party | undefined;
+}
+
+/**
+ * Builds the enriched `PartyGraph` from the normalized flat party list.
+ *
+ * Input: the output of `normalizeFlattenParties` — a flat list where:
+ * - Parent orgs appear with their original `subParties` array intact
+ * - Sub-parties are also promoted to top-level entries (without a `subParties` array)
+ *
+ * This function does a single linear pass to:
+ * 1. Create `Party` objects for every entry
+ * 2. Build URN and UUID lookup maps
+ * 3. Resolve parent↔child references using the original `subParties` arrays
+ */
+export function buildPartyGraph(normalizedParties: PartyFieldsFragment[]): PartyGraph {
+  const partyByUrn = new Map<string, Party>();
+  const partyByUuid = new Map<string, Party>();
+  let currentEndUser: Party | undefined;
+
+  // Pass 1: Create Party objects and index them
+  for (const raw of normalizedParties) {
+    // Skip duplicates — promoted sub-parties may share a URN with their nested entry
+    if (partyByUrn.has(raw.party)) continue;
+
+    const party: Party = {
+      party: raw.party,
+      partyType: raw.partyType,
+      name: raw.name,
+      partyUuid: raw.partyUuid,
+      partyId: raw.partyId,
+      isCurrentEndUser: raw.isCurrentEndUser,
+      isDeleted: raw.isDeleted,
+      hasOnlyAccessToSubParties: raw.hasOnlyAccessToSubParties ?? false,
+      dateOfBirth: raw.dateOfBirth,
+
+      // Will be resolved in pass 2
+      isParent: false,
+      parentParty: undefined,
+      subParties: [],
+
+      isPerson: raw.partyType === 'Person' || raw.partyType === 'SelfIdentified',
+      isOrganization: raw.partyType === 'Organization',
+    };
+
+    partyByUrn.set(party.party, party);
+    partyByUuid.set(party.partyUuid, party);
+
+    if (raw.isCurrentEndUser) {
+      currentEndUser = party;
+    }
+  }
+
+  // Pass 2: Resolve parent↔child references
+  // Only entries with a non-empty subParties array are parents.
+  for (const raw of normalizedParties) {
+    const rawSubs = raw.subParties;
+    if (!rawSubs || rawSubs.length === 0) continue;
+
+    const parent = partyByUrn.get(raw.party);
+    if (!parent) continue;
+
+    parent.isParent = true;
+    const children: Party[] = [];
+
+    for (const rawSub of rawSubs) {
+      let child = partyByUrn.get(rawSub.party);
+
+      // Sub-party may not exist as a top-level entry (e.g. when the input
+      // isn't from normalizeFlattenParties, or in test fixtures).
+      // Create and index it so all lookups work regardless.
+      if (!child) {
+        child = {
+          party: rawSub.party,
+          partyType: rawSub.partyType,
+          name: rawSub.name,
+          partyUuid: rawSub.partyUuid,
+          partyId: rawSub.partyId,
+          isCurrentEndUser: rawSub.isCurrentEndUser,
+          isDeleted: rawSub.isDeleted,
+          hasOnlyAccessToSubParties: false,
+          dateOfBirth: rawSub.dateOfBirth,
+          isParent: false,
+          parentParty: undefined,
+          subParties: [],
+          isPerson: rawSub.partyType === 'Person' || rawSub.partyType === 'SelfIdentified',
+          isOrganization: rawSub.partyType === 'Organization',
+        };
+        partyByUrn.set(child.party, child);
+        partyByUuid.set(child.partyUuid, child);
+      }
+
+      child.parentParty = parent;
+      children.push(child);
+    }
+
+    parent.subParties = children;
+  }
+
+  // Build the flat output list preserving insertion order but deduped
+  const parties = Array.from(partyByUrn.values());
+
+  return {
+    parties,
+    partyByUrn,
+    partyByUuid,
+    currentEndUser,
+  };
+}

--- a/packages/frontend/src/components/BetaModal/BetaModal.tsx
+++ b/packages/frontend/src/components/BetaModal/BetaModal.tsx
@@ -2,7 +2,7 @@ import { Button, Checkbox, Modal, Typography } from '@altinn/altinn-components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { getAboutNewAltinnLink } from '../../auth';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { pruneSearchQueryParams } from '../../pages/Inbox/queryParams.ts';
@@ -18,7 +18,7 @@ const PROFILE_PARTIES_ONBOARDING_KEY = 'arbeidsflate:profile-parties-onboarding-
 export const BetaModal = () => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   const searchParams = new URLSearchParams(window.location.search);
   const isMock = searchParams.get('mock') === 'true';
   const [isOpen, setIsOpen] = useState<boolean>(localStorage.getItem(betaKey) === null);

--- a/packages/frontend/src/components/EmptyState/EmptyState.tsx
+++ b/packages/frontend/src/components/EmptyState/EmptyState.tsx
@@ -2,7 +2,7 @@ import { Heading, Typography } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink } from '../../auth';
 import { SaveSearchButton, type SaveSearchButtonProps } from '../SavedSearchButton/SaveSearchButton.tsx';
 
@@ -14,7 +14,7 @@ interface EmptyStateProps {
 
 export const EmptyState = ({ viewType, savable, saveSearchButtonProps }: EmptyStateProps) => {
   const { t } = useTranslation();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   if (savable) {
     return (
       <Typography size="sm">

--- a/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
+++ b/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
@@ -2,7 +2,7 @@ import { FloatingDropdown as FloatingDropdownAc } from '@altinn/altinn-component
 import { ExternalLinkIcon, LeaveIcon, QuestionmarkIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink, getNeedHelpLink } from '../../auth';
 import { QUERY_KEYS } from '../../constants/queryKeys';
 import { i18n } from '../../i18n/config';
@@ -21,7 +21,7 @@ export const FloatingDropdown = () => {
   const [_, setShowTour] = useGlobalState<boolean>(QUERY_KEYS.SHOW_TOUR, false);
   const [__, setShowProfileTour] = useGlobalState<boolean>(QUERY_KEYS.SHOW_PROFILE_TOUR, false);
 
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
 
   const isTourBlacklisted = TOUR_BLACKLISTED_PAGES.includes(location.pathname as PageRoutes);
 

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.spec.ts
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.spec.ts
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCustomWrapper } from '../../../../utils/test-utils.tsx';
 import { useParties } from '../../../api/hooks/useParties.ts';
+import { buildPartyGraph } from '../../../api/utils/partyGraph.ts';
 import { useProfile } from '../../../pages/Profile';
 import { formatNorwegianId, formatSSN, useAccounts } from './useAccounts.tsx';
 
@@ -127,6 +128,8 @@ const parties: PartyFieldsFragment[] = [
   },
 ];
 
+const partiesPartyGraph = buildPartyGraph(parties);
+
 describe('useAccounts', () => {
   const mockT = vi.fn((key: string) => key);
   const mockSetSelectedPartyIds = vi.fn();
@@ -135,7 +138,10 @@ describe('useAccounts', () => {
     vi.clearAllMocks();
 
     (useTranslation as Mock).mockReturnValue({ t: mockT });
-    (useParties as Mock).mockReturnValue({ setSelectedPartyIds: mockSetSelectedPartyIds });
+    (useParties as Mock).mockReturnValue({
+      setSelectedPartyIds: mockSetSelectedPartyIds,
+      partyGraph: partiesPartyGraph,
+    });
     (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
   });
 
@@ -260,6 +266,391 @@ describe('useAccounts', () => {
     // When showDescription is false, accounts should not have descriptions
     const accountsWithDescription = result.current.accounts.filter((acc) => acc.description);
     expect(accountsWithDescription.length).toBe(0);
+  });
+});
+
+/**
+ * Dedicated fixtures for parent/child relationship tests.
+ *
+ * These simulate the output of normalizeFlattenParties — a flat list where:
+ * - Parent orgs appear with their subParties array intact
+ * - SubParties are promoted to top-level entries WITHOUT a subParties array
+ */
+const parentOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:100000001',
+  partyType: 'Organization',
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:100000010',
+      partyType: 'Organization',
+      name: 'Child Org Alpha',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-child-alpha',
+      partyId: 11,
+    },
+    {
+      party: 'urn:altinn:organization:identifier-no:100000011',
+      partyType: 'Organization',
+      name: 'Child Org Beta',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-child-beta',
+      partyId: 12,
+    },
+  ],
+  name: 'Parent Org',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-parent-org',
+  partyId: 10,
+};
+
+const disabledParentOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:100000099',
+  partyType: 'Organization',
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:100000098',
+      partyType: 'Organization',
+      name: 'Only Child',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-only-child',
+      partyId: 21,
+    },
+  ],
+  name: 'Disabled Parent',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: true,
+  partyUuid: 'uuid-disabled-parent',
+  partyId: 20,
+};
+
+// Promoted subParties as they appear in the flat list (no subParties field)
+const promotedChildAlpha: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:100000010',
+  partyType: 'Organization',
+  name: 'Child Org Alpha',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-child-alpha',
+  partyId: 11,
+};
+
+const promotedChildBeta: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:100000011',
+  partyType: 'Organization',
+  name: 'Child Org Beta',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-child-beta',
+  partyId: 12,
+};
+
+const promotedOnlyChild: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:100000098',
+  partyType: 'Organization',
+  name: 'Only Child',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-only-child',
+  partyId: 21,
+};
+
+const standaloneOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:200000001',
+  partyType: 'Organization',
+  subParties: [],
+  name: 'Standalone Org',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-standalone',
+  partyId: 30,
+};
+
+const endUserPerson: PartyFieldsFragment = {
+  party: 'urn:altinn:person:identifier-no:01010112345',
+  partyType: 'Person',
+  subParties: [],
+  name: 'Ola Nordmann',
+  isCurrentEndUser: true,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-enduser',
+  partyId: 1,
+};
+
+// Flat list simulating normalizeFlattenParties output
+const relationshipParties: PartyFieldsFragment[] = [
+  endUserPerson,
+  parentOrg,
+  promotedChildAlpha,
+  promotedChildBeta,
+  disabledParentOrg,
+  promotedOnlyChild,
+  standaloneOrg,
+];
+
+const relationshipPartyGraph = buildPartyGraph(relationshipParties);
+
+describe('useAccounts — parent/child relationship resolution', () => {
+  const mockT = vi.fn((key: string) => key);
+  const mockSetSelectedPartyIds = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTranslation as Mock).mockReturnValue({ t: mockT });
+    (useParties as Mock).mockReturnValue({
+      setSelectedPartyIds: mockSetSelectedPartyIds,
+      partyGraph: relationshipPartyGraph,
+    });
+    (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
+  });
+
+  const renderAccounts = (overrides?: Partial<Parameters<typeof useAccounts>[0]>) =>
+    renderHook(
+      () =>
+        useAccounts({
+          parties: relationshipParties,
+          selectedParties: [endUserPerson],
+          allOrganizationsSelected: false,
+          isLoading: false,
+          ...overrides,
+        }),
+      { wrapper: createCustomWrapper() },
+    );
+
+  it('marks parent orgs with isParent: true', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const parentAccount = orgAccounts.find((a) => a.id === parentOrg.party);
+    expect(parentAccount).toBeDefined();
+    expect(parentAccount!.isParent).toBe(true);
+  });
+
+  it('marks promoted subParties with isParent: false', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const childAlphaAccount = orgAccounts.find((a) => a.id === promotedChildAlpha.party);
+    expect(childAlphaAccount).toBeDefined();
+    expect(childAlphaAccount!.isParent).toBe(false);
+  });
+
+  it('sets parentId on children to the parent party URN', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const childAlpha = orgAccounts.find((a) => a.id === promotedChildAlpha.party);
+    const childBeta = orgAccounts.find((a) => a.id === promotedChildBeta.party);
+
+    expect(childAlpha!.parentId).toBe(parentOrg.party);
+    expect(childBeta!.parentId).toBe(parentOrg.party);
+  });
+
+  it('sets parentName on children to the parent name', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const childAlpha = orgAccounts.find((a) => a.id === promotedChildAlpha.party);
+    expect(childAlpha!.parentName).toBe('Parent Org');
+  });
+
+  it('sets groupId on children to the parent party URN', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const childAlpha = orgAccounts.find((a) => a.id === promotedChildAlpha.party);
+    const childBeta = orgAccounts.find((a) => a.id === promotedChildBeta.party);
+
+    expect(childAlpha!.groupId).toBe(parentOrg.party);
+    expect(childBeta!.groupId).toBe(parentOrg.party);
+  });
+
+  it('standalone org with empty subParties array is NOT a parent (isParent: false), no parentId, groupId equals own party', () => {
+    // With PartyGraph: empty subParties means no children → isParent: false.
+    // This fixes the old behavior where Array.isArray([]) was true.
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const standalone = orgAccounts.find((a) => a.id === standaloneOrg.party);
+    expect(standalone).toBeDefined();
+    expect(standalone!.isParent).toBe(false);
+    expect(standalone!.parentId).toBeUndefined();
+    expect(standalone!.groupId).toBe(standaloneOrg.party);
+  });
+
+  it('parent with hasOnlyAccessToSubParties is disabled', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const disabled = orgAccounts.find((a) => a.id === disabledParentOrg.party);
+    expect(disabled).toBeDefined();
+    expect(disabled!.disabled).toBe(true);
+  });
+
+  it('child description contains ↳ and partOf with parent name', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const childAlpha = orgAccounts.find((a) => a.id === promotedChildAlpha.party);
+    expect(childAlpha!.description).toBeDefined();
+    expect(childAlpha!.description).toContain('↳');
+    expect(childAlpha!.description).toContain('Parent Org');
+  });
+
+  it('parent description does NOT contain ↳', () => {
+    const { result } = renderAccounts();
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+
+    const parent = orgAccounts.find((a) => a.id === parentOrg.party);
+    expect(parent!.description).toBeDefined();
+    expect(parent!.description).not.toContain('↳');
+  });
+});
+
+describe('useAccounts — organization sort order', () => {
+  const mockT = vi.fn((key: string) => key);
+  const mockSetSelectedPartyIds = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTranslation as Mock).mockReturnValue({ t: mockT });
+    (useParties as Mock).mockReturnValue({
+      setSelectedPartyIds: mockSetSelectedPartyIds,
+      partyGraph: relationshipPartyGraph,
+    });
+    (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
+  });
+
+  it('parents are sorted alphabetically, children grouped under their parent and sorted within', () => {
+    const { result } = renderHook(
+      () =>
+        useAccounts({
+          parties: relationshipParties,
+          selectedParties: [endUserPerson],
+          allOrganizationsSelected: false,
+          isLoading: false,
+        }),
+      { wrapper: createCustomWrapper() },
+    );
+
+    const orgAccounts = result.current.accounts.filter((a) => a.type === 'company');
+    const orgNames = orgAccounts.map((a) => a.name);
+
+    // Parents sorted alphabetically: "Disabled Parent" before "Parent Org"
+    // Children grouped under their parent, sorted within the group
+    // Standalone orgs (no parent, not a parent) come after grouped entries
+
+    const disabledParentIdx = orgNames.indexOf('Disabled Parent');
+    const onlyChildIdx = orgNames.indexOf('Only Child');
+    const parentOrgIdx = orgNames.indexOf('Parent Org');
+    const childAlphaIdx = orgNames.indexOf('Child Org Alpha');
+    const childBetaIdx = orgNames.indexOf('Child Org Beta');
+    const standaloneIdx = orgNames.indexOf('Standalone Org');
+
+    // Disabled Parent comes before Parent Org (alphabetical parents)
+    expect(disabledParentIdx).toBeLessThan(parentOrgIdx);
+
+    // Only Child comes right after Disabled Parent
+    expect(onlyChildIdx).toBe(disabledParentIdx + 1);
+
+    // Children come after their parent
+    expect(childAlphaIdx).toBeGreaterThan(parentOrgIdx);
+    expect(childBetaIdx).toBeGreaterThan(parentOrgIdx);
+
+    // Children are sorted alphabetically within their group
+    expect(childAlphaIdx).toBeLessThan(childBetaIdx);
+
+    // Standalone org comes after all grouped entries
+    expect(standaloneIdx).toBeGreaterThan(childBetaIdx);
+  });
+});
+
+describe('useAccounts — person accounts sort order', () => {
+  const mockT = vi.fn((key: string) => key);
+  const mockSetSelectedPartyIds = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTranslation as Mock).mockReturnValue({ t: mockT });
+    (useParties as Mock).mockReturnValue({
+      setSelectedPartyIds: mockSetSelectedPartyIds,
+      partyGraph: partiesPartyGraph,
+    });
+    (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
+  });
+
+  it('other people (not current end user) are sorted alphabetically by name', () => {
+    const { result } = renderHook(
+      () =>
+        useAccounts({
+          parties,
+          selectedParties: [parties[0]],
+          allOrganizationsSelected: false,
+          isLoading: false,
+        }),
+      { wrapper: createCustomWrapper() },
+    );
+
+    const personAccounts = result.current.accounts.filter((a) => a.type === 'person' && !a.isCurrentEndUser);
+    const names = personAccounts.map((a) => a.name);
+
+    // ANKI A should come before Banksi (alphabetical)
+    expect(names.indexOf('ANKI A')).toBeLessThan(names.indexOf('Banksi'));
+  });
+});
+
+describe('useAccounts — currentAccountName', () => {
+  const mockT = vi.fn((key: string) => key);
+  const mockSetSelectedPartyIds = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTranslation as Mock).mockReturnValue({ t: mockT });
+    (useParties as Mock).mockReturnValue({
+      setSelectedPartyIds: mockSetSelectedPartyIds,
+      partyGraph: partiesPartyGraph,
+    });
+    (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
+  });
+
+  it('returns selected party name when a single party is selected', () => {
+    const { result } = renderHook(
+      () =>
+        useAccounts({
+          parties,
+          selectedParties: [parties[0]],
+          allOrganizationsSelected: false,
+          isLoading: false,
+        }),
+      { wrapper: createCustomWrapper() },
+    );
+
+    expect(result.current.currentAccountName).toBe('TEST TESTESEN');
+  });
+
+  it('returns "all organizations" label when allOrganizationsSelected is true', () => {
+    const { result } = renderHook(
+      () =>
+        useAccounts({
+          parties,
+          selectedParties: parties.filter((p) => p.partyType === 'Organization'),
+          allOrganizationsSelected: true,
+          isLoading: false,
+        }),
+      { wrapper: createCustomWrapper() },
+    );
+
+    expect(result.current.currentAccountName).toBe('parties.labels.all_organizations');
   });
 });
 

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
@@ -47,7 +47,6 @@ interface UseAccountsProps {
   allOrganizationsSelected: boolean;
   options?: UseAccountOptions;
   isLoading?: boolean;
-  availableParties?: PartyFieldsFragment[];
 }
 
 interface UseAccountsOutput {
@@ -99,18 +98,21 @@ export const useAccounts = ({
   allOrganizationsSelected,
   options: inputOptions,
   isLoading,
-  availableParties: availablePartiesInput,
 }: UseAccountsProps): UseAccountsOutput => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { setSelectedPartyIds } = useParties();
+  const { setSelectedPartyIds, partyGraph } = useParties();
   const { user, favoritesGroup, shouldShowDeletedEntities } = useProfile();
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
   const [searchString, setSearchString] = useState<string>('');
   const queryClient = useQueryClient();
   const accountSearchThreshold = 2;
   const showSearch = parties.length > accountSearchThreshold;
-  const availableParties = availablePartiesInput ?? parties;
+
+  const favoriteUuids = useMemo(
+    () => new Set(favoritesGroup?.parties?.filter((uuid): uuid is string => uuid != null) ?? []),
+    [favoritesGroup?.parties],
+  );
 
   const loadingAccountMenuItem: AccountMenuItemProps = {
     id: 'loading-account',
@@ -172,7 +174,7 @@ export const useAccounts = ({
           type: 'person' as AccountMenuItemProps['type'],
           icon: { name: person.name, type: 'person' as AvatarType },
           isDeleted: person.isDeleted,
-          isFavorite: favoritesGroup?.parties?.includes(person.partyUuid) || isPreselectedParty,
+          isFavorite: favoriteUuids.has(person.partyUuid) || isPreselectedParty,
           isPreselectedParty,
           isCurrentEndUser: false,
           uuid: person.partyUuid,
@@ -182,23 +184,22 @@ export const useAccounts = ({
         } as PartyItemProp;
       })
       .sort((a, b) => compareName(a.name, b.name));
-  }, [allOrganizationsSelected, otherPeople, favoritesGroup, options.showDescription, t, selectedParties, user]);
+  }, [allOrganizationsSelected, otherPeople, favoriteUuids, options.showDescription, t, selectedParties, user]);
 
   const organizationAccounts = useMemo<PartyItemProp[]>(() => {
     const mapped = organizations.map((party) => {
-      const isParent = Array.isArray(availableParties.find((p) => p.party === party.party)?.subParties);
+      // O(1) lookup via partyGraph
+      const enriched = partyGraph.partyByUrn.get(party.party);
+      const isParent = enriched?.isParent ?? false;
+      const parentParty = enriched?.parentParty;
       const isPreselectedParty = user?.profileSettingPreference?.preselectedPartyUuid === party.partyUuid;
 
-      const parent = isParent
-        ? undefined
-        : availableParties.find((org) => org?.subParties?.some((sub) => sub.party === party.party));
-
       const description =
-        parent?.name && party?.party
+        parentParty?.name && party?.party
           ? `↳ ${t('word.orgNo')} ${formatNorwegianId(
               party.party,
               false,
-            )}, ${t('profile.account.partOf')} ${parent.name}`
+            )}, ${t('profile.account.partOf')} ${parentParty.name}`
           : `${t('word.orgNo')} ${formatNorwegianId(party.party, false)}`;
       const orgNo = getSSNOrOrgNo(party.party);
       return {
@@ -216,17 +217,17 @@ export const useAccounts = ({
           isDeleted: party.isDeleted,
         },
         isDeleted: party.isDeleted,
-        isFavorite: favoritesGroup?.parties?.includes(party.partyUuid) || isPreselectedParty,
+        isFavorite: favoriteUuids.has(party.partyUuid) || isPreselectedParty,
         isPreselectedParty,
         isCurrentEndUser: false,
         uuid: party.partyUuid,
         disabled: party.hasOnlyAccessToSubParties,
         isParent,
-        parentId: parent?.party,
-        parentName: parent?.name,
+        parentId: parentParty?.party,
+        parentName: parentParty?.name,
         description: options.showDescription ? description : undefined,
         badge: party.isDeleted ? { color: 'neutral', label: t('badge.deleted'), variant: 'subtle' } : undefined,
-        groupId: parent?.party ?? party.party,
+        groupId: parentParty?.party ?? party.party,
       } as PartyItemProp;
     });
 
@@ -258,8 +259,8 @@ export const useAccounts = ({
     selectedParties,
     allOrganizationsSelected,
     organizations,
-    availableParties,
-    favoritesGroup,
+    partyGraph,
+    favoriteUuids,
     options.showDescription,
     t,
     user,
@@ -394,7 +395,7 @@ export const useAccounts = ({
         search.delete(FixedGlobalQueryParams.party);
         search.delete(FixedGlobalQueryParams.subAccounts);
       } else {
-        const party = parties.find((p) => p.party === partyId);
+        const party = partyGraph.partyByUrn.get(partyId);
         if (!party) {
           console.error('Selected party not found:', partyId);
           return;

--- a/packages/frontend/src/components/PageLayout/Footer/useFooter.tsx
+++ b/packages/frontend/src/components/PageLayout/Footer/useFooter.tsx
@@ -1,11 +1,11 @@
 import type { FooterProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../../../api/hooks/useParties';
+import { useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors.ts';
 import { getFooterLinks } from '../../../auth';
 
 export const useFooter = (): FooterProps => {
   const { t, i18n } = useTranslation();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   const footerLinks = getFooterLinks(currentPartyUuid || '', i18n.language);
 
   return {

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { useParties } from '../../../api/hooks/useParties.ts';
+import { useCurrentEndUser, useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors.ts';
 import { PageRoutes } from '../../../pages/routes.ts';
 import { buildInboxMenu } from './inboxMenu.tsx';
 import { buildProfileMenu } from './profileMenu.tsx';
@@ -17,7 +17,8 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
   const isProfile = pathname.includes(PageRoutes.profile);
   const fromView = (state as { fromView?: string })?.fromView;
   const { t } = useTranslation();
-  const { currentEndUser, currentPartyUuid } = useParties();
+  const currentEndUser = useCurrentEndUser();
+  const currentPartyUuid = useCurrentPartyUuid();
 
   const inboxMenus = buildInboxMenu({
     t,

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -188,13 +188,11 @@ export const PageLayout: React.FC = () => {
   };
 
   return (
-    <>
-      <Layout {...layoutProps} useGlobalHeader>
-        <Outlet />
-        <Snackbar />
-        <BetaModal />
-        <FloatingDropdown />
-      </Layout>
-    </>
+    <Layout {...layoutProps} useGlobalHeader>
+      <Outlet />
+      <Snackbar />
+      <BetaModal />
+      <FloatingDropdown />
+    </Layout>
   );
 };

--- a/packages/frontend/src/components/PageLayout/mapPartyToAuthorizedParty.spec.ts
+++ b/packages/frontend/src/components/PageLayout/mapPartyToAuthorizedParty.spec.ts
@@ -1,0 +1,242 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { describe, expect, it } from 'vitest';
+import { extractIdentifierNumber, mapPartiesToAuthorizedParties } from './mapPartyToAuthorizedParty.ts';
+
+// ----- Fixtures -----
+
+const person: PartyFieldsFragment = {
+  party: 'urn:altinn:person:identifier-no:12345678901',
+  partyType: 'Person',
+  name: 'Ola Nordmann',
+  isCurrentEndUser: true,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-person',
+  partyId: 1,
+  subParties: [],
+};
+
+const parentOrg: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000001',
+  partyType: 'Organization',
+  name: 'Stor Bedrift AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-parent',
+  partyId: 2,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:910000010',
+      partyType: 'Organization',
+      name: 'Avd Oslo',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-child-oslo',
+      partyId: 3,
+    },
+    {
+      party: 'urn:altinn:organization:identifier-no:910000011',
+      partyType: 'Organization',
+      name: 'Avd Bergen',
+      isCurrentEndUser: false,
+      isDeleted: true,
+      partyUuid: 'uuid-child-bergen',
+      partyId: 4,
+    },
+  ],
+};
+
+const disabledParent: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:920000001',
+  partyType: 'Organization',
+  name: 'Disabled Parent AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: true,
+  partyUuid: 'uuid-disabled-parent',
+  partyId: 5,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:920000010',
+      partyType: 'Organization',
+      name: 'Only Child',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-only-child',
+      partyId: 6,
+    },
+  ],
+};
+
+// Promoted subParty (as produced by normalizeFlattenParties — no subParties field)
+const promotedChild: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:910000010',
+  partyType: 'Organization',
+  name: 'Avd Oslo',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  hasOnlyAccessToSubParties: false,
+  partyUuid: 'uuid-child-oslo',
+  partyId: 3,
+};
+
+// ----- extractIdentifierNumber -----
+
+describe('extractIdentifierNumber', () => {
+  it('extracts number from person URN', () => {
+    expect(extractIdentifierNumber('urn:altinn:person:identifier-no:12345678901')).toBe('12345678901');
+  });
+
+  it('extracts number from organization URN', () => {
+    expect(extractIdentifierNumber('urn:altinn:organization:identifier-no:910000001')).toBe('910000001');
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(extractIdentifierNumber(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for URN without identifier-no segment', () => {
+    expect(extractIdentifierNumber('urn:altinn:person:uuid:some-uuid')).toBeUndefined();
+  });
+
+  it('returns empty string when identifier-no: is present but value is empty', () => {
+    expect(extractIdentifierNumber('urn:altinn:person:identifier-no:')).toBe('');
+  });
+});
+
+// ----- mapPartiesToAuthorizedParties -----
+
+describe('mapPartiesToAuthorizedParties', () => {
+  it('maps a simple person party', () => {
+    const result = mapPartiesToAuthorizedParties([person]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].partyUuid).toBe('uuid-person');
+    expect(result[0].name).toBe('Ola Nordmann');
+    expect(result[0].partyId).toBe(person.party);
+    expect(result[0].type).toBe('Person');
+    expect(result[0].isDeleted).toBe(false);
+    expect(result[0].organizationNumber).toBeUndefined();
+  });
+
+  it('maps organization with organizationNumber extracted from URN', () => {
+    const standaloneOrg: PartyFieldsFragment = {
+      party: 'urn:altinn:organization:identifier-no:987654321',
+      partyType: 'Organization',
+      name: 'Enkel AS',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      hasOnlyAccessToSubParties: false,
+      partyUuid: 'uuid-enkel',
+      partyId: 10,
+      subParties: [],
+    };
+    const result = mapPartiesToAuthorizedParties([standaloneOrg]);
+
+    expect(result[0].organizationNumber).toBe('987654321');
+  });
+
+  it('nests subParties as subunits on the parent', () => {
+    const result = mapPartiesToAuthorizedParties([parentOrg]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Stor Bedrift AS');
+    expect(result[0].subunits).toHaveLength(2);
+    expect(result[0].subunits![0].name).toBe('Avd Oslo');
+    expect(result[0].subunits![1].name).toBe('Avd Bergen');
+  });
+
+  it('subunit fields are mapped correctly', () => {
+    const result = mapPartiesToAuthorizedParties([parentOrg]);
+    const oslo = result[0].subunits![0];
+
+    expect(oslo.partyUuid).toBe('uuid-child-oslo');
+    expect(oslo.partyId).toBe('urn:altinn:organization:identifier-no:910000010');
+    expect(oslo.type).toBe('Organization');
+    expect(oslo.isDeleted).toBe(false);
+    expect(oslo.organizationNumber).toBe('910000010');
+  });
+
+  it('preserves isDeleted on subunits', () => {
+    const result = mapPartiesToAuthorizedParties([parentOrg]);
+    const bergen = result[0].subunits![1];
+
+    expect(bergen.isDeleted).toBe(true);
+  });
+
+  it('filters out promoted subParties from the top-level list (deduplication)', () => {
+    // This simulates the flattened list from normalizeFlattenParties where
+    // promotedChild appears both as a subParty of parentOrg AND as a top-level entry.
+    const flatList: PartyFieldsFragment[] = [person, parentOrg, promotedChild];
+    const result = mapPartiesToAuthorizedParties(flatList);
+
+    // promotedChild has partyUuid 'uuid-child-oslo' which is in parentOrg.subParties,
+    // so it should be filtered out from top level
+    const topLevelIds = result.map((p) => p.partyUuid);
+    expect(topLevelIds).toContain('uuid-person');
+    expect(topLevelIds).toContain('uuid-parent');
+    expect(topLevelIds).not.toContain('uuid-child-oslo');
+
+    // But it still appears as a subunit of the parent
+    expect(result.find((p) => p.partyUuid === 'uuid-parent')!.subunits![0].partyUuid).toBe('uuid-child-oslo');
+  });
+
+  it('maps hasOnlyAccessToSubParties to onlyHierarchyElementWithNoAccess', () => {
+    const result = mapPartiesToAuthorizedParties([disabledParent]);
+
+    expect(result[0].onlyHierarchyElementWithNoAccess).toBe(true);
+  });
+
+  it('defaults onlyHierarchyElementWithNoAccess to false when hasOnlyAccessToSubParties is false', () => {
+    const result = mapPartiesToAuthorizedParties([person]);
+
+    expect(result[0].onlyHierarchyElementWithNoAccess).toBe(false);
+  });
+
+  it('handles empty input', () => {
+    expect(mapPartiesToAuthorizedParties([])).toEqual([]);
+  });
+
+  it('party with no subParties has undefined subunits', () => {
+    // promotedChild has no subParties field at all (SubPartyFieldsFragment)
+    // When it's NOT filtered out (no parent in the list), subunits should be undefined
+    const result = mapPartiesToAuthorizedParties([promotedChild]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].subunits).toBeUndefined();
+  });
+
+  it('handles multiple parents each with their own children in a flat list', () => {
+    const promotedOnlyChild: PartyFieldsFragment = {
+      party: 'urn:altinn:organization:identifier-no:920000010',
+      partyType: 'Organization',
+      name: 'Only Child',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      hasOnlyAccessToSubParties: false,
+      partyUuid: 'uuid-only-child',
+      partyId: 6,
+    };
+
+    const flatList: PartyFieldsFragment[] = [person, parentOrg, promotedChild, disabledParent, promotedOnlyChild];
+    const result = mapPartiesToAuthorizedParties(flatList);
+
+    // Top level: person, parentOrg, disabledParent (promoted children filtered out)
+    expect(result).toHaveLength(3);
+    const topNames = result.map((p) => p.name);
+    expect(topNames).toEqual(['Ola Nordmann', 'Stor Bedrift AS', 'Disabled Parent AS']);
+
+    // Each parent has its own children nested
+    expect(result[1].subunits).toHaveLength(2);
+    expect(result[2].subunits).toHaveLength(1);
+    expect(result[2].subunits![0].name).toBe('Only Child');
+  });
+
+  it('sets authorizedResources and authorizedRoles to empty arrays', () => {
+    const result = mapPartiesToAuthorizedParties([person]);
+
+    expect(result[0].authorizedResources).toEqual([]);
+    expect(result[0].authorizedRoles).toEqual([]);
+  });
+});

--- a/packages/frontend/src/components/PageLayout/mapPartyToAuthorizedParty.ts
+++ b/packages/frontend/src/components/PageLayout/mapPartyToAuthorizedParty.ts
@@ -1,5 +1,6 @@
 import type { AuthorizedParty } from '@altinn/altinn-components';
 import type { PartyFieldsFragment } from 'bff-types-generated';
+import type { PartyGraph } from '../../api/utils/partyGraph.ts';
 
 //TODO: Date of birth not available in party API
 /**
@@ -30,7 +31,28 @@ const toAuthorizedParty = (party) => {
   };
 };
 
-export const mapPartiesToAuthorizedParties = (parties: PartyFieldsFragment[]): AuthorizedParty[] => {
+/**
+ * Converts the flat party list into a hierarchical AuthorizedParty[] structure.
+ *
+ * When a `partyGraph` is provided (O(1) lookups), uses `party.parentParty` to
+ * filter out promoted sub-parties and `party.subParties` for nesting.
+ *
+ * Falls back to the legacy approach (build a Set of sub-party UUIDs) when no graph is available.
+ */
+export const mapPartiesToAuthorizedParties = (
+  parties: PartyFieldsFragment[],
+  partyGraph?: PartyGraph,
+): AuthorizedParty[] => {
+  if (partyGraph) {
+    return partyGraph.parties
+      .filter((party) => !party.parentParty)
+      .map((party) => ({
+        ...toAuthorizedParty(party),
+        subunits: party.subParties.length > 0 ? party.subParties.map(toAuthorizedParty) : undefined,
+      }));
+  }
+
+  // Legacy fallback
   const subPartyUuids = new Set(parties.flatMap((party) => party.subParties?.map((sub) => sub.partyUuid) ?? []));
 
   return parties

--- a/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
+++ b/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
@@ -7,12 +7,19 @@ import {
   useAccountSelector,
 } from '@altinn/altinn-components';
 import type { ChangeEvent } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps, useLocation, useNavigate } from 'react-router-dom';
 import { Analytics } from '../../analytics/analytics.ts';
 import { ANALYTICS_EVENTS } from '../../analytics/analyticsEvents.ts';
-import { useParties } from '../../api/hooks/useParties.ts';
+import {
+  useCurrentEndUser,
+  useCurrentPartyUuid,
+  usePartiesLoading,
+  usePartyGraph,
+  useSelectedParties,
+  useSetSelectedPartyIds,
+} from '../../api/hooks/usePartiesSelectors.ts';
 import { updateLanguage } from '../../api/queries.ts';
 import { createFiltersURLQuery, getFrontPageLink } from '../../auth';
 import { useFeatureFlag } from '../../featureFlags';
@@ -31,12 +38,16 @@ interface UseHeaderConfigOutput {
 }
 
 export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutput => {
-  const { currentEndUser, parties, selectedParties, isLoading, currentPartyUuid, setSelectedPartyIds } = useParties();
+  const currentEndUser = useCurrentEndUser();
+  const partyGraph = usePartyGraph();
+  const selectedParties = useSelectedParties();
+  const isLoading = usePartiesLoading();
+  const currentPartyUuid = useCurrentPartyUuid();
+  const setSelectedPartyIds = useSetSelectedPartyIds();
   const { t, i18n } = useTranslation();
   const { logError } = useErrorLogger();
   const location = useLocation();
   const navigate = useNavigate();
-  const isProfile = location.pathname.includes(PageRoutes.profile);
   const { searchValue, setSearchValue, onClear } = useSearchString();
 
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
@@ -50,33 +61,53 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
     updateShowDeletedEntities,
   } = useProfile();
 
-  const handleToggleFavorite = useCallback(
-    async (accountUuid: string) => {
-      const isFavorite = favoritesGroup?.parties?.includes(accountUuid);
-      try {
-        if (isFavorite) {
-          await deleteFavoriteParty(accountUuid);
-        } else {
-          await addFavoriteParty(accountUuid);
-        }
-      } catch (error) {
-        logError(
-          error as Error,
-          {
-            context: 'useHeaderConfig.handleToggleFavorite',
-            accountUuid,
-            action: isFavorite ? 'remove' : 'add',
-          },
-          'Error toggling favorite party',
-        );
-      }
-    },
-    [favoritesGroup?.parties, addFavoriteParty, deleteFavoriteParty, logError],
-  );
+  // Use refs so handleToggleFavorite has a stable identity and doesn't
+  // invalidate useAccountSelector's useMemo (which reprocesses 12k parties).
+  const favoritesRef = useRef(favoritesGroup?.parties);
+  favoritesRef.current = favoritesGroup?.parties;
+  const addFavoriteRef = useRef(addFavoriteParty);
+  addFavoriteRef.current = addFavoriteParty;
+  const deleteFavoriteRef = useRef(deleteFavoriteParty);
+  deleteFavoriteRef.current = deleteFavoriteParty;
+  const logErrorRef = useRef(logError);
+  logErrorRef.current = logError;
 
-  const handleSelectAccount = (accountUuid: string) => {
-    const targetRoute = isProfile ? PageRoutes.profile : PageRoutes.inbox;
-    const party = parties.find((p) => p.partyUuid === accountUuid);
+  const handleToggleFavorite = useCallback(async (accountUuid: string) => {
+    const isFavorite = favoritesRef.current?.includes(accountUuid);
+    try {
+      if (isFavorite) {
+        await deleteFavoriteRef.current(accountUuid);
+      } else {
+        await addFavoriteRef.current(accountUuid);
+      }
+    } catch (error) {
+      logErrorRef.current(
+        error as Error,
+        {
+          context: 'useHeaderConfig.handleToggleFavorite',
+          accountUuid,
+          action: isFavorite ? 'remove' : 'add',
+        },
+        'Error toggling favorite party',
+      );
+    }
+  }, []);
+
+  // Stable ref for handleSelectAccount to avoid invalidating useAccountSelector's memo
+  const partyGraphRef = useRef(partyGraph);
+  partyGraphRef.current = partyGraph;
+  const selectedPartiesRef = useRef(selectedParties);
+  selectedPartiesRef.current = selectedParties;
+  const setSelectedPartyIdsRef = useRef(setSelectedPartyIds);
+  setSelectedPartyIdsRef.current = setSelectedPartyIds;
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+
+  const handleSelectAccount = useCallback((accountUuid: string) => {
+    const loc = window.location;
+    const currentIsProfile = loc.pathname.includes(PageRoutes.profile);
+    const targetRoute = currentIsProfile ? PageRoutes.profile : PageRoutes.inbox;
+    const party = partyGraphRef.current.partyByUuid.get(accountUuid);
 
     if (!party) {
       console.error('Selected party not found:', accountUuid);
@@ -84,45 +115,47 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
     }
 
     /* Selected party already selected */
-    if (selectedParties.length === 1 && selectedParties[0].party === party.party) {
+    const sp = selectedPartiesRef.current;
+    if (sp.length === 1 && sp[0].party === party.party) {
       return;
     }
 
     if (party.partyType === 'Person') {
-      setSelectedPartyIds([party.party], false);
+      setSelectedPartyIdsRef.current([party.party], false);
     } else {
-      const search = new URLSearchParams(location.search);
+      const search = new URLSearchParams(loc.search);
       search.set('party', party.party);
       search.delete('allParties');
       search.delete(FixedGlobalQueryParams.subAccounts);
-      navigate(`${targetRoute}?${search.toString()}`, {
-        replace: location.pathname === targetRoute,
+      navigateRef.current(`${targetRoute}?${search.toString()}`, {
+        replace: loc.pathname === targetRoute,
       });
     }
-  };
+  }, []);
 
-  const handleShowDeletedUnitsChange = useCallback(
-    async (shouldShow: boolean) => {
-      try {
-        await updateShowDeletedEntities(shouldShow);
-      } catch (error) {
-        logError(
-          error as Error,
-          {
-            context: 'useHeaderConfig.handleShowDeletedUnitsChange',
-            shouldShow,
-          },
-          'Error updating show deleted units setting',
-        );
-      }
-    },
-    [updateShowDeletedEntities, logError],
-  );
+  const updateShowDeletedEntitiesRef = useRef(updateShowDeletedEntities);
+  updateShowDeletedEntitiesRef.current = updateShowDeletedEntities;
 
-  const partyListDTO = mapPartiesToAuthorizedParties(parties);
+  const handleShowDeletedUnitsChange = useCallback(async (shouldShow: boolean) => {
+    try {
+      await updateShowDeletedEntitiesRef.current(shouldShow);
+    } catch (error) {
+      logErrorRef.current(
+        error as Error,
+        {
+          context: 'useHeaderConfig.handleShowDeletedUnitsChange',
+          shouldShow,
+        },
+        'Error updating show deleted units setting',
+      );
+    }
+  }, []);
 
-  const favoriteAccountUuids = (favoritesGroup?.parties ?? []).filter(
-    (uuid): uuid is string => uuid !== null && uuid !== undefined,
+  const partyListDTO = useMemo(() => mapPartiesToAuthorizedParties(partyGraph.parties, partyGraph), [partyGraph]);
+
+  const favoriteAccountUuids = useMemo(
+    () => (favoritesGroup?.parties ?? []).filter((uuid): uuid is string => uuid !== null && uuid !== undefined),
+    [favoritesGroup?.parties],
   );
 
   const selfAccountUuid = currentEndUser?.partyUuid;

--- a/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
+++ b/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
@@ -3,7 +3,7 @@ import { BookmarkFillIcon, BookmarkIcon } from '@navikt/aksel-icons';
 import type { ButtonHTMLAttributes, RefAttributes } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useSelectedPartyIds } from '../../api/hooks/usePartiesSelectors.ts';
 import { buildCurrentStateURL, findMatchingSavedSearch } from '../../pages/SavedSearches';
 import { useSavedSearches } from '../../pages/SavedSearches/useSavedSearches.tsx';
 import { useSearchString } from '../PageLayout/Search';
@@ -26,7 +26,7 @@ export const SaveSearchButton = ({
   onSaveSuccess,
 }: SaveSearchButtonProps) => {
   const { t } = useTranslation();
-  const { selectedPartyIds } = useParties();
+  const selectedPartyIds = useSelectedPartyIds();
   const { enteredSearchValue } = useSearchString();
   const {
     currentPartySavedSearches: savedSearches,

--- a/packages/frontend/src/onboardingTour/OnboardingPopover.tsx
+++ b/packages/frontend/src/onboardingTour/OnboardingPopover.tsx
@@ -3,7 +3,7 @@ import { XMarkIcon } from '@navikt/aksel-icons';
 import { useTour } from '@reactour/tour';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../api/hooks/useParties';
+import { useSelectedProfile } from '../api/hooks/usePartiesSelectors.ts';
 import styles from './onboardingPopover.module.css';
 
 interface OnboardingPopoverProps {
@@ -13,7 +13,7 @@ interface OnboardingPopoverProps {
 }
 
 export const OnboardingPopover = ({ titleKey, infoTextKey, hideNextButton }: OnboardingPopoverProps) => {
-  const { selectedProfile } = useParties();
+  const selectedProfile = useSelectedProfile();
   const { t } = useTranslation();
   const { currentStep, steps, setCurrentStep, setIsOpen } = useTour();
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
@@ -22,7 +22,7 @@ import { useDialogActions } from './useDialogActions.tsx';
 export const DialogDetailsPage = () => {
   const { id: dialogId } = useParams();
   const [isActivityLogOpen, setIsActivityLogOpen] = useState<boolean>(false);
-  const { parties } = useParties();
+  const { partyGraph } = useParties();
   const { t } = useTranslation();
   const location = useLocation();
   const qc = useQueryClient();
@@ -33,7 +33,7 @@ export const DialogDetailsPage = () => {
     isError,
     isAuthLevelTooLow,
     dataUpdatedAt,
-  } = useDialogById(parties, dialogId);
+  } = useDialogById(partyGraph.parties, dialogId);
   const isLoading = isLoadingDialog || (!isSuccess && !isError);
   const displayDialogActions = !!(dialogId && dialog && !isLoading);
   const { delegationHref } = useDelegation(dialogId, dialog?.party);

--- a/packages/frontend/src/pages/DialogDetailsPage/useDelegation.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/useDelegation.tsx
@@ -1,6 +1,6 @@
 import type { DialogLookupQuery } from 'bff-types-generated';
 import { useMemo } from 'react';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { usePartyGraph } from '../../api/hooks/usePartiesSelectors.ts';
 import { graphQLSDK } from '../../api/queries.ts';
 import { getAccessAMUILink } from '../../auth';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
@@ -23,7 +23,7 @@ const getDelegationHref = (instanceUrn: string, resourceId: string, dialogId: st
 };
 
 export const useDelegation = (dialogId?: string, party?: string): UseDelegationOutput => {
-  const { parties } = useParties();
+  const partyGraph = usePartyGraph();
   const instanceRef = `urn:altinn:dialog-id:${dialogId}`;
   const enableDelegationLink = useFeatureFlag('auth.enableDelegationLink');
   const { data, isSuccess } = useAuthenticatedQuery<DialogLookupQuery>({
@@ -37,8 +37,8 @@ export const useDelegation = (dialogId?: string, party?: string): UseDelegationO
   });
 
   const partyUuid = useMemo(() => {
-    return parties.find((p) => p.party === party)?.partyUuid;
-  }, [parties, party]);
+    return party ? partyGraph.partyByUrn.get(party)?.partyUuid : undefined;
+  }, [partyGraph, party]);
 
   if (!enableDelegationLink) {
     return {

--- a/packages/frontend/src/pages/Inbox/AlertBanner.tsx
+++ b/packages/frontend/src/pages/Inbox/AlertBanner.tsx
@@ -1,7 +1,7 @@
 import { DsAlert, DsParagraph, Heading } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink } from '../../auth';
 import { useAlertBanner } from '../../hooks/useAlertBanner.ts';
 
@@ -11,7 +11,7 @@ interface AlertBannerProps {
 
 export const AlertBanner = ({ showAlertBanner }: AlertBannerProps) => {
   const { t } = useTranslation();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   const alertBannerContent = useAlertBanner();
   const linkUrl = alertBannerContent?.link?.url || createMessageBoxLink(currentPartyUuid);
   const linkText = alertBannerContent?.link?.text || t('inbox.historical_messages_date_warning_link');

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -130,7 +130,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
     selectedParties,
     selectedPartyIds,
     allOrganizationsSelected,
-    parties,
+    partyGraph,
     partiesEmptyList,
     isError: unableToLoadParties,
     isLoading: isLoadingParties,
@@ -184,7 +184,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const serviceLimitReached = selectedServicesCount > 20;
 
   const { accounts, accountSearch, accountGroups, onSelectAccount, currentAccountName } = useAccounts({
-    parties,
+    parties: partyGraph.parties,
     selectedParties,
     allOrganizationsSelected,
     options: {

--- a/packages/frontend/src/pages/Inbox/filters.tsx
+++ b/packages/frontend/src/pages/Inbox/filters.tsx
@@ -193,7 +193,14 @@ const createServiceOwnerFilter = (
   allDialogs: CountableDialogFieldsFragment[],
   allOrganizations: OrganizationFieldsFragment[],
 ): FilterProps => {
-  const mostRelevantOrgs = Array.from(new Set([...allDialogs.map((d) => d.org)]));
+  const mostRelevantOrgs = new Set(allDialogs.map((d) => d.org));
+
+  // Pre-index for O(1) lookups instead of O(n²) .find() inside .map()
+  const orgById = new Map<string, OrganizationFieldsFragment>();
+  for (const o of allOrganizations ?? []) {
+    if (o.id) orgById.set(o.id, o);
+  }
+
   return {
     id: FilterCategory.ORG,
     icon: MenuHamburgerIcon,
@@ -204,7 +211,7 @@ const createServiceOwnerFilter = (
     removable: true,
     groups: {
       'service-owners': {
-        title: mostRelevantOrgs.length ? '' : t('filter_bar.group.choose_sender'),
+        title: mostRelevantOrgs.size ? '' : t('filter_bar.group.choose_sender'),
       },
       selected: {},
       'most-relevant': {
@@ -213,14 +220,14 @@ const createServiceOwnerFilter = (
     },
     items: allOrganizations
       .map((org) => {
-        const localizedOrg = getOrganization(allOrganizations, org.id ?? '');
+        const localizedOrg = getOrganization(orgById, org.id ?? '');
         return {
           id: org.id ?? '',
           name: FilterCategory.ORG,
           title: localizedOrg?.name ?? '',
           value: org.id ?? '',
           role: 'checkbox',
-          groupId: mostRelevantOrgs.includes(org.id ?? '') ? 'most-relevant' : 'service-owners',
+          groupId: mostRelevantOrgs.has(org.id ?? '') ? 'most-relevant' : 'service-owners',
         };
       })
       .sort((a, b) => {
@@ -342,15 +349,22 @@ export const createServiceFilter = ({
   currentFilters = {},
   allOrganizations,
 }: ServiceFilterProps): FilterProps => {
-  const suggestedServiceIds = getSuggestedServiceIds();
+  const suggestedServiceIds = new Set(getSuggestedServiceIds());
+
+  // Pre-index organizations by id for O(1) lookups (avoids 6,700 × O(n) .find() calls)
+  const orgById = new Map<string, OrganizationFieldsFragment>();
+  for (const o of allOrganizations ?? []) {
+    if (o.id) orgById.set(o.id, o);
+  }
+
   const serviceFilters: FilterProps[] = serviceResources
     .map((s) => ({
       id: s.id!,
       name: s.id!,
       items: [],
       title: s.title ?? '',
-      groupId: suggestedServiceIds?.includes(s.id!) ? 'most-relevant' : 'services',
-      description: getOrganization(allOrganizations, s.org ?? '')?.name || '',
+      groupId: suggestedServiceIds.has(s.id!) ? 'most-relevant' : 'services',
+      description: getOrganization(orgById, s.org ?? '')?.name || '',
     }))
     .sort((a, b) => {
       const groupOrder: Record<string, number> = {

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -14,7 +14,7 @@ import { useTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next';
 import { Link, type LinkProps } from 'react-router-dom';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useAllOrganizationsSelected } from '../../api/hooks/usePartiesSelectors.ts';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import { useDialogActions } from '../DialogDetailsPage/useDialogActions.tsx';
 import type { CurrentSeenByLog } from './Inbox.tsx';
@@ -119,7 +119,7 @@ const useGroupedDialogs = ({
   const { t } = useTranslation();
   const format = useFormat();
   const systemLabelActions = useDialogActions();
-  const { allOrganizationsSelected } = useParties();
+  const allOrganizationsSelected = useAllOrganizationsSelected();
   const collapseGroups = displaySearchResults || (viewType !== 'inbox' && viewType !== 'sent');
   const getCollapsedGroupTitle = (viewType: InboxViewType, count: number, hasNextPage: boolean) =>
     (hasNextPage ? t('word.moreThan') : '') + t(`inbox.heading.title.${viewType}`, { count });

--- a/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
+++ b/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
@@ -44,8 +44,7 @@ export type PreselectedActorModalProps = {
 
 export const PartiesOverviewPage = () => {
   const { t } = useTranslation();
-  const { isSelfIdentifiedUser, parties, selectedParties, allOrganizationsSelected, isLoading, flattenedParties } =
-    useParties();
+  const { isSelfIdentifiedUser, partyGraph, selectedParties, allOrganizationsSelected, isLoading } = useParties();
   const { getAccountAlertSettings, settings } = useSettings({ disabled: isSelfIdentifiedUser, isSelfIdentifiedUser });
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
   const {
@@ -64,13 +63,12 @@ export const PartiesOverviewPage = () => {
 
   const { filters, getFilterLabel, filterState, setFilterState, filteredParties, isSearching } = useAccountFilters({
     searchValue,
-    parties,
+    parties: partyGraph.parties,
     includeDeletedParties: true,
   });
 
   const { accounts, accountGroups } = useAccounts({
     parties: filteredParties,
-    availableParties: parties,
     selectedParties,
     allOrganizationsSelected,
     isLoading,
@@ -154,20 +152,22 @@ export const PartiesOverviewPage = () => {
     as: 'span' as ElementType,
   });
 
+  type OrganizationItemInput = {
+    party: string;
+    name: string;
+    isDeleted: boolean;
+    parentParty?: { party: string } | undefined;
+    subParties?: Array<{ party: string; name: string; isDeleted: boolean }>;
+  };
+
   const createOrganizationItem = (
-    item: {
-      party: string;
-      name: string;
-      isDeleted: boolean;
-      parentId?: string;
-      subParties?: Array<{ party: string; name: string; isDeleted: boolean }>;
-    },
+    item: OrganizationItemInput,
     currentParty: { party: string } | undefined,
   ): AccountOrganizationItemProps => ({
     avatar: {
       type: 'company' as AvatarType,
       name: item.name,
-      variant: item.parentId ? ('outline' as AvatarVariant) : undefined,
+      variant: item.parentParty ? ('outline' as AvatarVariant) : undefined,
       isDeleted: item.isDeleted,
     },
     items: item.subParties?.map((subParty) => createSubPartyItem(subParty, item)),
@@ -178,21 +178,14 @@ export const PartiesOverviewPage = () => {
   });
 
   const getOrganizationAccounts = (
-    currentParty: { party: string } | undefined,
-    parentParty: { party: string } | undefined,
-    flattenedParties: Array<{
-      party: string;
-      name: string;
-      isDeleted: boolean;
-      parentId?: string;
-      subParties?: Array<{ party: string; name: string; isDeleted: boolean }>;
-    }>,
+    currentParty: OrganizationItemInput | undefined,
+    parentParty: OrganizationItemInput | undefined,
   ) => {
-    const organizationAccounts = parentParty
-      ? flattenedParties?.filter((item) => item.party.includes(parentParty.party)) || []
-      : flattenedParties?.filter((item) => item.party.includes(currentParty?.party ?? '')) || [];
-
-    return organizationAccounts?.map((item) => createOrganizationItem(item, currentParty));
+    const root = parentParty ?? currentParty;
+    if (!root) return [];
+    return [root, ...(root.subParties ?? []).map((sub) => ({ ...sub, parentParty: root }))].map((item) =>
+      createOrganizationItem(item, currentParty),
+    );
   };
 
   const PartyDetails = ({
@@ -200,23 +193,13 @@ export const PartiesOverviewPage = () => {
     isCurrentEndUser,
     id,
   }: { type: AccountListItemType; isCurrentEndUser: boolean; id: string }) => {
-    const currentParty = flattenedParties?.find((item) => item.party === id);
-    const parentParty = flattenedParties?.find((item) => item.partyUuid === currentParty?.parentId);
+    const enrichedParty = partyGraph.partyByUrn.get(id);
+    const parentParty = enrichedParty?.parentParty;
 
     const organizationAccounts = useMemo(() => {
       if (type !== 'company') return undefined;
-      return getOrganizationAccounts(
-        currentParty,
-        parentParty,
-        flattenedParties as Array<{
-          party: string;
-          isDeleted: boolean;
-          name: string;
-          parentId?: string;
-          subParties?: Array<{ party: string; name: string; isDeleted: boolean }>;
-        }>,
-      );
-    }, [type, currentParty, parentParty]);
+      return getOrganizationAccounts(enrichedParty, parentParty);
+    }, [type, enrichedParty, parentParty]);
 
     if (isCurrentEndUser) {
       const contactSettings = settings.filter((s) => s.groupId === 'contact');

--- a/packages/frontend/src/pages/Profile/Settings/useSettings.tsx
+++ b/packages/frontend/src/pages/Profile/Settings/useSettings.tsx
@@ -106,13 +106,13 @@ export const useSettings = ({
   isSelfIdentifiedUser = false,
   disabled = false,
 }: UseSettingsInput = {}): UseSettingsOutput => {
-  const { isLoading: isLoadingParties, parties, selectedParties, allOrganizationsSelected } = useParties();
+  const { isLoading: isLoadingParties, partyGraph, selectedParties, allOrganizationsSelected } = useParties();
   const { user, showClientUnits, setShowClientUnits, shouldShowDeletedEntities, updateShowDeletedEntities } =
     useProfile();
   const { t } = useTranslation();
   const [searchString, setSearchString] = useState<string>('');
   const { partiesWithNotificationSettings, uniqueEmailAddresses, uniquePhoneNumbers } =
-    usePartiesWithNotificationSettings(parties);
+    usePartiesWithNotificationSettings(partyGraph.parties);
   const { verifiedAddresses } = useVerifiedAddresses();
 
   const isVerifiedAddress = (value: string, type: 'Email' | 'Sms') =>
@@ -168,7 +168,7 @@ export const useSettings = ({
 
   const { accounts, accountGroups } = useAccounts({
     isLoading: isLoadingParties,
-    parties,
+    parties: partyGraph.parties,
     allOrganizationsSelected,
     selectedParties,
     options: {

--- a/packages/frontend/src/pages/Profile/usePartiesWithNotificationSettings.tsx
+++ b/packages/frontend/src/pages/Profile/usePartiesWithNotificationSettings.tsx
@@ -1,5 +1,6 @@
 import type { PartyFieldsFragment } from 'bff-types-generated';
 import { useMemo } from 'react';
+import { usePartyGraph } from '../../api/hooks/usePartiesSelectors.ts';
 import { updateNotificationsetting } from '../../api/queries.ts';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
@@ -33,14 +34,14 @@ export interface GroupedPhoneNumberType {
 }
 
 export const usePartiesWithNotificationSettings = (parties: PartyFieldsFragment[]) => {
+  const partyGraph = usePartyGraph();
   const { notificationSettingsForCurrentUser } = useNotificationSettingsForCurrentUser();
 
   const partiesKey = useMemo(() => {
     if (!parties?.length) return null;
-    return parties
-      .map((party) => party.partyUuid)
-      .sort((a, b) => a.localeCompare(b))
-      .join(',');
+    // Use count as cache key — partyGraph.parties has stable identity via useMemo,
+    // so a length change is the only meaningful signal for invalidation.
+    return `parties:${parties.length}`;
   }, [parties]);
 
   const { data: partiesWithNotificationSettings = [], isLoading: isLoadingNotificationSettings } =
@@ -51,25 +52,28 @@ export const usePartiesWithNotificationSettings = (parties: PartyFieldsFragment[
         partiesKey,
         notificationSettingsForCurrentUser,
       ],
-      queryFn: async () => {
+      queryFn: () => {
         if (!parties?.length) return [];
 
-        const filteredParties = parties.filter((party) => !party.isCurrentEndUser);
-
-        return await Promise.all(
-          filteredParties.map(async (party) => {
-            const notificationSettings =
-              notificationSettingsForCurrentUser?.find((setting) => setting?.partyUuid === party.partyUuid) ??
-              undefined;
-            return { ...party, notificationSettings, key: party.partyUuid };
-          }),
+        // Pre-index notification settings by partyUuid for O(1) lookups
+        const settingsByUuid = new Map(
+          (notificationSettingsForCurrentUser ?? []).filter((s) => s?.partyUuid).map((s) => [s!.partyUuid, s]),
         );
+
+        return parties
+          .filter((party) => !party.isCurrentEndUser)
+          .map((party) => ({
+            ...party,
+            notificationSettings: settingsByUuid.get(party.partyUuid) ?? undefined,
+            key: party.partyUuid,
+          }));
       },
       enabled: !!parties?.length,
       refetchOnWindowFocus: false,
       staleTime: 1000 * 60 * 10,
     });
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const uniqueEmailAddresses: GroupedEmailAddressType[] = useMemo(() => {
     const emailMap = new Map<string, UniqueEmailAddressType[]>();
     const emails = partiesWithNotificationSettings
@@ -80,7 +84,7 @@ export const usePartiesWithNotificationSettings = (parties: PartyFieldsFragment[
             partyUuid: party.partyUuid,
             name: party.name,
             type: party.partyType === 'Organization' ? 'company' : 'person',
-            hasParentParty: !Array.isArray(party.subParties),
+            hasParentParty: !!partyGraph.partyByUrn.get(party.party)?.parentParty,
           }) as UniqueEmailAddressType,
       )
       .filter(
@@ -101,6 +105,7 @@ export const usePartiesWithNotificationSettings = (parties: PartyFieldsFragment[
     }));
   }, [partiesWithNotificationSettings]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const uniquePhoneNumbers: GroupedPhoneNumberType[] = useMemo(() => {
     const phoneNumberMap = new Map<string, UniquePhoneNumberType[]>();
 
@@ -112,7 +117,7 @@ export const usePartiesWithNotificationSettings = (parties: PartyFieldsFragment[
             partyUuid: party.partyUuid,
             name: party.name,
             type: party.partyType === 'Organization' ? 'company' : 'person',
-            hasParentParty: !Array.isArray(party.subParties),
+            hasParentParty: !!partyGraph.partyByUrn.get(party.party)?.parentParty,
           }) as UniquePhoneNumberType,
       )
       .filter(

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
@@ -1,7 +1,7 @@
 import { BookmarkModal, BookmarkSettingsList, Heading, PageBase, Toolbar } from '@altinn/altinn-components';
 import { type ChangeEvent, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useSelectedPartyIds } from '../../api/hooks/usePartiesSelectors.ts';
 import { getPageRouteTitle } from '../../components/PageLayout/pageRouteToTitle.ts';
 import { usePageTitle } from '../../hooks/usePageTitle.tsx';
 import { PageRoutes } from '../routes.ts';
@@ -11,7 +11,7 @@ import { useSavedSearches } from './useSavedSearches.tsx';
 export const SavedSearchesPage = () => {
   const { t } = useTranslation();
   usePageTitle({ baseTitle: t('sidebar.saved_searches') });
-  const { selectedPartyIds } = useParties();
+  const selectedPartyIds = useSelectedPartyIds();
   const [inputValues, setInputValues] = useState<Record<string, string>>({});
   const [searchQuery, setSearchQuery] = useState('');
   const {
@@ -27,7 +27,6 @@ export const SavedSearchesPage = () => {
   } = useSavedSearches(selectedPartyIds);
   const currentSearch = useMemo(() => items?.find((item) => item.id === openedSavedSearch), [items, openedSavedSearch]);
   const filteredItems = filterBookmarksBySearch(items ?? [], searchQuery);
-
   //set groups priority (for sorting): personal=0, all-organizations=1 and the rest get 2
   const groupOrder: Record<string, number> = { personal: 0, 'all-organizations': 1 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,8 +440,8 @@ importers:
         specifier: ^3.8.0
         version: 3.8.0(react@19.2.3)
       '@tanstack/react-query':
-        specifier: ^5.85.9
-        version: 5.90.20(react@19.2.3)
+        specifier: 5.95.2
+        version: 5.95.2(react@19.2.3)
       '@tanstack/react-virtual':
         specifier: ^3.13.22
         version: 3.13.22(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4077,11 +4077,11 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@tanstack/query-core@5.90.20':
-    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+  '@tanstack/query-core@5.95.2':
+    resolution: {integrity: sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==}
 
-  '@tanstack/react-query@5.90.20':
-    resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
+  '@tanstack/react-query@5.95.2':
+    resolution: {integrity: sha512-/wGkvLj/st5Ud1Q76KF1uFxScV7WeqN1slQx5280ycwAyYkIPGaRZAEgHxe3bjirSd5Zpwkj6zNcR4cqYni/ZA==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -15322,11 +15322,11 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tanstack/query-core@5.90.20': {}
+  '@tanstack/query-core@5.95.2': {}
 
-  '@tanstack/react-query@5.90.20(react@19.2.3)':
+  '@tanstack/react-query@5.95.2(react@19.2.3)':
     dependencies:
-      '@tanstack/query-core': 5.90.20
+      '@tanstack/query-core': 5.95.2
       react: 19.2.3
 
   '@tanstack/react-virtual@3.13.22(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':


### PR DESCRIPTION
Disclosure: This work has heavily been assisted using Claude Opus 4.6, and still needs some proper QA, but the results are pretty good. Now a user with 15_000 parties will be able to use Arbeidsflate.

Performance: optimize party lookups for large party lists

**Problem:** With large party lists (many organizations + sub-parties), the frontend suffered from excessive re-renders and O(n²) lookup patterns — repeated `.find()` / `.flatMap().find()` scans over the full party list on every dialog item, filter, and organization resolution.

**Solution:**

- **Introduced `PartyGraph`** (`partyGraph.ts`) — a precomputed graph structure built once in a single O(n) pass from the normalized party list. Provides O(1) lookups by URN and UUID via `Map`, with pre-resolved parent↔child relationships.

- **Added fine-grained selector hooks** (`usePartiesSelectors.ts`) — `useCurrentPartyUuid()`, `useSelectedProfile()`, `usePartyGraph()`, etc. Components that previously consumed the full `useParties()` hook (subscribing to 7+ state sources) now subscribe only to the slice they need, drastically reducing unnecessary re-renders.

- **Replaced O(n²) organization lookups** in filters and dialog mapping with pre-indexed `Map<id, org>` for O(1) access.

- **Simplified `PartiesOverviewPage`** — removed `flattenedParties` traversal in favor of direct `partyGraph.partyByUrn` lookups and pre-linked `parentParty` references.

- **Refactored `getOrganization()`** to accept both `Map` and array inputs, enabling callers to opt into O(1) lookups without breaking existing call sites.

- **Added comprehensive tests** for `partyGraph`, `mapDialogToInboxItems`, `normalizeParties`, `mapPartyToAuthorizedParty`, and `useAccounts`.


Todo:

- [ ] Fix Sonar complexity issues
- [ ] Fix Playwright tests
- [ ] Fix linting / typecheck complaints

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
