### PR TITLE
chore(infra): Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/extract_polaris_findings.yml
+++ b/.github/workflows/extract_polaris_findings.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -35,6 +35,6 @@ jobs:
           python .github/tools/extract_findings.py "$POLARIS_URL" "$POLARIS_TOKEN" "$POLARIS_PORTFOLIO_ID" "$POLARIS_PROJECT_ID"
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           sarif_file: "polaris_issues.sarif"

--- a/.github/workflows/workflow-e2e-tests.yml
+++ b/.github/workflows/workflow-e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
       failure_timestamp: ${{ steps.generate-timestamp.outputs.timestamp }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Generate timestamp
         id: generate-timestamp
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Check if LAST_E2E_FAILURE variable exists
         id: check_variable
         run: |


### PR DESCRIPTION
## Summary
- Pin `actions/checkout`, `actions/setup-python`, and `github/codeql-action/upload-sarif` to full commit SHAs in workflow files that used mutable version tags
- This is supply chain hardening — prevents tag mutation attacks where a compromised action tag could inject malicious code
- No functional changes; all actions remain at the same effective versions

## Related issue
- https://github.com/Altinn/dialogporten/issues/3697


## Changes
| Action | Pinned SHA | Version |
|--------|-----------|---------|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-python` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| `github/codeql-action/upload-sarif` | `ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3` | v3.34.1 |

## Files modified
- `extract_polaris_findings.yml` — pinned 3 actions (`checkout@v4` → v4.3.1, `setup-python@v5` → v5.6.0, `codeql-action/upload-sarif@v3` → v3.34.1)
- `workflow-e2e-tests.yml` — pinned 2 `checkout@v4` → v4.3.1

## Test plan
- [ ] Verify CI workflows still pass (no functional change, only version pinning)