### PR TITLE
fix: massive improvements to performance for parties calculating and handling

### DIFF
--- a/packages/e2e/tests/saved-searches.spec.ts
+++ b/packages/e2e/tests/saved-searches.spec.ts
@@ -59,7 +59,7 @@ test.describe('Saved Searches', () => {
     await page.goto(`${baseURL}/saved-searches`);
 
     // Step 7: Verify saved search appears
-    await expect(page.locator('#main-content')).toContainText('1 lagret søk', { timeout: 10000 });
+    await expect(page.locator('#main-content')).toContainText('Personlige søk', { timeout: 10000 });
 
     // Step 8: Open saved search menu
     const menuButton = page.getByRole('button', { name: 'Åpne meny' });

--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -31,7 +31,8 @@ import { type OrganizationOutput, getOrganization, getOrganizationByLocale } fro
 import { type TimelineSegmentWithTransmissions, getTransmissions } from '../utils/transmissions.ts';
 import { getViewTypes } from '../utils/viewType.ts';
 import type { InboxViewType } from './useDialogs.tsx';
-import { type ProfileType, useParties } from './useParties.ts';
+import type { ProfileType } from './useParties.ts';
+import { useSelectedProfile } from './usePartiesSelectors.ts';
 
 export enum EmbeddableMediaType {
   markdown = 'application/vnd.dialogporten.frontchannelembed-url;type=text/markdown',
@@ -348,7 +349,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
   const { organizations, isLoading: isOrganizationsLoading } = useOrganizations();
   const queryClient = useQueryClient();
   const disableFlipNamesPatch = useFeatureFlag<boolean>('dialogporten.disableFlipNamesPatch');
-  const { selectedProfile } = useParties();
+  const selectedProfile = useSelectedProfile();
   const partyURIs = parties.map((party) => party.party);
   const { data, isSuccess, isLoading, isError, dataUpdatedAt } = useAuthenticatedQuery<GetDialogByIdQuery>({
     queryKey: [QUERY_KEYS.DIALOG_BY_ID, id],

--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -8,7 +8,7 @@ import type {
   SystemLabel,
 } from 'bff-types-generated';
 import i18n from 'i18next';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useAuthenticatedInfiniteQuery } from '../../auth/useAuthenticatedInfiniteQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useFeatureFlag } from '../../featureFlags';
@@ -19,6 +19,7 @@ import { useOrganizations } from '../../pages/Inbox/useOrganizations.ts';
 import { useProfile } from '../../pages/Profile';
 import { graphQLSDK } from '../queries.ts';
 import { getPartyIds, mapDialogToToInboxItems, mergeDialogItems } from '../utils/dialog.ts';
+import { buildOrganizationMap } from '../utils/organizations.ts';
 import { useParties } from './useParties.ts';
 
 /* Number of max parties used to fetch dialogs with party input param from Dialogporten */
@@ -81,7 +82,7 @@ export const useDialogs = ({
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
   const enableSubAccountsMenu = useFeatureFlag<boolean>('filters.enableSubAccountsMenu');
   const { shouldShowDeletedEntities } = useProfile();
-  const { selectedParties, parties: allParties, allOrganizationsSelected } = useParties();
+  const { selectedParties, allOrganizationsSelected, partyGraph } = useParties();
   const format = useFormat();
 
   const shouldExcludeDeleted = isDeletedUnitsFilterEnabled && !shouldShowDeletedEntities;
@@ -195,7 +196,8 @@ export const useDialogs = ({
     hasNextPage: lastPage?.searchDialogs?.hasNextPage === true,
     itemsIsNull: lastPage?.searchDialogs?.items === null,
   });
-  const dialogs = mapDialogToToInboxItems(content, allParties, organizations, format, disableFlipNamesPatch);
+  const orgMap = useMemo(() => buildOrganizationMap(organizations), [organizations]);
+  const dialogs = mapDialogToToInboxItems(content, partyGraph, orgMap, format, disableFlipNamesPatch);
   /*  isFetching && isPlaceholderData is used to determine if we are fetching the initial data for the query key */
   const isActuallyLoading = isLoading || (isFetching && isPlaceholderData);
 

--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -13,6 +13,7 @@ import {
 import { useGlobalState } from '../../useGlobalState.ts';
 import { graphQLSDK } from '../queries.ts';
 import { normalizeFlattenParties } from '../utils/normalizeFlattenParties.ts';
+import { EMPTY_PARTY_GRAPH, type PartyGraph, buildPartyGraph } from '../utils/partyGraph.ts';
 import { MAX_DIALOG_PARTY_SIZE } from './useDialogs.tsx';
 
 export type ProfileType = 'company' | 'person' | 'neutral';
@@ -31,7 +32,7 @@ interface UsePartiesOutput {
   allOrganizationsSelected: boolean;
   selectedProfile: ProfileType;
   partiesEmptyList: boolean;
-  flattenedParties: FlattenedParty[];
+  partyGraph: PartyGraph;
   currentPartyUuid: string | undefined;
   isSelfIdentifiedUser: boolean;
   selfIdentifiedUserType: SelfIdentifiedUserType;
@@ -44,10 +45,6 @@ const stripQueryParamsForPersonParty = (searchParamString: string) => {
   params.delete(FixedGlobalQueryParams.allParties);
   params.delete(FixedGlobalQueryParams.subAccounts);
   return params.toString();
-};
-
-type FlattenedParty = PartyFieldsFragment & {
-  parentId?: string;
 };
 
 const createPartyParams = (searchParamString: string, key: string, value: string): URLSearchParams => {
@@ -119,7 +116,8 @@ export const useParties = (): UsePartiesOutput => {
       handleChangSearchParams(params);
     }
 
-    const matchedParties = data?.filter((party) => partyIds.includes(party.party)) ?? [];
+    const partyIdSet = new Set(partyIds);
+    const matchedParties = data?.filter((party) => partyIdSet.has(party.party)) ?? [];
     handleSetSelectedParties(matchedParties);
 
     const selectedParty = matchedParties[0];
@@ -132,21 +130,21 @@ export const useParties = (): UsePartiesOutput => {
   };
 
   const selectAllOrganizations = () => {
-    const allOrgParties =
-      data?.filter((party) => party.party.includes('organization')).map((party) => party.party) ?? [];
+    const allOrgParties: string[] = [];
+    for (const [urn] of partyGraph.partyByUrn) {
+      if (urn.includes('organization')) {
+        allOrgParties.push(urn);
+      }
+    }
     setSelectedPartyIds(allOrgParties, true);
   };
 
-  const getPartyFromURL = () => {
-    const partyFromQuery = getSelectedPartyFromQueryParams(searchParams);
-    if (partyFromQuery) {
-      return data?.find((party) => party.party === partyFromQuery);
-    }
-
-    return undefined;
-  };
-
   const currentEndUser = useMemo(() => data?.find((party) => party.isCurrentEndUser), [data]);
+
+  const partyGraph = useMemo(() => {
+    if (!data) return EMPTY_PARTY_GRAPH;
+    return buildPartyGraph(data);
+  }, [data]);
 
   const initializePartySelection = () => {
     // Synchronous guard — prevents multiple hook instances from initializing
@@ -159,9 +157,9 @@ export const useParties = (): UsePartiesOutput => {
       selectAllOrganizations();
     } else {
       const partyFromQuery = getSelectedPartyFromQueryParams(searchParams);
-      const partyFromCookie = cookiePartyUuid ? data?.find((party) => party.partyUuid === cookiePartyUuid) : undefined;
+      const partyFromCookie = cookiePartyUuid ? partyGraph.partyByUuid.get(cookiePartyUuid) : undefined;
       // URL takes highest precedence
-      const orgFromURL = getPartyFromURL();
+      const orgFromURL = partyFromQuery ? partyGraph.partyByUrn.get(partyFromQuery) : undefined;
 
       if (partyFromQuery && orgFromURL) {
         setSelectedPartyIds([orgFromURL.party], false);
@@ -198,8 +196,11 @@ export const useParties = (): UsePartiesOutput => {
     }
   }, [isSuccess, data]);
 
+  // Derive a stable key from only party-related query params to avoid reacting to unrelated URL changes
+  const partyParamKey = `${searchParams.get(FixedGlobalQueryParams.party) ?? ''}|${searchParams.get(FixedGlobalQueryParams.allParties) ?? ''}`;
+
   // Handle URL-driven account switching (after initialization)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Only react to searchParams changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only react to party-related param changes
   useEffect(() => {
     if (!isSuccess || !data?.length || !queryClient.getQueryData(['hasInitializedPartySelection'])) {
       return;
@@ -213,28 +214,17 @@ export const useParties = (): UsePartiesOutput => {
     if (allPartiesParam) {
       selectAllOrganizations();
     } else if (partyParam) {
-      const party = data?.find((p) => p.party === partyParam);
+      const party = partyGraph.partyByUrn.get(partyParam);
       if (party) {
         setSelectedPartyIds([party.party], false);
       }
     }
-  }, [searchParams]);
+  }, [partyParamKey]);
 
   const isCompanyProfile =
     isCompanyFromParams || allOrganizationsSelected || selectedParties?.[0]?.partyType === 'Organization';
 
   const selectedProfile: ProfileType = allOrganizationsSelected ? 'neutral' : isCompanyProfile ? 'company' : 'person';
-
-  const flattenedParties = useMemo(() => {
-    if (!data) return [];
-    return data.flatMap((party) => [
-      party,
-      ...(party.subParties?.map((subParty) => ({
-        ...subParty,
-        parentId: party.partyUuid,
-      })) ?? []),
-    ]) as FlattenedParty[];
-  }, [data]);
 
   const currentPartyUuid = useMemo(() => {
     return allOrganizationsSelected ? currentEndUser?.partyUuid : selectedParties[0]?.partyUuid;
@@ -249,13 +239,15 @@ export const useParties = (): UsePartiesOutput => {
     return 'None';
   }, [currentEndUser]);
 
+  const selectedPartyIds = useMemo(() => selectedParties.map((party) => party.party), [selectedParties]);
+
   return {
     isLoading,
     isSuccess,
     isError,
-    flattenedParties,
+    partyGraph,
     selectedParties,
-    selectedPartyIds: selectedParties.map((party) => party.party) ?? [],
+    selectedPartyIds,
     setSelectedParties: handleSetSelectedParties,
     setSelectedPartyIds,
     parties: data ?? [],

--- a/packages/frontend/src/api/hooks/usePartiesSelectors.ts
+++ b/packages/frontend/src/api/hooks/usePartiesSelectors.ts
@@ -1,0 +1,158 @@
+import { useQuery } from '@tanstack/react-query';
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { useSearchParams } from 'react-router-dom';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
+import type { PartyGraph } from '../utils/partyGraph.ts';
+import { EMPTY_PARTY_GRAPH, buildPartyGraph } from '../utils/partyGraph.ts';
+import type { ProfileType, SelfIdentifiedUserType } from './useParties.ts';
+
+/**
+ * These selector hooks use React Query's `select` option to narrow subscriptions.
+ * `select` is auto-memoized when the function reference is stable (extracted, not inline),
+ * and structural sharing ensures the component only re-renders when the selected value
+ * actually changes — not when the underlying cache entry changes.
+ *
+ * See: https://tanstack.com/query/v5/docs/framework/react/guides/render-optimizations
+ */
+
+/* ── Stable selector functions (never recreated, so React Query memoizes the result) ── */
+const selectCurrentEndUser = (parties: PartyFieldsFragment[]) => parties.find((p) => p.isCurrentEndUser);
+
+const selectEndUserUuid = (parties: PartyFieldsFragment[]) => parties.find((p) => p.isCurrentEndUser)?.partyUuid;
+
+const selectFirstPartyUuid = (parties: PartyFieldsFragment[]) => (parties as PartyFieldsFragment[])[0]?.partyUuid;
+
+const selectFirstPartyType = (parties: PartyFieldsFragment[]) => (parties as PartyFieldsFragment[])[0]?.partyType;
+
+const selectPartyIds = (parties: PartyFieldsFragment[]) => parties.map((p) => p.party);
+
+const selectSelfIdentifiedUserType = (parties: PartyFieldsFragment[]): SelfIdentifiedUserType => {
+  const endUser = parties.find((p) => p.isCurrentEndUser);
+  if (!endUser || endUser.partyType !== 'SelfIdentified') return 'None';
+  if (endUser.party.includes('urn:altinn:person:idporten-email:')) return 'Email';
+  if (endUser.party.includes('urn:altinn:person:legacy-selfidentified:')) return 'Legacy';
+  return 'None';
+};
+
+/* ── Shared query options (no fetch, just read from cache) ── */
+const partiesQueryOptions = {
+  queryKey: [QUERY_KEYS.PARTIES],
+  staleTime: Number.POSITIVE_INFINITY,
+  enabled: false,
+  queryFn: async () => [] as PartyFieldsFragment[],
+};
+
+const selectedPartiesQueryOptions = {
+  queryKey: [QUERY_KEYS.SELECTED_PARTIES],
+  staleTime: Number.POSITIVE_INFINITY,
+  enabled: false,
+  initialData: [] as PartyFieldsFragment[],
+  queryFn: async () => [] as PartyFieldsFragment[],
+};
+
+const allOrgsQueryOptions = {
+  queryKey: [QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED],
+  staleTime: Number.POSITIVE_INFINITY,
+  enabled: false,
+  initialData: false,
+  queryFn: async () => false,
+} as const;
+
+/**
+ * Returns the current party UUID.
+ * Uses `select` to extract only the UUID from each subscription,
+ * so re-renders only when the actual UUID changes.
+ */
+export const useCurrentPartyUuid = (): string | undefined => {
+  const { data: allOrganizationsSelected = false } = useQuery(allOrgsQueryOptions);
+  const { data: selectedPartyUuid } = useQuery({ ...selectedPartiesQueryOptions, select: selectFirstPartyUuid });
+  const { data: endUserUuid } = useQuery({ ...partiesQueryOptions, select: selectEndUserUuid });
+
+  return allOrganizationsSelected ? endUserUuid : selectedPartyUuid;
+};
+
+/**
+ * Returns the selected profile type ('company' | 'person' | 'neutral').
+ * Uses `select` on SELECTED_PARTIES to extract only the partyType.
+ */
+export const useSelectedProfile = (): ProfileType => {
+  const { data: allOrganizationsSelected = false } = useQuery(allOrgsQueryOptions);
+  const { data: firstPartyType } = useQuery({ ...selectedPartiesQueryOptions, select: selectFirstPartyType });
+  const [searchParams] = useSearchParams();
+
+  if (allOrganizationsSelected) return 'neutral';
+
+  const party = searchParams.get('party');
+  const allParties = searchParams.get('allParties');
+  const isCompanyFromParams = Boolean(party || allParties);
+  const isCompanyProfile = isCompanyFromParams || firstPartyType === 'Organization';
+
+  return isCompanyProfile ? 'company' : 'person';
+};
+
+/**
+ * Returns a precomputed PartyGraph for O(1) lookups.
+ * `buildPartyGraph` is a stable reference — React Query only re-runs it when data changes.
+ * Note: PartyGraph uses Maps which aren't structurally sharable,
+ * but PARTIES data is immutable (staleTime: Infinity) so this is fine.
+ */
+export const usePartyGraph = (): PartyGraph => {
+  const { data } = useQuery({
+    ...partiesQueryOptions,
+    select: buildPartyGraph,
+  });
+  return data ?? EMPTY_PARTY_GRAPH;
+};
+
+/**
+ * Returns the current end user party.
+ * Uses `select` with structural sharing — same reference returned if end user unchanged.
+ */
+export const useCurrentEndUser = (): PartyFieldsFragment | undefined => {
+  const { data } = useQuery({
+    ...partiesQueryOptions,
+    select: selectCurrentEndUser,
+  });
+  return data;
+};
+
+/**
+ * Returns whether the user is self-identified.
+ * Subscribes only to: IS_SELF_IDENTIFIED_USER (a boolean, minimal subscription).
+ */
+export const useIsSelfIdentifiedUser = (): boolean => {
+  const { data = false } = useQuery({
+    queryKey: [QUERY_KEYS.IS_SELF_IDENTIFIED_USER],
+    staleTime: Number.POSITIVE_INFINITY,
+    enabled: false,
+    initialData: false,
+    queryFn: async () => false,
+  });
+  return data;
+};
+
+/**
+ * Returns the self-identified user type.
+ * Uses `select` to derive the type directly — returns a primitive string,
+ * so structural sharing ensures no re-render unless the type actually changes.
+ */
+export const useSelfIdentifiedUserType = (): SelfIdentifiedUserType => {
+  const { data = 'None' } = useQuery({
+    ...partiesQueryOptions,
+    select: selectSelfIdentifiedUserType,
+  });
+  return data;
+};
+
+/**
+ * Returns the selected party IDs (URNs).
+ * Uses `select` to map to string[] — structural sharing preserves the array reference
+ * when the IDs haven't changed, preventing downstream re-renders.
+ */
+export const useSelectedPartyIds = (): string[] => {
+  const { data = [] } = useQuery({
+    ...selectedPartiesQueryOptions,
+    select: selectPartyIds,
+  });
+  return data;
+};

--- a/packages/frontend/src/api/hooks/useServiceResource.ts
+++ b/packages/frontend/src/api/hooks/useServiceResource.ts
@@ -10,6 +10,7 @@ import { useParties } from './useParties.ts';
 
 interface UseServiceResourceOutput {
   serviceResources: ServiceResource[];
+  serviceResourceById: Map<string, ServiceResource>;
   isSuccess: boolean;
   isLoading: boolean;
 }
@@ -57,5 +58,13 @@ export const useServiceResource = (): UseServiceResourceOutput => {
     [data?.serviceResources],
   );
 
-  return { serviceResources, isLoading, isSuccess };
+  const serviceResourceById = useMemo(() => {
+    const map = new Map<string, ServiceResource>();
+    for (const sr of serviceResources) {
+      if (sr.id) map.set(sr.id, sr);
+    }
+    return map;
+  }, [serviceResources]);
+
+  return { serviceResources, serviceResourceById, isLoading, isSuccess };
 };

--- a/packages/frontend/src/api/utils/dialog.ts
+++ b/packages/frontend/src/api/utils/dialog.ts
@@ -1,7 +1,6 @@
 import {
   DialogStatus,
   type GetAllDialogsForPartiesQueryVariables,
-  type OrganizationFieldsFragment,
   type PartyFieldsFragment,
   type SearchDialogFieldsFragment,
   SystemLabel,
@@ -13,7 +12,13 @@ import type { InboxItemInput } from '../../pages/Inbox/InboxItemInput.ts';
 import { getIsUnread } from '../../pages/Inbox/status.ts';
 import { getActorProps } from '../hooks/useDialogById.tsx';
 import type { InboxViewType } from '../hooks/useDialogs.tsx';
-import { type OrganizationOutput, getOrganization, getOrganizationByLocale } from './organizations.ts';
+import {
+  type OrganizationLookup,
+  type OrganizationOutput,
+  getOrganization,
+  getOrganizationByLocale,
+} from './organizations.ts';
+import type { PartyGraph } from './partyGraph.ts';
 import { getViewTypes } from './viewType.ts';
 
 interface SeenByItem {
@@ -58,26 +63,25 @@ export const getSeenByLabel = (
 
 export function mapDialogToToInboxItems(
   input: SearchDialogFieldsFragment[],
-  parties: PartyFieldsFragment[],
-  organizations: OrganizationFieldsFragment[],
+  partyGraph: PartyGraph,
+  organizations: OrganizationLookup,
   format: FormatFunction,
   stopReversingPersonNameOrder: boolean,
 ): InboxItemInput[] {
+  const endUserParty = partyGraph.currentEndUser;
+
   return input.map((item) => {
     const titleObj = item.content.title.value;
     const summaryObj = item.content.summary?.value;
-    const endUserParty = parties?.find((party) => party.isCurrentEndUser);
     const senderName = item.content.senderName?.value;
     const extendedStatusObj = item.content.extendedStatus?.value;
 
-    const dialogReceiverParty = parties?.find((party) => party.party === item.party);
-    const dialogReceiverSubParty = parties
-      ?.flatMap((party) => party.subParties ?? [])
-      .find((subParty) => subParty.party === item.party);
+    const receiverParty = partyGraph.partyByUrn.get(item.party);
+    const isSubParty = partyGraph.parentByChildUrn.has(item.party);
+    const actualReceiverParty = receiverParty ?? endUserParty;
 
-    const actualReceiverParty = dialogReceiverParty ?? dialogReceiverSubParty ?? endUserParty;
-    const serviceOwner = getOrganization(organizations || [], item.org);
-    const serviceOwnerNbName = getOrganizationByLocale(organizations || [], item.org, 'nb')?.name;
+    const serviceOwner = getOrganization(organizations, item.org);
+    const serviceOwnerNbName = getOrganizationByLocale(organizations, item.org, 'nb')?.name;
     const { isSeenByEndUser, seenByOthersCount, seenByLabel } = getSeenByLabel(item.seenSinceLastContentUpdate, t);
 
     return {
@@ -97,12 +101,9 @@ export function mapDialogToToInboxItems(
         imageUrlAlt: t('dialog.imageAltURL', { companyName: getPreferredPropertyByLocale(senderName)?.value }),
       },
       recipient: {
-        name: actualReceiverParty?.name ?? dialogReceiverSubParty?.name ?? '',
+        name: actualReceiverParty?.name ?? '',
         type: actualReceiverParty?.partyType === 'Organization' ? 'company' : 'person',
-        variant:
-          dialogReceiverParty && !dialogReceiverParty.subParties && actualReceiverParty?.partyType === 'Organization'
-            ? 'outline'
-            : 'solid',
+        variant: receiverParty && isSubParty && actualReceiverParty?.partyType === 'Organization' ? 'outline' : 'solid',
       },
       serviceResourceType: item.serviceResourceType,
       color: actualReceiverParty?.partyType === 'Organization' ? 'company' : 'person',

--- a/packages/frontend/src/api/utils/mapDialogToInboxItems.spec.ts
+++ b/packages/frontend/src/api/utils/mapDialogToInboxItems.spec.ts
@@ -1,0 +1,161 @@
+import type { OrganizationFieldsFragment, PartyFieldsFragment, SearchDialogFieldsFragment } from 'bff-types-generated';
+import { describe, expect, it, vi } from 'vitest';
+import { mapDialogToToInboxItems } from './dialog.ts';
+import { buildOrganizationMap } from './organizations.ts';
+import { buildPartyGraph } from './partyGraph.ts';
+
+vi.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock('../../i18n/property.ts', () => ({
+  getPreferredPropertyByLocale: (obj: { languageCode: string; value: string }[] | undefined) => obj?.[0],
+}));
+
+vi.mock('../../pages/Inbox/status.ts', () => ({
+  getIsUnread: () => false,
+}));
+
+vi.mock('../hooks/useDialogById.tsx', () => ({
+  getActorProps: () => ({ name: 'Actor', type: 'company' }),
+}));
+
+vi.mock('./viewType.ts', () => ({
+  getViewTypes: () => ['inbox'],
+}));
+
+const personParty: PartyFieldsFragment = {
+  party: 'urn:altinn:person:identifier-no:11111111111',
+  partyType: 'Person',
+  name: 'Test User',
+  isCurrentEndUser: true,
+  isDeleted: false,
+  partyUuid: 'uuid-person',
+  partyId: 1,
+  hasOnlyAccessToSubParties: false,
+  subParties: [],
+};
+
+const orgParty: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:999888777',
+  partyType: 'Organization',
+  name: 'Test Org AS',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  partyUuid: 'uuid-org',
+  partyId: 2,
+  hasOnlyAccessToSubParties: false,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:999888001',
+      partyType: 'Organization',
+      name: 'Sub Org',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-sub',
+      partyId: 3,
+    },
+  ],
+};
+
+const promotedSubParty: PartyFieldsFragment = {
+  party: 'urn:altinn:organization:identifier-no:999888001',
+  partyType: 'Organization',
+  name: 'Sub Org',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  partyUuid: 'uuid-sub',
+  partyId: 3,
+  hasOnlyAccessToSubParties: false,
+  subParties: [],
+};
+
+const parties = [personParty, orgParty, promotedSubParty];
+const partyGraph = buildPartyGraph(parties);
+
+const organizations: OrganizationFieldsFragment[] = [
+  {
+    id: 'org-1',
+    name: { nb: 'Skatteetaten', nn: 'Skatteetaten', en: 'Tax Administration' },
+    logo: 'https://example.com/logo.png',
+  },
+];
+const orgMap = buildOrganizationMap(organizations);
+
+const mockFormat = (date: string | Date, _fmt: string) => String(date);
+
+const createDialog = (overrides: Partial<SearchDialogFieldsFragment> = {}): SearchDialogFieldsFragment =>
+  ({
+    id: 'dialog-1',
+    party: orgParty.party,
+    org: 'org-1',
+    status: 'InProgress',
+    contentUpdatedAt: '2024-01-01T00:00:00Z',
+    createdAt: '2024-01-01T00:00:00Z',
+    guiAttachmentCount: 0,
+    serviceResourceType: 'GenericAccessResource',
+    dueAt: null,
+    hasUnopenedContent: false,
+    fromServiceOwnerTransmissionsCount: 0,
+    fromPartyTransmissionsCount: 0,
+    serviceResource: 'urn:altinn:resource:test',
+    endUserContext: { systemLabels: [] },
+    seenSinceLastContentUpdate: [],
+    content: {
+      title: { value: [{ languageCode: 'nb', value: 'Test Dialog' }] },
+      summary: { value: [{ languageCode: 'nb', value: 'Summary' }] },
+      senderName: { value: [{ languageCode: 'nb', value: 'Skatteetaten' }] },
+      extendedStatus: null,
+    },
+    ...overrides,
+  }) as unknown as SearchDialogFieldsFragment;
+
+describe('mapDialogToToInboxItems', () => {
+  it('should map a dialog to an inbox item with correct receiver', () => {
+    const result = mapDialogToToInboxItems([createDialog()], partyGraph, orgMap, mockFormat, false);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('dialog-1');
+    expect(result[0].recipient.name).toBe('Test Org AS');
+    expect(result[0].recipient.type).toBe('company');
+    expect(result[0].recipient.variant).toBe('solid');
+  });
+
+  it('should set outline variant for sub-party receivers', () => {
+    const dialog = createDialog({ party: promotedSubParty.party });
+    const result = mapDialogToToInboxItems([dialog], partyGraph, orgMap, mockFormat, false);
+
+    expect(result[0].recipient.name).toBe('Sub Org');
+    expect(result[0].recipient.variant).toBe('outline');
+  });
+
+  it('should fall back to end user party when dialog party is not found', () => {
+    const dialog = createDialog({ party: 'urn:altinn:unknown:123' });
+    const result = mapDialogToToInboxItems([dialog], partyGraph, orgMap, mockFormat, false);
+
+    expect(result[0].recipient.name).toBe('Test User');
+    expect(result[0].recipient.type).toBe('person');
+  });
+
+  it('should resolve organization name from orgMap', () => {
+    const result = mapDialogToToInboxItems([createDialog()], partyGraph, orgMap, mockFormat, false);
+
+    expect(result[0].org).toBe('org-1');
+  });
+
+  it('should handle empty input array', () => {
+    const result = mapDialogToToInboxItems([], partyGraph, orgMap, mockFormat, false);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle multiple dialogs efficiently', () => {
+    const dialogs = Array.from({ length: 1000 }, (_, i) => createDialog({ id: `dialog-${i}` }));
+
+    const start = performance.now();
+    const result = mapDialogToToInboxItems(dialogs, partyGraph, orgMap, mockFormat, false);
+    const elapsed = performance.now() - start;
+
+    expect(result).toHaveLength(1000);
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/packages/frontend/src/api/utils/normalizeFlattenParties.ts
+++ b/packages/frontend/src/api/utils/normalizeFlattenParties.ts
@@ -6,32 +6,37 @@ type PartyField = PartyFieldsFragment | SubPartyFieldsFragment;
  where name of parent differs from sub parties
  */
 export const normalizeFlattenParties = (parties: PartyFieldsFragment[]): PartyFieldsFragment[] => {
-  const partiesInTitleCase =
-    parties.map((party) => ({
-      ...party,
-      name: formatDisplayName({
-        fullName: party.name,
-        type: party.partyType === 'Person' ? 'person' : 'company',
-      }),
-      subParties: party.subParties?.map((subParty) => ({
+  const result: PartyField[] = [];
+  /* Cache formatted names – many sub-parties share the same name/type combination */
+  const nameCache = new Map<string, string>();
+  const cachedFormat = (fullName: string, type: 'person' | 'company'): string => {
+    const key = `${type}:${fullName}`;
+    let cached = nameCache.get(key);
+    if (cached === undefined) {
+      cached = formatDisplayName({ fullName, type });
+      nameCache.set(key, cached);
+    }
+    return cached;
+  };
+
+  for (const party of parties) {
+    const partyType = party.partyType === 'Person' ? 'person' : 'company';
+    const subParties =
+      party.subParties?.map((subParty) => ({
         ...subParty,
-        name: formatDisplayName({
-          fullName: subParty.name,
-          type: subParty.partyType === 'Person' ? 'person' : 'company',
-        }),
-      })),
-    })) ?? [];
+        name: cachedFormat(subParty.name, subParty.partyType === 'Person' ? 'person' : 'company'),
+      })) ?? [];
 
-  return partiesInTitleCase.reduce<PartyField[]>((acc, party) => {
-    const subParties = party.subParties ?? [];
-
-    acc.push({
+    result.push({
       ...party,
+      name: cachedFormat(party.name, partyType),
       subParties,
     });
-    // Promote others
-    acc.push(...subParties);
 
-    return acc;
-  }, []) as PartyFieldsFragment[];
+    for (const sub of subParties) {
+      result.push(sub);
+    }
+  }
+
+  return result as PartyFieldsFragment[];
 };

--- a/packages/frontend/src/api/utils/organizations.ts
+++ b/packages/frontend/src/api/utils/organizations.ts
@@ -6,12 +6,21 @@ export interface OrganizationOutput {
   logo: string;
 }
 
+export type OrganizationLookup = OrganizationFieldsFragment[] | Map<string, OrganizationFieldsFragment>;
+
+const resolveOrg = (organizations: OrganizationLookup, orgId: string): OrganizationFieldsFragment | undefined => {
+  if (organizations instanceof Map) {
+    return organizations.get(orgId);
+  }
+  return organizations?.find((o) => o.id === orgId);
+};
+
 export const getOrganizationByLocale = (
-  organizations: OrganizationFieldsFragment[],
+  organizations: OrganizationLookup,
   org: string,
   locale: string,
 ): OrganizationOutput | undefined => {
-  const currentOrg = organizations?.find((o) => o.id === (org as string));
+  const currentOrg = resolveOrg(organizations, org);
   const name = currentOrg?.name && (currentOrg.name[locale as keyof typeof currentOrg.name] ?? '');
   const logo = currentOrg?.logo ?? '';
   return {
@@ -20,9 +29,19 @@ export const getOrganizationByLocale = (
   };
 };
 
-export const getOrganization = (
-  organizations: OrganizationFieldsFragment[],
-  org: string,
-): OrganizationOutput | undefined => {
+export const getOrganization = (organizations: OrganizationLookup, org: string): OrganizationOutput | undefined => {
   return getOrganizationByLocale(organizations, org, i18n.language);
+};
+
+export const buildOrganizationMap = (
+  organizations: OrganizationFieldsFragment[] | undefined | null,
+): Map<string, OrganizationFieldsFragment> => {
+  const map = new Map<string, OrganizationFieldsFragment>();
+  if (!organizations) return map;
+  for (const org of organizations) {
+    if (org.id) {
+      map.set(org.id, org);
+    }
+  }
+  return map;
 };

--- a/packages/frontend/src/api/utils/partyGraph.spec.ts
+++ b/packages/frontend/src/api/utils/partyGraph.spec.ts
@@ -1,0 +1,196 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { describe, expect, it } from 'vitest';
+import { EMPTY_PARTY_GRAPH, buildPartyGraph } from './partyGraph.ts';
+
+const createParty = (overrides: Partial<PartyFieldsFragment> = {}): PartyFieldsFragment => ({
+  party: 'urn:altinn:person:identifier-no:12345678901',
+  partyType: 'Person',
+  name: 'Test Person',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  partyUuid: 'uuid-person-1',
+  partyId: 1,
+  hasOnlyAccessToSubParties: false,
+  subParties: [],
+  ...overrides,
+});
+
+const personParty = createParty({
+  party: 'urn:altinn:person:identifier-no:11111111111',
+  partyType: 'Person',
+  name: 'Test Testesen',
+  isCurrentEndUser: true,
+  partyUuid: 'uuid-person-enduser',
+  partyId: 1,
+});
+
+const orgParty = createParty({
+  party: 'urn:altinn:organization:identifier-no:999888777',
+  partyType: 'Organization',
+  name: 'Test Org AS',
+  isCurrentEndUser: false,
+  partyUuid: 'uuid-org-1',
+  partyId: 2,
+  subParties: [
+    {
+      party: 'urn:altinn:organization:identifier-no:999888001',
+      partyType: 'Organization',
+      name: 'Sub Org A',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-sub-a',
+      partyId: 3,
+    },
+    {
+      party: 'urn:altinn:organization:identifier-no:999888002',
+      partyType: 'Organization',
+      name: 'Sub Org B',
+      isCurrentEndUser: false,
+      isDeleted: true,
+      partyUuid: 'uuid-sub-b',
+      partyId: 4,
+    },
+  ],
+});
+
+const promotedSubA = createParty({
+  party: 'urn:altinn:organization:identifier-no:999888001',
+  partyType: 'Organization',
+  name: 'Sub Org A',
+  isCurrentEndUser: false,
+  partyUuid: 'uuid-sub-a',
+  partyId: 3,
+  subParties: [],
+});
+
+const promotedSubB = createParty({
+  party: 'urn:altinn:organization:identifier-no:999888002',
+  partyType: 'Organization',
+  name: 'Sub Org B',
+  isCurrentEndUser: false,
+  isDeleted: true,
+  partyUuid: 'uuid-sub-b',
+  partyId: 4,
+  subParties: [],
+});
+
+const parties: PartyFieldsFragment[] = [personParty, orgParty, promotedSubA, promotedSubB];
+
+describe('buildPartyGraph', () => {
+  it('should build a graph with O(1) URN lookups for all parties', () => {
+    const graph = buildPartyGraph(parties);
+
+    expect(graph.partyByUrn.get(personParty.party)).toBe(personParty);
+    expect(graph.partyByUrn.get(orgParty.party)).toBe(orgParty);
+    expect(graph.partyByUrn.get(promotedSubA.party)).toBe(promotedSubA);
+    expect(graph.partyByUrn.get(promotedSubB.party)).toBe(promotedSubB);
+    expect(graph.partyByUrn.size).toBe(4);
+  });
+
+  it('should build a graph with O(1) UUID lookups', () => {
+    const graph = buildPartyGraph(parties);
+
+    expect(graph.partyByUuid.get('uuid-person-enduser')).toBe(personParty);
+    expect(graph.partyByUuid.get('uuid-org-1')).toBe(orgParty);
+    expect(graph.partyByUuid.get('uuid-sub-a')).toBe(promotedSubA);
+    expect(graph.partyByUuid.get('uuid-sub-b')).toBe(promotedSubB);
+  });
+
+  it('should resolve parent party for sub-parties via parentByChildUrn', () => {
+    const graph = buildPartyGraph(parties);
+
+    expect(graph.parentByChildUrn.get(promotedSubA.party)).toBe(orgParty);
+    expect(graph.parentByChildUrn.get(promotedSubB.party)).toBe(orgParty);
+    expect(graph.parentByChildUrn.has(personParty.party)).toBe(false);
+    expect(graph.parentByChildUrn.has(orgParty.party)).toBe(false);
+  });
+
+  it('should identify the current end user', () => {
+    const graph = buildPartyGraph(parties);
+
+    expect(graph.currentEndUser).toBe(personParty);
+  });
+
+  it('should pick the first current end user when multiple exist', () => {
+    const secondEndUser = createParty({
+      party: 'urn:altinn:person:identifier-no:22222222222',
+      name: 'Second User',
+      isCurrentEndUser: true,
+      partyUuid: 'uuid-person-2',
+    });
+    const graph = buildPartyGraph([personParty, secondEndUser]);
+
+    expect(graph.currentEndUser).toBe(personParty);
+  });
+
+  it('should return undefined currentEndUser when none exists', () => {
+    const noEndUser = [
+      createParty({ isCurrentEndUser: false, partyUuid: 'a' }),
+      createParty({ party: 'urn:altinn:organization:identifier-no:111', isCurrentEndUser: false, partyUuid: 'b' }),
+    ];
+    const graph = buildPartyGraph(noEndUser);
+
+    expect(graph.currentEndUser).toBeUndefined();
+  });
+
+  it('should handle an empty party list', () => {
+    const graph = buildPartyGraph([]);
+
+    expect(graph.partyByUrn.size).toBe(0);
+    expect(graph.partyByUuid.size).toBe(0);
+    expect(graph.parentByChildUrn.size).toBe(0);
+    expect(graph.currentEndUser).toBeUndefined();
+  });
+
+  it('should handle parties without sub-parties', () => {
+    const standalone = createParty({
+      party: 'urn:altinn:organization:identifier-no:555',
+      partyUuid: 'uuid-standalone',
+      subParties: undefined,
+    });
+    const graph = buildPartyGraph([standalone]);
+
+    expect(graph.partyByUrn.get(standalone.party)).toBe(standalone);
+    expect(graph.parentByChildUrn.size).toBe(0);
+  });
+
+  it('should handle large party lists efficiently', () => {
+    const largeList: PartyFieldsFragment[] = [];
+    for (let i = 0; i < 15_000; i++) {
+      largeList.push(
+        createParty({
+          party: `urn:altinn:organization:identifier-no:${String(i).padStart(9, '0')}`,
+          partyUuid: `uuid-${i}`,
+          partyId: i,
+          name: `Org ${i}`,
+        }),
+      );
+    }
+
+    const start = performance.now();
+    const graph = buildPartyGraph(largeList);
+    const elapsed = performance.now() - start;
+
+    expect(graph.partyByUrn.size).toBe(15_000);
+    expect(graph.partyByUuid.size).toBe(15_000);
+    // Should complete in well under 100ms even for 15k parties
+    expect(elapsed).toBeLessThan(100);
+
+    // O(1) lookup should be instant
+    const lookupStart = performance.now();
+    const party = graph.partyByUrn.get('urn:altinn:organization:identifier-no:000007500');
+    const lookupElapsed = performance.now() - lookupStart;
+
+    expect(party?.name).toBe('Org 7500');
+    expect(lookupElapsed).toBeLessThan(1);
+  });
+});
+
+describe('EMPTY_PARTY_GRAPH', () => {
+  it('should have empty maps and undefined currentEndUser', () => {
+    expect(EMPTY_PARTY_GRAPH.partyByUrn.size).toBe(0);
+    expect(EMPTY_PARTY_GRAPH.partyByUuid.size).toBe(0);
+    expect(EMPTY_PARTY_GRAPH.parentByChildUrn.size).toBe(0);
+    expect(EMPTY_PARTY_GRAPH.currentEndUser).toBeUndefined();
+  });
+});

--- a/packages/frontend/src/api/utils/partyGraph.ts
+++ b/packages/frontend/src/api/utils/partyGraph.ts
@@ -1,0 +1,45 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+
+export interface PartyGraph {
+  /** O(1) lookup of any party (top-level or promoted sub-party) by its URN */
+  partyByUrn: Map<string, PartyFieldsFragment>;
+  /** O(1) lookup of any party by its UUID */
+  partyByUuid: Map<string, PartyFieldsFragment>;
+  /** O(1) lookup of parent party for a sub-party, keyed by sub-party URN */
+  parentByChildUrn: Map<string, PartyFieldsFragment>;
+  /** The current end user party (first match) */
+  currentEndUser: PartyFieldsFragment | undefined;
+}
+
+export const EMPTY_PARTY_GRAPH: PartyGraph = {
+  partyByUrn: new Map(),
+  partyByUuid: new Map(),
+  parentByChildUrn: new Map(),
+  currentEndUser: undefined,
+};
+
+/**
+ * Builds a precomputed graph from the normalized (flattened) party list in a single O(n) pass.
+ * Provides O(1) lookups by URN and UUID, with pre-resolved parent↔child relationships.
+ */
+export function buildPartyGraph(parties: PartyFieldsFragment[]): PartyGraph {
+  const partyByUrn = new Map<string, PartyFieldsFragment>();
+  const partyByUuid = new Map<string, PartyFieldsFragment>();
+  const parentByChildUrn = new Map<string, PartyFieldsFragment>();
+  let currentEndUser: PartyFieldsFragment | undefined;
+
+  for (const party of parties) {
+    partyByUrn.set(party.party, party);
+    if (party.partyUuid) {
+      partyByUuid.set(party.partyUuid, party);
+    }
+    if (party.isCurrentEndUser && !currentEndUser) {
+      currentEndUser = party;
+    }
+    for (const sub of party.subParties ?? []) {
+      parentByChildUrn.set(sub.party, party);
+    }
+  }
+
+  return { partyByUrn, partyByUuid, parentByChildUrn, currentEndUser };
+}

--- a/packages/frontend/src/components/BetaModal/BetaModal.tsx
+++ b/packages/frontend/src/components/BetaModal/BetaModal.tsx
@@ -2,7 +2,7 @@ import { Button, Checkbox, Modal, Typography } from '@altinn/altinn-components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors';
 import { getAboutNewAltinnLink } from '../../auth';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { pruneSearchQueryParams } from '../../pages/Inbox/queryParams.ts';
@@ -18,7 +18,7 @@ const PROFILE_PARTIES_ONBOARDING_KEY = 'arbeidsflate:profile-parties-onboarding-
 export const BetaModal = () => {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   const searchParams = new URLSearchParams(window.location.search);
   const isMock = searchParams.get('mock') === 'true';
   const [isOpen, setIsOpen] = useState<boolean>(localStorage.getItem(betaKey) === null);

--- a/packages/frontend/src/components/EmptyState/EmptyState.tsx
+++ b/packages/frontend/src/components/EmptyState/EmptyState.tsx
@@ -2,7 +2,7 @@ import { Heading, Typography } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink } from '../../auth';
 
 interface EmptyStateProps {
@@ -12,7 +12,7 @@ interface EmptyStateProps {
 
 export const EmptyState = ({ viewType, savable }: EmptyStateProps) => {
   const { t } = useTranslation();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   if (savable) {
     return (
       <Typography size="sm">

--- a/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
+++ b/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
@@ -2,7 +2,7 @@ import { FloatingDropdown as FloatingDropdownAc } from '@altinn/altinn-component
 import { ExternalLinkIcon, LeaveIcon, QuestionmarkIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors';
 import { createMessageBoxLink, getNeedHelpLink } from '../../auth';
 import { QUERY_KEYS } from '../../constants/queryKeys';
 import { i18n } from '../../i18n/config';
@@ -21,7 +21,7 @@ export const FloatingDropdown = () => {
   const [_, setShowTour] = useGlobalState<boolean>(QUERY_KEYS.SHOW_TOUR, false);
   const [__, setShowProfileTour] = useGlobalState<boolean>(QUERY_KEYS.SHOW_PROFILE_TOUR, false);
 
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
 
   const isTourBlacklisted = TOUR_BLACKLISTED_PAGES.includes(location.pathname as PageRoutes);
 

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.spec.ts
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.spec.ts
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCustomWrapper } from '../../../../utils/test-utils.tsx';
 import { useParties } from '../../../api/hooks/useParties.ts';
+import { buildPartyGraph } from '../../../api/utils/partyGraph.ts';
 import { useProfile } from '../../../pages/Profile';
 import { formatNorwegianId, formatSSN, useAccounts } from './useAccounts.tsx';
 
@@ -135,7 +136,10 @@ describe('useAccounts', () => {
     vi.clearAllMocks();
 
     (useTranslation as Mock).mockReturnValue({ t: mockT });
-    (useParties as Mock).mockReturnValue({ setSelectedPartyIds: mockSetSelectedPartyIds });
+    (useParties as Mock).mockReturnValue({
+      setSelectedPartyIds: mockSetSelectedPartyIds,
+      partyGraph: buildPartyGraph(parties),
+    });
     (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
   });
 

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
@@ -9,10 +9,11 @@ import type {
 import { useQueryClient } from '@tanstack/react-query';
 import type { PartyFieldsFragment } from 'bff-types-generated';
 import i18n from 'i18next';
-import { type ChangeEvent, type ReactNode, useMemo, useState } from 'react';
+import { type ChangeEvent, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useParties } from '../../../api/hooks/useParties.ts';
+import type { PartyGraph } from '../../../api/utils/partyGraph.ts';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { useFeatureFlag } from '../../../featureFlags';
 import { FixedGlobalQueryParams } from '../../../pages/Inbox/queryParams.ts';
@@ -48,6 +49,8 @@ interface UseAccountsProps {
   options?: UseAccountOptions;
   isLoading?: boolean;
   availableParties?: PartyFieldsFragment[];
+  /** Pre-built party graph to avoid duplicate O(n) graph construction. Falls back to useParties().partyGraph */
+  partyGraph?: PartyGraph;
 }
 
 interface UseAccountsOutput {
@@ -87,11 +90,17 @@ export const formatNorwegianId = (partyId: string, isCurrentEndUser: boolean) =>
   return [ssnOrOrgNo.slice(0, 3), ssnOrOrgNo.slice(3, 6), ssnOrOrgNo.slice(6, 9)].join('\u2009');
 };
 
-const compareName = (a: string, b: string) =>
-  a.localeCompare(b, i18n.language, {
-    sensitivity: 'base',
-    ignorePunctuation: true,
-  });
+/** Reuse a single Intl.Collator per language – ~10-50x faster than localeCompare per call */
+let _collatorLang = '';
+let _collator: Intl.Collator;
+const getCollator = (): Intl.Collator => {
+  if (_collatorLang !== i18n.language) {
+    _collatorLang = i18n.language;
+    _collator = new Intl.Collator(i18n.language, { sensitivity: 'base' });
+  }
+  return _collator;
+};
+const compareName = (a: string, b: string) => getCollator().compare(a, b);
 
 export const useAccounts = ({
   parties,
@@ -99,18 +108,18 @@ export const useAccounts = ({
   allOrganizationsSelected,
   options: inputOptions,
   isLoading,
-  availableParties: availablePartiesInput,
+  availableParties: _availableParties,
+  partyGraph: externalPartyGraph,
 }: UseAccountsProps): UseAccountsOutput => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { setSelectedPartyIds } = useParties();
+  const { setSelectedPartyIds, partyGraph: hookPartyGraph } = useParties();
   const { user, favoritesGroup, shouldShowDeletedEntities } = useProfile();
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
   const [searchString, setSearchString] = useState<string>('');
   const queryClient = useQueryClient();
   const accountSearchThreshold = 2;
   const showSearch = parties.length > accountSearchThreshold;
-  const availableParties = availablePartiesInput ?? parties;
 
   const loadingAccountMenuItem: AccountMenuItemProps = {
     id: 'loading-account',
@@ -120,12 +129,6 @@ export const useAccounts = ({
     icon: { name: '', type: 'person' },
     name: '',
   };
-
-  const currentEndUser = useMemo(() => {
-    return parties.find(
-      (party) => (party.partyType === 'Person' || party.partyType === 'SelfIdentified') && party.isCurrentEndUser,
-    );
-  }, [parties]);
 
   const otherPeople = useMemo(
     () => parties.filter((party) => party.partyType === 'Person' && !party.isCurrentEndUser),
@@ -156,6 +159,8 @@ export const useAccounts = ({
 
   const options = { ...defaultOptions, ...inputOptions };
 
+  const favoritesSet = useMemo(() => new Set(favoritesGroup?.parties ?? []), [favoritesGroup?.parties]);
+
   const otherPeopleAccounts = useMemo<PartyItemProp[]>(() => {
     return otherPeople
       .map((person) => {
@@ -172,7 +177,7 @@ export const useAccounts = ({
           type: 'person' as AccountMenuItemProps['type'],
           icon: { name: person.name, type: 'person' as AvatarType },
           isDeleted: person.isDeleted,
-          isFavorite: favoritesGroup?.parties?.includes(person.partyUuid) || isPreselectedParty,
+          isFavorite: favoritesSet.has(person.partyUuid) || isPreselectedParty,
           isPreselectedParty,
           isCurrentEndUser: false,
           uuid: person.partyUuid,
@@ -182,16 +187,19 @@ export const useAccounts = ({
         } as PartyItemProp;
       })
       .sort((a, b) => compareName(a.name, b.name));
-  }, [allOrganizationsSelected, otherPeople, favoritesGroup, options.showDescription, t, selectedParties, user]);
+  }, [allOrganizationsSelected, otherPeople, favoritesSet, options.showDescription, t, selectedParties, user]);
+
+  const availablePartiesGraph = externalPartyGraph ?? hookPartyGraph;
+
+  const currentEndUser = availablePartiesGraph.currentEndUser;
 
   const organizationAccounts = useMemo<PartyItemProp[]>(() => {
     const mapped = organizations.map((party) => {
-      const isParent = Array.isArray(availableParties.find((p) => p.party === party.party)?.subParties);
+      const matchInAvailable = availablePartiesGraph.partyByUrn.get(party.party);
+      const isParent = Array.isArray(matchInAvailable?.subParties);
       const isPreselectedParty = user?.profileSettingPreference?.preselectedPartyUuid === party.partyUuid;
 
-      const parent = isParent
-        ? undefined
-        : availableParties.find((org) => org?.subParties?.some((sub) => sub.party === party.party));
+      const parent = isParent ? undefined : availablePartiesGraph.parentByChildUrn.get(party.party);
 
       const description =
         parent?.name && party?.party
@@ -216,7 +224,7 @@ export const useAccounts = ({
           isDeleted: party.isDeleted,
         },
         isDeleted: party.isDeleted,
-        isFavorite: favoritesGroup?.parties?.includes(party.partyUuid) || isPreselectedParty,
+        isFavorite: favoritesSet.has(party.partyUuid) || isPreselectedParty,
         isPreselectedParty,
         isCurrentEndUser: false,
         uuid: party.partyUuid,
@@ -258,32 +266,12 @@ export const useAccounts = ({
     selectedParties,
     allOrganizationsSelected,
     organizations,
-    availableParties,
-    favoritesGroup,
+    availablePartiesGraph,
+    favoritesSet,
     options.showDescription,
     t,
     user,
   ]);
-
-  if (isLoading) {
-    return {
-      accounts: [loadingAccountMenuItem as PartyItemProp],
-      accountGroups: { loading: { title: t('profile.accounts.loading') } },
-      accountSearch: undefined,
-      onSelectAccount: () => {},
-      currentAccountName: '',
-    };
-  }
-
-  if (!selectedParties?.length) {
-    return {
-      accounts: [],
-      accountGroups: {},
-      accountSearch: undefined,
-      onSelectAccount: () => {},
-      currentAccountName: '',
-    };
-  }
 
   /** deleted units filtering - FF: "inbox.enableDeletedUnitsFilter"
    * FF off -> always include deleted parties
@@ -293,132 +281,184 @@ export const useAccounts = ({
   const shouldExcludeDeleted = options.excludeDeleted ?? true;
   const includeDeletedParties = isDeletedUnitsFilterEnabled ? (shouldShowDeletedEntities ?? false) : true;
 
-  const accountGroups = {
-    ...options.groups,
-    ...(organizationAccounts.length && options.groups?.companies
-      ? {
-          [organizationAccounts?.[0].id]: options.groups?.companies,
-        }
-      : {}),
-  } as MenuItemGroups;
-
-  const norwegianId = currentEndUser?.party ? formatNorwegianId(currentEndUser.party, true) : '';
-  const description = currentEndUser?.party && norwegianId ? t('word.ssn') + norwegianId : '';
-
-  const endUserAccount: PartyItemProp | undefined = currentEndUser
-    ? {
-        id: currentEndUser.party ?? '',
-        selected: !allOrganizationsSelected && currentEndUser.party === selectedParties[0]?.party,
-        searchWords: [currentEndUser.name],
-        name: currentEndUser.name ?? '',
-        title: currentEndUser.name ?? '',
-        type: 'person' as AccountMenuItemProps['type'],
-        groupId: 'primary',
-        icon: {
-          name: currentEndUser.name ?? '',
-          type: 'person' as AvatarType,
-        },
-        isCurrentEndUser: true,
-        uuid: currentEndUser.partyUuid ?? '',
-        description: options.showDescription ? description : undefined,
-        badge: { color: 'person', label: t('badge.you') },
-      }
-    : undefined;
-
-  // Filter organizations for "Alle virksomheter" avatar group
-  const organizationsForAvatarGroup =
-    shouldExcludeDeleted && !includeDeletedParties
-      ? organizationAccounts.filter((org) => !org.isDeleted)
-      : organizationAccounts;
-
-  const allOrganizationsAccount: PartyItemProp = {
-    uuid: 'N/A',
-    selected: allOrganizationsSelected,
-    id: 'ALL',
-    name: t('parties.labels.all_organizations'),
-    title: t('parties.labels.all_organizations'),
-    type: 'group',
-    groupId: 'groups',
-    icon: {
-      type: 'group' as AccountMenuItemProps['type'],
-      maxItemsCountReachedLabel: organizationsForAvatarGroup.length > 99 ? '..' : '',
-      items: organizationsForAvatarGroup.map((party) => ({
-        id: party.id,
-        name: party.name,
-        type: 'company' as AccountMenuItemProps['type'],
-        variant: party.isParent ? 'solid' : 'outline',
-      })),
-    } as AvatarGroupProps,
-  };
-
-  const favorites = [...organizationAccounts, ...otherPeopleAccounts]
-    .filter((a) => a.isFavorite)
-    .map((a) => ({ ...a, groupId: SettingsType.favorites }));
-
-  const accounts: PartyItemProp[] = [
-    ...(endUserAccount ? [endUserAccount] : []),
-    ...(options.showFavorites ? favorites : []),
-    ...(options.showGroups ? (organizationAccounts.length > 1 ? [allOrganizationsAccount] : []) : []),
-    ...otherPeopleAccounts,
-    ...organizationAccounts,
-  ];
-
-  const accountSearch = showSearch
-    ? {
-        name: 'account-search',
-        value: searchString,
-        onChange: (event: ChangeEvent<HTMLInputElement>) => {
-          setSearchString(event.target.value);
-        },
-        placeholder: t('parties.search'),
-      }
-    : undefined;
-
-  const onSelectAccount = (partyId: string, route: PageRoutes) => {
-    const search = new URLSearchParams(location.search);
-    const isPersonAccount = partyId.includes('person');
-    const isAllPartiesSelected = search.get('allParties') === 'true';
-    const isCurrentAccount = partyId === selectedParties[0]?.party;
-
-    if (isCurrentAccount && !isAllPartiesSelected) return;
-
-    queryClient.setQueryData([QUERY_KEYS.SELECTED_SUB_ACCOUNTS], []);
-
-    /* Prevent person urn in query param */
-    if (isPersonAccount) {
-      setSelectedPartyIds([partyId], false);
-    } else {
-      /* State will picked up by url change */
-      if (partyId === 'ALL') {
-        search.set(FixedGlobalQueryParams.allParties, 'true');
-        search.delete(FixedGlobalQueryParams.party);
-        search.delete(FixedGlobalQueryParams.subAccounts);
-      } else {
-        const party = parties.find((p) => p.party === partyId);
-        if (!party) {
-          console.error('Selected party not found:', partyId);
-          return;
-        }
-        search.set(FixedGlobalQueryParams.party, party.party);
-        search.delete(FixedGlobalQueryParams.allParties);
-        search.delete(FixedGlobalQueryParams.subAccounts);
-      }
-      navigate(`${route}?${search.toString()}`, { replace: true });
+  // Memoize the full account assembly to avoid O(n) work on every render
+  const { assembledAccounts, accountGroups } = useMemo(() => {
+    if (!selectedParties?.length) {
+      return { assembledAccounts: [] as PartyItemProp[], accountGroups: {} as MenuItemGroups };
     }
-  };
 
-  let filteredAccounts = accounts;
-  if (shouldExcludeDeleted && !includeDeletedParties) {
-    filteredAccounts = accounts.filter((item) => {
-      if (item.groupId === SettingsType.favorites || item.groupId === 'primary') {
-        return true;
+    const groups = {
+      ...options.groups,
+      ...(organizationAccounts.length && options.groups?.companies
+        ? { [organizationAccounts[0].id]: options.groups?.companies }
+        : {}),
+    } as MenuItemGroups;
+
+    const norwegianId = currentEndUser?.party ? formatNorwegianId(currentEndUser.party, true) : '';
+    const desc = currentEndUser?.party && norwegianId ? t('word.ssn') + norwegianId : '';
+
+    const endUserAccount: PartyItemProp | undefined = currentEndUser
+      ? {
+          id: currentEndUser.party ?? '',
+          selected: !allOrganizationsSelected && currentEndUser.party === selectedParties[0]?.party,
+          searchWords: [currentEndUser.name],
+          name: currentEndUser.name ?? '',
+          title: currentEndUser.name ?? '',
+          type: 'person' as AccountMenuItemProps['type'],
+          groupId: 'primary',
+          icon: { name: currentEndUser.name ?? '', type: 'person' as AvatarType },
+          isCurrentEndUser: true,
+          uuid: currentEndUser.partyUuid ?? '',
+          description: options.showDescription ? desc : undefined,
+          badge: { color: 'person', label: t('badge.you') },
+        }
+      : undefined;
+
+    const orgCount =
+      shouldExcludeDeleted && !includeDeletedParties
+        ? organizationAccounts.reduce((n, org) => n + (org.isDeleted ? 0 : 1), 0)
+        : organizationAccounts.length;
+
+    /* Only map the first few items for the avatar group icon – the rest are never visible */
+    const AVATAR_GROUP_LIMIT = 10;
+    const avatarGroupSource =
+      shouldExcludeDeleted && !includeDeletedParties
+        ? organizationAccounts.filter((org) => !org.isDeleted)
+        : organizationAccounts;
+    const avatarGroupItems = avatarGroupSource.slice(0, AVATAR_GROUP_LIMIT).map((party) => ({
+      id: party.id,
+      name: party.name,
+      type: 'company' as AccountMenuItemProps['type'],
+      variant: party.isParent ? 'solid' : 'outline',
+    }));
+
+    const allOrganizationsAccount: PartyItemProp = {
+      uuid: 'N/A',
+      selected: allOrganizationsSelected,
+      id: 'ALL',
+      name: t('parties.labels.all_organizations'),
+      title: t('parties.labels.all_organizations'),
+      type: 'group',
+      groupId: 'groups',
+      icon: {
+        type: 'group' as AccountMenuItemProps['type'],
+        maxItemsCountReachedLabel: orgCount > 99 ? '..' : '',
+        items: avatarGroupItems,
+      } as AvatarGroupProps,
+    };
+
+    const favorites: PartyItemProp[] = [];
+    for (const a of organizationAccounts) {
+      if (a.isFavorite) favorites.push({ ...a, groupId: SettingsType.favorites });
+    }
+    for (const a of otherPeopleAccounts) {
+      if (a.isFavorite) favorites.push({ ...a, groupId: SettingsType.favorites });
+    }
+
+    const result: PartyItemProp[] = [];
+    if (endUserAccount) result.push(endUserAccount);
+    if (options.showFavorites) {
+      for (const f of favorites) result.push(f);
+    }
+    if (options.showGroups && organizationAccounts.length > 1) result.push(allOrganizationsAccount);
+    for (const a of otherPeopleAccounts) result.push(a);
+    for (const a of organizationAccounts) result.push(a);
+
+    let finalAccounts = result;
+    if (shouldExcludeDeleted && !includeDeletedParties) {
+      finalAccounts = result.filter((item) => {
+        if (item.groupId === SettingsType.favorites || item.groupId === 'primary') return true;
+        return !item.isDeleted;
+      });
+    }
+
+    return { assembledAccounts: finalAccounts, accountGroups: groups };
+  }, [
+    selectedParties,
+    allOrganizationsSelected,
+    organizationAccounts,
+    otherPeopleAccounts,
+    currentEndUser,
+    options.groups,
+    options.showDescription,
+    options.showFavorites,
+    options.showGroups,
+    shouldExcludeDeleted,
+    includeDeletedParties,
+    t,
+  ]);
+
+  const onSelectAccount = useCallback(
+    (partyId: string, route: PageRoutes) => {
+      const search = new URLSearchParams(location.search);
+      const isPersonAccount = partyId.includes('person');
+      const isAllPartiesSelected = search.get('allParties') === 'true';
+      const isCurrentAccount = partyId === selectedParties[0]?.party;
+
+      if (isCurrentAccount && !isAllPartiesSelected) return;
+
+      queryClient.setQueryData([QUERY_KEYS.SELECTED_SUB_ACCOUNTS], []);
+
+      if (isPersonAccount) {
+        setSelectedPartyIds([partyId], false);
+      } else {
+        if (partyId === 'ALL') {
+          search.set(FixedGlobalQueryParams.allParties, 'true');
+          search.delete(FixedGlobalQueryParams.party);
+          search.delete(FixedGlobalQueryParams.subAccounts);
+        } else {
+          const party = availablePartiesGraph.partyByUrn.get(partyId);
+          if (!party) {
+            console.error('Selected party not found:', partyId);
+            return;
+          }
+          search.set(FixedGlobalQueryParams.party, party.party);
+          search.delete(FixedGlobalQueryParams.allParties);
+          search.delete(FixedGlobalQueryParams.subAccounts);
+        }
+        navigate(`${route}?${search.toString()}`, { replace: true });
       }
-      return !item.isDeleted;
-    });
+    },
+    [selectedParties, queryClient, setSelectedPartyIds, availablePartiesGraph, navigate],
+  );
+
+  const accountSearch = useMemo(
+    () =>
+      showSearch
+        ? {
+            name: 'account-search',
+            value: searchString,
+            onChange: (event: ChangeEvent<HTMLInputElement>) => {
+              setSearchString(event.target.value);
+            },
+            placeholder: t('parties.search'),
+          }
+        : undefined,
+    [showSearch, searchString, t],
+  );
+
+  if (isLoading) {
+    return {
+      accounts: [loadingAccountMenuItem as PartyItemProp],
+      accountGroups: { loading: { title: t('profile.accounts.loading') } },
+      accountSearch: undefined,
+      onSelectAccount,
+      currentAccountName: '',
+    };
+  }
+
+  if (!selectedParties?.length) {
+    return {
+      accounts: [],
+      accountGroups: {},
+      accountSearch: undefined,
+      onSelectAccount,
+      currentAccountName: '',
+    };
   }
 
   return {
-    accounts: filteredAccounts,
+    accounts: assembledAccounts,
     accountGroups,
     accountSearch,
     onSelectAccount,

--- a/packages/frontend/src/components/PageLayout/Footer/useFooter.tsx
+++ b/packages/frontend/src/components/PageLayout/Footer/useFooter.tsx
@@ -1,11 +1,11 @@
 import type { FooterProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../../../api/hooks/useParties';
+import { useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors';
 import { getFooterLinks } from '../../../auth';
 
 export const useFooter = (): FooterProps => {
   const { t, i18n } = useTranslation();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   const footerLinks = getFooterLinks(currentPartyUuid || '', i18n.language);
 
   return {

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { useParties } from '../../../api/hooks/useParties.ts';
+import { useCurrentEndUser, useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors.ts';
 import { PageRoutes } from '../../../pages/routes.ts';
 import { buildInboxMenu } from './inboxMenu.tsx';
 import { buildProfileMenu } from './profileMenu.tsx';
@@ -17,7 +17,8 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
   const isProfile = pathname.includes(PageRoutes.profile);
   const fromView = (state as { fromView?: string })?.fromView;
   const { t } = useTranslation();
-  const { currentEndUser, currentPartyUuid } = useParties();
+  const currentEndUser = useCurrentEndUser();
+  const currentPartyUuid = useCurrentPartyUuid();
 
   const inboxMenus = buildInboxMenu({
     t,

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -10,11 +10,12 @@ import {
   Snackbar,
 } from '@altinn/altinn-components';
 import { useQueryClient } from '@tanstack/react-query';
+import type { PartyFieldsFragment } from 'bff-types-generated';
 import i18n from 'i18next';
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps, Outlet, useLocation, useSearchParams } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentEndUser, useCurrentPartyUuid, useSelectedProfile } from '../../api/hooks/usePartiesSelectors.ts';
 import { getFrontPageLink } from '../../auth';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
@@ -42,7 +43,11 @@ export const PageLayout: React.FC = () => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [docTitle] = useGlobalState<string>(QUERY_KEYS.CURRENT_DIALOG_TITLE, '');
-  const { selectedProfile, selectedParties, allOrganizationsSelected, currentEndUser, currentPartyUuid } = useParties();
+  const selectedProfile = useSelectedProfile();
+  const currentEndUser = useCurrentEndUser();
+  const currentPartyUuid = useCurrentPartyUuid();
+  const [allOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
+  const [selectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
   const [isErrorState] = useGlobalState<boolean>(QUERY_KEYS.ERROR_STATE, false);
   const { headerProps } = useHeaderConfig();
   const footer: FooterProps = useFooter();

--- a/packages/frontend/src/components/PageLayout/mapPartyToAuthorizedParty.spec.ts
+++ b/packages/frontend/src/components/PageLayout/mapPartyToAuthorizedParty.spec.ts
@@ -1,0 +1,121 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { describe, expect, it } from 'vitest';
+import { extractIdentifierNumber, mapPartiesToAuthorizedParties } from './mapPartyToAuthorizedParty.ts';
+
+const createParty = (overrides: Partial<PartyFieldsFragment> = {}): PartyFieldsFragment => ({
+  party: 'urn:altinn:person:identifier-no:12345678901',
+  partyType: 'Person',
+  name: 'Test Person',
+  isCurrentEndUser: false,
+  isDeleted: false,
+  partyUuid: 'uuid-1',
+  partyId: 1,
+  hasOnlyAccessToSubParties: false,
+  subParties: [],
+  ...overrides,
+});
+
+describe('extractIdentifierNumber', () => {
+  it('should extract number from URN format', () => {
+    expect(extractIdentifierNumber('urn:altinn:person:identifier-no:12345678901')).toBe('12345678901');
+  });
+
+  it('should extract org number from URN format', () => {
+    expect(extractIdentifierNumber('urn:altinn:organization:identifier-no:999888777')).toBe('999888777');
+  });
+
+  it('should return undefined for missing partyId', () => {
+    expect(extractIdentifierNumber(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined for invalid format', () => {
+    expect(extractIdentifierNumber('invalid-format')).toBeUndefined();
+  });
+});
+
+describe('mapPartiesToAuthorizedParties', () => {
+  it('should map a simple person party', () => {
+    const parties = [createParty()];
+    const result = mapPartiesToAuthorizedParties(parties);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Test Person');
+    expect(result[0].type).toBe('Person');
+    expect(result[0].organizationNumber).toBeUndefined();
+  });
+
+  it('should map an organization with identifier number', () => {
+    const parties = [
+      createParty({
+        party: 'urn:altinn:organization:identifier-no:999888777',
+        partyType: 'Organization',
+        name: 'Test Org AS',
+        partyUuid: 'uuid-org',
+      }),
+    ];
+    const result = mapPartiesToAuthorizedParties(parties);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].organizationNumber).toBe('999888777');
+  });
+
+  it('should filter out sub-parties from top-level and add them as subunits', () => {
+    const subParty = {
+      party: 'urn:altinn:organization:identifier-no:999888001',
+      partyType: 'Organization' as const,
+      name: 'Sub Unit',
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: 'uuid-sub',
+      partyId: 3,
+    };
+
+    const parentOrg = createParty({
+      party: 'urn:altinn:organization:identifier-no:999888777',
+      partyType: 'Organization',
+      name: 'Parent Org',
+      partyUuid: 'uuid-parent',
+      subParties: [subParty],
+    });
+
+    // Simulate normalizeFlattenParties which promotes sub-parties
+    const promotedSub = createParty({
+      ...subParty,
+      hasOnlyAccessToSubParties: false,
+      subParties: [],
+    });
+
+    const parties = [parentOrg, promotedSub];
+    const result = mapPartiesToAuthorizedParties(parties);
+
+    // Sub-party should be filtered from top-level
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Parent Org');
+    expect(result[0].subunits).toHaveLength(1);
+    expect(result[0].subunits?.[0].name).toBe('Sub Unit');
+  });
+
+  it('should handle parties with hasOnlyAccessToSubParties', () => {
+    const parties = [
+      createParty({
+        hasOnlyAccessToSubParties: true,
+        name: 'Access Only Parent',
+      }),
+    ];
+    const result = mapPartiesToAuthorizedParties(parties);
+
+    expect(result[0].onlyHierarchyElementWithNoAccess).toBe(true);
+  });
+
+  it('should handle empty party list', () => {
+    const result = mapPartiesToAuthorizedParties([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle deleted parties', () => {
+    const parties = [createParty({ isDeleted: true, name: 'Deleted Org' })];
+    const result = mapPartiesToAuthorizedParties(parties);
+
+    expect(result[0].isDeleted).toBe(true);
+  });
+});

--- a/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
+++ b/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
@@ -7,7 +7,7 @@ import {
   useAccountSelector,
 } from '@altinn/altinn-components';
 import type { ChangeEvent } from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps, useLocation, useNavigate } from 'react-router-dom';
 import { Analytics } from '../../analytics/analytics.ts';
@@ -31,7 +31,8 @@ interface UseHeaderConfigOutput {
 }
 
 export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutput => {
-  const { currentEndUser, parties, selectedParties, isLoading, currentPartyUuid, setSelectedPartyIds } = useParties();
+  const { currentEndUser, parties, selectedParties, isLoading, currentPartyUuid, setSelectedPartyIds, partyGraph } =
+    useParties();
   const { t, i18n } = useTranslation();
   const { logError } = useErrorLogger();
   const location = useLocation();
@@ -76,7 +77,7 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
 
   const handleSelectAccount = (accountUuid: string) => {
     const targetRoute = isProfile ? PageRoutes.profile : PageRoutes.inbox;
-    const party = parties.find((p) => p.partyUuid === accountUuid);
+    const party = partyGraph.partyByUuid.get(accountUuid);
 
     if (!party) {
       console.error('Selected party not found:', accountUuid);
@@ -119,7 +120,7 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
     [updateShowDeletedEntities, logError],
   );
 
-  const partyListDTO = mapPartiesToAuthorizedParties(parties);
+  const partyListDTO = useMemo(() => mapPartiesToAuthorizedParties(parties), [parties]);
 
   const favoriteAccountUuids = (favoritesGroup?.parties ?? []).filter(
     (uuid): uuid is string => uuid !== null && uuid !== undefined,

--- a/packages/frontend/src/components/SINotice/SINotice.tsx
+++ b/packages/frontend/src/components/SINotice/SINotice.tsx
@@ -1,11 +1,12 @@
 import { Alert, Flex } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentPartyUuid, useSelfIdentifiedUserType } from '../../api/hooks/usePartiesSelectors.ts';
 import { getAlternativeLoginLink } from '../../auth';
 
 export const SINotice = () => {
   const { t, i18n } = useTranslation();
-  const { currentPartyUuid, selfIdentifiedUserType } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
+  const selfIdentifiedUserType = useSelfIdentifiedUserType();
   switch (selfIdentifiedUserType) {
     case 'Email':
       return (

--- a/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
+++ b/packages/frontend/src/components/SavedSearchButton/SaveSearchButton.tsx
@@ -3,7 +3,7 @@ import { BookmarkFillIcon, BookmarkIcon } from '@navikt/aksel-icons';
 import type { ButtonHTMLAttributes, RefAttributes } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useSelectedPartyIds } from '../../api/hooks/usePartiesSelectors.ts';
 import { buildCurrentStateURL, findMatchingSavedSearch } from '../../pages/SavedSearches';
 import { useSavedSearches } from '../../pages/SavedSearches/useSavedSearches.tsx';
 import { useSearchString } from '../PageLayout/Search';
@@ -26,7 +26,7 @@ export const SaveSearchButton = ({
   onSaveSuccess,
 }: SaveSearchButtonProps) => {
   const { t } = useTranslation();
-  const { selectedPartyIds } = useParties();
+  const selectedPartyIds = useSelectedPartyIds();
   const { enteredSearchValue } = useSearchString();
   const {
     currentPartySavedSearches: savedSearches,

--- a/packages/frontend/src/onboardingTour/OnboardingPopover.tsx
+++ b/packages/frontend/src/onboardingTour/OnboardingPopover.tsx
@@ -3,7 +3,7 @@ import { XMarkIcon } from '@navikt/aksel-icons';
 import { useTour } from '@reactour/tour';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../api/hooks/useParties';
+import { useSelectedProfile } from '../api/hooks/usePartiesSelectors';
 import styles from './onboardingPopover.module.css';
 
 interface OnboardingPopoverProps {
@@ -13,7 +13,7 @@ interface OnboardingPopoverProps {
 }
 
 export const OnboardingPopover = ({ titleKey, infoTextKey, hideNextButton }: OnboardingPopoverProps) => {
-  const { selectedProfile } = useParties();
+  const selectedProfile = useSelectedProfile();
   const { t } = useTranslation();
   const { currentStep, steps, setCurrentStep, setIsOpen } = useTour();
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/frontend/src/pages/DialogDetailsPage/useDelegation.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/useDelegation.tsx
@@ -1,6 +1,6 @@
 import type { DialogLookupQuery } from 'bff-types-generated';
 import { useMemo } from 'react';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { usePartyGraph } from '../../api/hooks/usePartiesSelectors.ts';
 import { graphQLSDK } from '../../api/queries.ts';
 import { getAccessAMUILink } from '../../auth';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
@@ -23,7 +23,7 @@ const getDelegationHref = (instanceUrn: string, resourceId: string, dialogId: st
 };
 
 export const useDelegation = (dialogId?: string, party?: string): UseDelegationOutput => {
-  const { parties } = useParties();
+  const partyGraph = usePartyGraph();
   const instanceRef = `urn:altinn:dialog-id:${dialogId}`;
   const enableDelegationLink = useFeatureFlag('auth.enableDelegationLink');
   const { data, isSuccess } = useAuthenticatedQuery<DialogLookupQuery>({
@@ -37,8 +37,8 @@ export const useDelegation = (dialogId?: string, party?: string): UseDelegationO
   });
 
   const partyUuid = useMemo(() => {
-    return parties.find((p) => p.party === party)?.partyUuid;
-  }, [parties, party]);
+    return party ? partyGraph.partyByUrn.get(party)?.partyUuid : undefined;
+  }, [partyGraph, party]);
 
   if (!enableDelegationLink) {
     return {

--- a/packages/frontend/src/pages/Inbox/AlertBanner.tsx
+++ b/packages/frontend/src/pages/Inbox/AlertBanner.tsx
@@ -1,7 +1,7 @@
 import { DsAlert, DsParagraph, Heading } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink } from '../../auth';
 import { useAlertBanner } from '../../hooks/useAlertBanner.ts';
 
@@ -11,7 +11,7 @@ interface AlertBannerProps {
 
 export const AlertBanner = ({ showAlertBanner }: AlertBannerProps) => {
   const { t } = useTranslation();
-  const { currentPartyUuid } = useParties();
+  const currentPartyUuid = useCurrentPartyUuid();
   const alertBannerContent = useAlertBanner();
   const linkUrl = alertBannerContent?.link?.url || createMessageBoxLink(currentPartyUuid);
   const linkText = alertBannerContent?.link?.text || t('inbox.historical_messages_date_warning_link');

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -136,6 +136,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
     isError: unableToLoadParties,
     isLoading: isLoadingParties,
     organizationLimitReached,
+    partyGraph,
   } = useParties();
 
   const { items: savedSearchItems, onSaveSearch, onCloseSavedSearch } = useSavedSearches(selectedPartyIds);
@@ -188,6 +189,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
     parties,
     selectedParties,
     allOrganizationsSelected,
+    partyGraph,
     options: {
       showGroups: true,
     },
@@ -316,7 +318,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
         title: <span className={styles.searchButtonWrapper}>{groups[firstKey]?.title}</span>,
       },
     };
-  }, [groups, viewType, savedSearchDisabled, savedSearchFilterState, onSaveSuccess]);
+  }, [groups]);
 
   const sortGroupBy = useCallback(
     ([aKey]: [string, unknown], [bKey]: [string, unknown]) =>

--- a/packages/frontend/src/pages/Inbox/filters.tsx
+++ b/packages/frontend/src/pages/Inbox/filters.tsx
@@ -30,13 +30,14 @@ import {
 import type { Locale } from 'date-fns/locale';
 import { t } from 'i18next';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { getOrganization } from '../../api/utils/organizations.ts';
+import { buildOrganizationMap } from '../../api/utils/organizations.ts';
+import { type OrganizationLookup, getOrganization } from '../../api/utils/organizations.ts';
 import { getEnvByHost } from '../../auth';
 
 interface ServiceFilterProps {
   serviceResources: ServiceResource[];
   currentFilters?: FilterState;
-  allOrganizations: OrganizationFieldsFragment[];
+  allOrganizations: OrganizationLookup;
 }
 
 export enum DateFilterOption {
@@ -192,8 +193,9 @@ const createDateOptions = (): MenuItemProps[] => {
 const createServiceOwnerFilter = (
   allDialogs: CountableDialogFieldsFragment[],
   allOrganizations: OrganizationFieldsFragment[],
+  orgLookup: OrganizationLookup,
 ): FilterProps => {
-  const mostRelevantOrgs = Array.from(new Set([...allDialogs.map((d) => d.org)]));
+  const mostRelevantOrgs = new Set(allDialogs.map((d) => d.org));
   return {
     id: FilterCategory.ORG,
     icon: MenuHamburgerIcon,
@@ -204,7 +206,7 @@ const createServiceOwnerFilter = (
     removable: true,
     groups: {
       'service-owners': {
-        title: mostRelevantOrgs.length ? '' : t('filter_bar.group.choose_sender'),
+        title: mostRelevantOrgs.size ? '' : t('filter_bar.group.choose_sender'),
       },
       selected: {},
       'most-relevant': {
@@ -213,14 +215,14 @@ const createServiceOwnerFilter = (
     },
     items: allOrganizations
       .map((org) => {
-        const localizedOrg = getOrganization(allOrganizations, org.id ?? '');
+        const localizedOrg = getOrganization(orgLookup, org.id ?? '');
         return {
           id: org.id ?? '',
           name: FilterCategory.ORG,
           title: localizedOrg?.name ?? '',
           value: org.id ?? '',
           role: 'checkbox',
-          groupId: mostRelevantOrgs.includes(org.id ?? '') ? 'most-relevant' : 'service-owners',
+          groupId: mostRelevantOrgs.has(org.id ?? '') ? 'most-relevant' : 'service-owners',
         };
       })
       .sort((a, b) => {
@@ -342,14 +344,14 @@ export const createServiceFilter = ({
   currentFilters = {},
   allOrganizations,
 }: ServiceFilterProps): FilterProps => {
-  const suggestedServiceIds = getSuggestedServiceIds();
+  const suggestedServiceIds = new Set(getSuggestedServiceIds());
   const serviceFilters: FilterProps[] = serviceResources
     .map((s) => ({
       id: s.id!,
       name: s.id!,
       items: [],
       title: s.title ?? '',
-      groupId: suggestedServiceIds?.includes(s.id!) ? 'most-relevant' : 'services',
+      groupId: suggestedServiceIds.has(s.id!) ? 'most-relevant' : 'services',
       description: getOrganization(allOrganizations, s.org ?? '')?.name || '',
     }))
     .sort((a, b) => {
@@ -424,7 +426,8 @@ export const getFilters = ({
   enableServiceFilter?: boolean;
   prebuiltServiceFilter?: FilterProps;
 }): ToolbarFilterProps['filters'] => {
-  const senderOrgFilter = createServiceOwnerFilter(allDialogs, allOrganizations ?? []);
+  const orgLookup = buildOrganizationMap(allOrganizations ?? []);
+  const senderOrgFilter = createServiceOwnerFilter(allDialogs, allOrganizations ?? [], orgLookup);
   const statusFilter = createStatusFilter();
   const updatedAtFilter = createUpdatedAtFilter();
 

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -14,8 +14,9 @@ import { useTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next';
 import { Link, type LinkProps } from 'react-router-dom';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
+import { useGlobalState } from '../../useGlobalState.ts';
 import { useDialogActions } from '../DialogDetailsPage/useDialogActions.tsx';
 import type { CurrentSeenByLog } from './Inbox.tsx';
 import type { InboxItemInput } from './InboxItemInput.ts';
@@ -119,7 +120,7 @@ const useGroupedDialogs = ({
   const { t } = useTranslation();
   const format = useFormat();
   const systemLabelActions = useDialogActions();
-  const { allOrganizationsSelected } = useParties();
+  const [allOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
   const collapseGroups = displaySearchResults || (viewType !== 'inbox' && viewType !== 'sent');
   const getCollapsedGroupTitle = (viewType: InboxViewType, count: number, hasNextPage: boolean) =>
     (hasNextPage ? t('word.moreThan') : '') + t(`inbox.heading.title.${viewType}`, { count });

--- a/packages/frontend/src/pages/Inbox/useSubAccounts.tsx
+++ b/packages/frontend/src/pages/Inbox/useSubAccounts.tsx
@@ -1,6 +1,6 @@
 import type { MenuItemGroups, MenuItemProps } from '@altinn/altinn-components';
 import type { PartyFieldsFragment } from 'bff-types-generated';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import type { PartyItemProp } from '../../components/PageLayout/Accounts/useAccounts.tsx';
@@ -23,14 +23,14 @@ interface UseSubAccountsOutput {
 const ALL_SUB_ACCOUNTS_ID = 'ALL_SUB_ACCOUNTS';
 
 const getUniqueParties = (parties: PartyItemProp[]): PartyItemProp[] => {
-  const uniquePartyIds = new Set<string>();
-  const uniqueParties = new Set<PartyItemProp>();
+  const seen = new Set<string>();
+  const result: PartyItemProp[] = [];
   for (const party of parties) {
-    if (uniquePartyIds.has(party.id)) continue;
-    uniqueParties.add(party);
-    uniquePartyIds.add(party.id);
+    if (seen.has(party.id)) continue;
+    seen.add(party.id);
+    result.push(party);
   }
-  return Array.from(uniqueParties);
+  return result;
 };
 
 export const useSubAccounts = ({
@@ -46,6 +46,9 @@ export const useSubAccounts = ({
     return getSelectedSubAccountsFromQueryParams(searchParams);
   }, [searchParams.get(FixedGlobalQueryParams.subAccounts)]);
 
+  /** Set for O(1) lookups — avoids O(n×m) in .map() and .includes() checks */
+  const selectedSubAccountIdSet = useMemo(() => new Set(selectedSubAccountIds), [selectedSubAccountIds]);
+
   const updateSelectedSubAccountIds = useCallback(
     (ids: string[]) => {
       const nextParams = new URLSearchParams(searchParams.toString());
@@ -60,24 +63,43 @@ export const useSubAccounts = ({
     [searchParams, setSearchParams],
   );
 
+  /** Pre-index accounts by id and parentId for O(1) lookups instead of O(n) .find()/.filter() */
+  const accountIndex = useMemo(() => {
+    const byId = new Map<string, PartyItemProp>();
+    const byParentId = new Map<string, PartyItemProp[]>();
+    const companies: PartyItemProp[] = [];
+
+    for (const account of accounts) {
+      byId.set(account.id, account);
+      if (account.type === 'company' || account.type === 'subunit') {
+        companies.push(account);
+      }
+      if (account.parentId) {
+        let children = byParentId.get(account.parentId);
+        if (!children) {
+          children = [];
+          byParentId.set(account.parentId, children);
+        }
+        children.push(account);
+      }
+    }
+
+    return { byId, byParentId, companies };
+  }, [accounts]);
+
   const selectedPartyId = selectedParties[0]?.party;
-  const selectedAccount = useMemo(
-    () => accounts.find((account) => account.id === selectedPartyId),
-    [accounts, selectedPartyId],
-  );
+  const selectedAccount = useMemo(() => accountIndex.byId.get(selectedPartyId ?? ''), [accountIndex, selectedPartyId]);
   const parentAccount = useMemo(() => {
     return !allOrganizationsSelected && selectedAccount?.isParent ? selectedAccount : undefined;
   }, [allOrganizationsSelected, selectedAccount]);
 
   const subAccountsAndAll = useMemo<PartyItemProp[]>(() => {
     if (allOrganizationsSelected) {
-      return getUniqueParties(
-        accounts.filter((party: PartyItemProp) => party.type === 'company' || party.type === 'subunit'),
-      );
+      return getUniqueParties(accountIndex.companies);
     }
 
     if (parentAccount) {
-      const subUnits = accounts.filter((a) => a.parentId === parentAccount.id);
+      const subUnits = accountIndex.byParentId.get(parentAccount.id) ?? [];
       if (subUnits.length) {
         return getUniqueParties([parentAccount, ...subUnits]);
       }
@@ -85,7 +107,7 @@ export const useSubAccounts = ({
     }
 
     return [];
-  }, [allOrganizationsSelected, accounts, parentAccount]);
+  }, [allOrganizationsSelected, accountIndex, parentAccount]);
 
   const filteredSubAccounts = useMemo(() => {
     return subAccountsAndAll.filter((item) => !item.disabled);
@@ -108,25 +130,32 @@ export const useSubAccounts = ({
     [mainUnitLabel, parentAccount, subUnitLabel],
   );
 
-  const onSelectSubAccount = useCallback(
-    (id: string) => {
-      if (!id || id === ALL_SUB_ACCOUNTS_ID) {
-        updateSelectedSubAccountIds([]);
-        return;
-      }
+  /**
+   * Use a ref for the select handler so the subAccounts memo doesn't depend on selectedSubAccountIds.
+   * This avoids rebuilding the entire menu items array on every sub-account toggle.
+   */
+  const selectedSubAccountIdsRef = useRef(selectedSubAccountIds);
+  selectedSubAccountIdsRef.current = selectedSubAccountIds;
+  const updateRef = useRef(updateSelectedSubAccountIds);
+  updateRef.current = updateSelectedSubAccountIds;
 
-      if (selectedSubAccountIds.includes(id)) {
-        updateSelectedSubAccountIds(selectedSubAccountIds.filter((item: string) => item !== id));
-      } else {
-        updateSelectedSubAccountIds([...selectedSubAccountIds, id]);
-      }
-    },
-    [selectedSubAccountIds, updateSelectedSubAccountIds],
-  );
+  const onSelectSubAccount = useCallback((id: string) => {
+    if (!id || id === ALL_SUB_ACCOUNTS_ID) {
+      updateRef.current([]);
+      return;
+    }
+
+    const current = selectedSubAccountIdsRef.current;
+    if (current.includes(id)) {
+      updateRef.current(current.filter((item: string) => item !== id));
+    } else {
+      updateRef.current([...current, id]);
+    }
+  }, []);
 
   const subAccounts = useMemo<MenuItemProps[]>(() => {
     if (!filteredSubAccounts.length) return [];
-    const items = [...filteredSubAccounts].map((item) => {
+    const items = filteredSubAccounts.map((item) => {
       return {
         id: `subaccount-${item.id}`,
         groupId: item.parentId || item.id,
@@ -138,7 +167,7 @@ export const useSubAccounts = ({
         },
         name: 'subaccount',
         value: item.id,
-        checked: selectedSubAccountIds.includes(item.id),
+        checked: selectedSubAccountIdSet.has(item.id),
         disabled: item.disabled,
         searchWords: item.searchWords,
       } satisfies MenuItemProps;
@@ -152,23 +181,25 @@ export const useSubAccounts = ({
         role: 'radio',
         name: 'subaccount',
         value: 'all',
-        onChange: () => updateSelectedSubAccountIds([]),
-        checked: selectedSubAccountIds.length === 0,
+        onChange: () => updateRef.current([]),
+        checked: selectedSubAccountIdSet.size === 0,
       },
       ...items,
     ];
-  }, [
-    allLabel,
-    filteredSubAccounts,
-    getSubAccountTitle,
-    selectedSubAccountIds,
-    onSelectSubAccount,
-    updateSelectedSubAccountIds,
-  ]);
+  }, [allLabel, filteredSubAccounts, getSubAccountTitle, selectedSubAccountIdSet, onSelectSubAccount]);
+
+  /** Pre-index filteredSubAccounts by id for O(1) label lookup */
+  const filteredSubAccountsById = useMemo(() => {
+    const map = new Map<string, PartyItemProp>();
+    for (const item of filteredSubAccounts) {
+      map.set(item.id, item);
+    }
+    return map;
+  }, [filteredSubAccounts]);
 
   const getSubAccountLabel = useCallback(() => {
     if (selectedSubAccountIds.length === 1) {
-      const selectedSubAccount = filteredSubAccounts.find((item) => item.id === selectedSubAccountIds[0]);
+      const selectedSubAccount = filteredSubAccountsById.get(selectedSubAccountIds[0]);
       return selectedSubAccount ? getSubAccountTitle(selectedSubAccount) : allLabel;
     }
     if (allOrganizationsSelected) {
@@ -184,7 +215,15 @@ export const useSubAccounts = ({
       return t('parties.labels.units_count', { count: selectedSubAccountIds.length });
     }
     return t('parties.labels.units_count', { count: filteredSubAccounts.length });
-  }, [allLabel, filteredSubAccounts, selectedSubAccountIds, t, allOrganizationsSelected, getSubAccountTitle]);
+  }, [
+    allLabel,
+    filteredSubAccounts,
+    filteredSubAccountsById,
+    selectedSubAccountIds,
+    t,
+    allOrganizationsSelected,
+    getSubAccountTitle,
+  ]);
 
   const groups = {
     all: {

--- a/packages/frontend/src/pages/Profile/NotificationsPage/NotificationsPage.tsx
+++ b/packages/frontend/src/pages/Profile/NotificationsPage/NotificationsPage.tsx
@@ -2,6 +2,7 @@ import { Heading, ListItemLabel, PageBase, SettingsList, Toolbar } from '@altinn
 import type { NotificationSettingsResponse, PartyFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { useParties } from '../../../api/hooks/useParties.ts';
+import { useIsSelfIdentifiedUser } from '../../../api/hooks/usePartiesSelectors.ts';
 import { getNotificationSettingsLink } from '../../../auth';
 import { usePageTitle } from '../../../hooks/usePageTitle';
 import { SettingsType, useSettings } from '../Settings/useSettings.tsx';
@@ -16,7 +17,8 @@ export interface NotificationAccountsType extends PartyFieldsFragment {
 export const NotificationsPage = () => {
   const { t, i18n } = useTranslation();
   const { isLoading: isLoadingUser } = useProfile();
-  const { isLoading: isLoadingParties, isSelfIdentifiedUser } = useParties();
+  const { isLoading: isLoadingParties } = useParties();
+  const isSelfIdentifiedUser = useIsSelfIdentifiedUser();
   const notificationSettingsUrl = getNotificationSettingsLink(i18n.language);
 
   usePageTitle({ baseTitle: t('component.notifications') });

--- a/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
+++ b/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
@@ -16,7 +16,8 @@ import {
 } from '@altinn/altinn-components';
 import type { AccountListItemType } from '@altinn/altinn-components/dist/types/lib/components/Account/AccountListItem';
 import { BellIcon, HashtagIcon, HouseHeartFillIcon, HouseHeartIcon, InboxIcon } from '@navikt/aksel-icons';
-import { type ElementType, useMemo, useState } from 'react';
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { type ElementType, useDeferredValue, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps } from 'react-router-dom';
 import { useProfile } from '..';
@@ -44,7 +45,7 @@ export type PreselectedActorModalProps = {
 
 export const PartiesOverviewPage = () => {
   const { t } = useTranslation();
-  const { isSelfIdentifiedUser, parties, selectedParties, allOrganizationsSelected, isLoading, flattenedParties } =
+  const { isSelfIdentifiedUser, parties, selectedParties, allOrganizationsSelected, isLoading, partyGraph } =
     useParties();
   const { getAccountAlertSettings, settings } = useSettings({ disabled: isSelfIdentifiedUser, isSelfIdentifiedUser });
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
@@ -58,12 +59,13 @@ export const PartiesOverviewPage = () => {
   const [openConfirmSetPreselectedActorModal, setOpenConfirmSetPreselectedActorModal] =
     useState<PreselectedActorModalProps | null>(null);
   const [searchValue, setSearchValue] = useState<string>('');
+  const deferredSearchValue = useDeferredValue(searchValue);
   const [expandedItem, setExpandedItem] = useState<string>('');
 
   const includeDeletedParties = isDeletedUnitsFilterEnabled ? (shouldShowDeletedEntities ?? false) : true;
 
   const { filters, getFilterLabel, filterState, setFilterState, filteredParties, isSearching } = useAccountFilters({
-    searchValue,
+    searchValue: deferredSearchValue,
     parties,
     includeDeletedParties: true,
   });
@@ -74,6 +76,7 @@ export const PartiesOverviewPage = () => {
     selectedParties,
     allOrganizationsSelected,
     isLoading,
+    partyGraph,
     options: {
       showFavorites: !isSearching,
     },
@@ -179,20 +182,27 @@ export const PartiesOverviewPage = () => {
 
   const getOrganizationAccounts = (
     currentParty: { party: string } | undefined,
-    parentParty: { party: string } | undefined,
-    flattenedParties: Array<{
-      party: string;
-      name: string;
-      isDeleted: boolean;
-      parentId?: string;
-      subParties?: Array<{ party: string; name: string; isDeleted: boolean }>;
-    }>,
+    parentParty: PartyFieldsFragment | undefined,
   ) => {
-    const organizationAccounts = parentParty
-      ? flattenedParties?.filter((item) => item.party.includes(parentParty.party)) || []
-      : flattenedParties?.filter((item) => item.party.includes(currentParty?.party ?? '')) || [];
+    const rootParty = parentParty ?? partyGraph.partyByUrn.get(currentParty?.party ?? '');
+    if (!rootParty) return [];
 
-    return organizationAccounts?.map((item) => createOrganizationItem(item, currentParty));
+    const items = [rootParty, ...(rootParty.subParties ?? [])].map((item) => ({
+      party: item.party,
+      name: item.name,
+      isDeleted: item.isDeleted,
+      parentId: rootParty.party !== item.party ? rootParty.partyUuid : undefined,
+      subParties:
+        'subParties' in item
+          ? ((item as PartyFieldsFragment).subParties ?? []).map((sp) => ({
+              party: sp.party,
+              name: sp.name,
+              isDeleted: sp.isDeleted,
+            }))
+          : undefined,
+    }));
+
+    return items.map((item) => createOrganizationItem(item, currentParty));
   };
 
   const PartyDetails = ({
@@ -200,22 +210,12 @@ export const PartiesOverviewPage = () => {
     isCurrentEndUser,
     id,
   }: { type: AccountListItemType; isCurrentEndUser: boolean; id: string }) => {
-    const currentParty = flattenedParties?.find((item) => item.party === id);
-    const parentParty = flattenedParties?.find((item) => item.partyUuid === currentParty?.parentId);
+    const currentParty = partyGraph.partyByUrn.get(id);
+    const parentParty = partyGraph.parentByChildUrn.get(id);
 
     const organizationAccounts = useMemo(() => {
       if (type !== 'company') return undefined;
-      return getOrganizationAccounts(
-        currentParty,
-        parentParty,
-        flattenedParties as Array<{
-          party: string;
-          isDeleted: boolean;
-          name: string;
-          parentId?: string;
-          subParties?: Array<{ party: string; name: string; isDeleted: boolean }>;
-        }>,
-      );
+      return getOrganizationAccounts(currentParty, parentParty);
     }, [type, currentParty, parentParty]);
 
     if (isCurrentEndUser) {
@@ -340,12 +340,14 @@ export const PartiesOverviewPage = () => {
   const accountListItems = useMemo(() => accounts.map(mapAccountToPartyListItem), [accounts]);
 
   const displayHits = useMemo(() => {
+    if (!isSearching) return accountListItems;
     return accountListItems.map((a) => ({ ...a, groupId: 'search' }));
-  }, [accountListItems]);
+  }, [accountListItems, isSearching]);
 
-  const searchGroup = {
-    search: { title: t('search.hits', { count: displayHits.length }) },
-  };
+  const searchGroup = useMemo(
+    () => ({ search: { title: t('search.hits', { count: displayHits.length }) } }),
+    [displayHits.length, t],
+  );
 
   return (
     <PageBase color="person">

--- a/packages/frontend/src/pages/Profile/Profile.tsx
+++ b/packages/frontend/src/pages/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 import { DashboardHeader, PageBase, SettingsList } from '@altinn/altinn-components';
 import { formatDisplayName } from '@altinn/altinn-components';
 import { t } from 'i18next';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useCurrentEndUser, useIsSelfIdentifiedUser } from '../../api/hooks/usePartiesSelectors.ts';
 import { formatSSN } from '../../components/PageLayout/Accounts/useAccounts.tsx';
 import { usePageTitle } from '../../hooks/usePageTitle.tsx';
 import { useProfileOnboarding } from '../../onboardingTour/useProfileOnboarding';
@@ -10,8 +10,8 @@ import { useProfile } from './useProfile';
 
 export const Profile = () => {
   const { user, isLoading } = useProfile();
-  const { currentEndUser } = useParties();
-  const { isSelfIdentifiedUser } = useParties();
+  const currentEndUser = useCurrentEndUser();
+  const isSelfIdentifiedUser = useIsSelfIdentifiedUser();
   const { settings } = useSettings({
     options: {
       includeGroups: [SettingsType.contact],

--- a/packages/frontend/src/pages/Profile/Settings/Settings.tsx
+++ b/packages/frontend/src/pages/Profile/Settings/Settings.tsx
@@ -2,13 +2,15 @@ import { Heading, PageBase, SettingsList, Toolbar } from '@altinn/altinn-compone
 import { useTranslation } from 'react-i18next';
 import { useProfile } from '..';
 import { useParties } from '../../../api/hooks/useParties';
+import { useIsSelfIdentifiedUser } from '../../../api/hooks/usePartiesSelectors';
 import { usePageTitle } from '../../../hooks/usePageTitle';
 import { SettingsType, useSettings } from './useSettings.tsx';
 
 export const Settings = () => {
   const { t } = useTranslation();
   const { isLoading: isLoadingUser } = useProfile();
-  const { isLoading: isLoadingParties, isSelfIdentifiedUser } = useParties();
+  const { isLoading: isLoadingParties } = useParties();
+  const isSelfIdentifiedUser = useIsSelfIdentifiedUser();
 
   usePageTitle({ baseTitle: t('component.settings') });
 

--- a/packages/frontend/src/pages/Profile/Settings/useSettings.tsx
+++ b/packages/frontend/src/pages/Profile/Settings/useSettings.tsx
@@ -106,7 +106,7 @@ export const useSettings = ({
   isSelfIdentifiedUser = false,
   disabled = false,
 }: UseSettingsInput = {}): UseSettingsOutput => {
-  const { isLoading: isLoadingParties, parties, selectedParties, allOrganizationsSelected } = useParties();
+  const { isLoading: isLoadingParties, parties, selectedParties, allOrganizationsSelected, partyGraph } = useParties();
   const { user, showClientUnits, setShowClientUnits, shouldShowDeletedEntities, updateShowDeletedEntities } =
     useProfile();
   const { t } = useTranslation();
@@ -171,6 +171,7 @@ export const useSettings = ({
     parties,
     allOrganizationsSelected,
     selectedParties,
+    partyGraph,
     options: {
       groups: options?.groups,
       showDescription: true,

--- a/packages/frontend/src/pages/Profile/useAccountFilters.tsx
+++ b/packages/frontend/src/pages/Profile/useAccountFilters.tsx
@@ -89,35 +89,34 @@ export const useAccountFilters = ({
 
   const filteredParties = useMemo(() => {
     const filters = filterState?.partyScope ?? [];
-    let result = includeDeletedParties ? parties : parties.filter((party) => !party.isDeleted);
+    const filterSet = new Set(filters);
+    const isAllParties = filterSet.has(FilterStateEnum.ALL_PARTIES);
+    const includeCompanies = isAllParties || filterSet.has(FilterStateEnum.COMPANIES);
+    const includePersons = isAllParties || filterSet.has(FilterStateEnum.PERSONS);
 
-    if (searchValue.length > 0) {
-      const search = searchValue.toLowerCase();
-      const normalized = search.trim().toLowerCase();
-      const parts = normalized.split(/\s+/);
+    const hasSearch = searchValue.length > 0;
+    const normalized = hasSearch ? searchValue.trim().toLowerCase() : '';
+    const parts = hasSearch ? normalized.split(/\s+/) : [];
 
-      result = result.filter((s) => {
-        const name = (s.name ?? '').toString().toLowerCase();
-        const party = (s.party ?? '').toString().toLowerCase();
-        return (
-          parts.some((part) => name.includes(part) || party.includes(part)) ||
+    const result: PartyFieldsFragment[] = [];
+
+    for (const party of parties) {
+      if (!includeDeletedParties && party.isDeleted) continue;
+
+      if (party.partyType === 'Organization' ? !includeCompanies : !includePersons) continue;
+
+      if (hasSearch) {
+        const name = (party.name ?? '').toLowerCase();
+        const urn = (party.party ?? '').toLowerCase();
+        const matches =
+          parts.some((part) => name.includes(part) || urn.includes(part)) ||
           name.includes(normalized) ||
-          party.includes(normalized)
-        );
-      });
+          urn.includes(normalized);
+        if (!matches) continue;
+      }
+
+      result.push(party);
     }
-
-    result = result.filter((party) => {
-      if (filters.includes(FilterStateEnum.ALL_PARTIES)) {
-        return true;
-      }
-
-      if (filters.includes(FilterStateEnum.COMPANIES) && party.partyType === 'Organization') {
-        return true;
-      }
-
-      return filters.includes(FilterStateEnum.PERSONS) && party.partyType === 'Person';
-    });
 
     return result;
   }, [parties, filterState, searchValue, includeDeletedParties]);

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
@@ -1,7 +1,7 @@
 import { BookmarkModal, BookmarkSettingsList, Heading, PageBase, Toolbar } from '@altinn/altinn-components';
 import { type ChangeEvent, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParties } from '../../api/hooks/useParties.ts';
+import { useSelectedPartyIds } from '../../api/hooks/usePartiesSelectors.ts';
 import { getPageRouteTitle } from '../../components/PageLayout/pageRouteToTitle.ts';
 import { usePageTitle } from '../../hooks/usePageTitle.tsx';
 import { PageRoutes } from '../routes.ts';
@@ -11,7 +11,7 @@ import { useSavedSearches } from './useSavedSearches.tsx';
 export const SavedSearchesPage = () => {
   const { t } = useTranslation();
   usePageTitle({ baseTitle: t('sidebar.saved_searches') });
-  const { selectedPartyIds } = useParties();
+  const selectedPartyIds = useSelectedPartyIds();
   const [inputValues, setInputValues] = useState<Record<string, string>>({});
   const [searchQuery, setSearchQuery] = useState('');
   const {

--- a/packages/frontend/src/pages/SavedSearches/searchUtils.ts
+++ b/packages/frontend/src/pages/SavedSearches/searchUtils.ts
@@ -1,15 +1,10 @@
 import type { BookmarkSettingsItemProps, QueryItemProps } from '@altinn/altinn-components';
-import {
-  DialogStatus,
-  type OrganizationFieldsFragment,
-  type SavedSearchesFieldsFragment,
-  type ServiceResource,
-  SystemLabel,
-} from 'bff-types-generated';
+import { DialogStatus, type SavedSearchesFieldsFragment, type ServiceResource, SystemLabel } from 'bff-types-generated';
 import type { Locale } from 'date-fns';
 import type { TFunction } from 'i18next';
 import { logError } from '../../analytics/errorLogger.ts';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
+import type { OrganizationLookup } from '../../api/utils/organizations.ts';
 import { getOrganization } from '../../api/utils/organizations.ts';
 import type { FormatDistanceFunction } from '../../i18n/useDateFnsLocale.tsx';
 import { DateFilterOption, formatDateRange, formatSingleDate } from '../Inbox/filters';
@@ -37,13 +32,13 @@ export const isPlaceholderValue = (value: string | undefined | null): boolean =>
 export const buildFilterParams = (
   savedSearch: SavedSearchesFieldsFragment,
   deps: {
-    organizations: OrganizationFieldsFragment[];
-    serviceResources: ServiceResource[];
+    organizations: OrganizationLookup;
+    serviceResourceById: Map<string, ServiceResource>;
     locale: Locale;
     t: TFunction;
   },
 ): QueryItemProps[] => {
-  const { organizations, serviceResources, locale, t } = deps;
+  const { organizations, serviceResourceById, locale, t } = deps;
   const filters = savedSearch.data?.filters ?? [];
 
   const fromDateFilter = filters.find((f) => f?.id === 'fromDate');
@@ -71,7 +66,7 @@ export const buildFilterParams = (
       }
 
       if (filter?.id === 'service') {
-        const service = serviceResources.find((sr) => sr.id === filter.value);
+        const service = serviceResourceById.get(filter.value ?? '');
         return { type: 'filter', label: service?.title ?? '' };
       }
 

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
@@ -13,7 +13,7 @@ import type {
   SavedSearchesQuery,
   SearchDataValueFilter,
 } from 'bff-types-generated';
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps, useNavigate } from 'react-router-dom';
 import { Analytics } from '../../analytics/analytics.ts';
@@ -22,6 +22,7 @@ import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
 import { useParties } from '../../api/hooks/useParties.ts';
 import { useServiceResource } from '../../api/hooks/useServiceResource.ts';
 import { createSavedSearch, deleteSavedSearch, fetchSavedSearches, updateSavedSearch } from '../../api/queries.ts';
+import { buildOrganizationMap } from '../../api/utils/organizations.ts';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useErrorLogger } from '../../hooks/useErrorLogger';
@@ -127,8 +128,9 @@ export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesO
   const [isCTALoading, setIsCTALoading] = useState<boolean>(false);
   const [openedSavedSearch, setOpenedSavedSearch] = useState<string | null>(null);
   const { organizations } = useOrganizations();
-  const { serviceResources } = useServiceResource();
-  const { parties, currentEndUser, setSelectedPartyIds } = useParties();
+  const orgMap = useMemo(() => buildOrganizationMap(organizations), [organizations]);
+  const { serviceResourceById } = useServiceResource();
+  const { currentEndUser, setSelectedPartyIds, partyGraph } = useParties();
   const { locale } = useDateFnsLocale();
   const navigate = useNavigate();
 
@@ -256,25 +258,31 @@ export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesO
     }
   };
 
-  const getSavedSearchGroupId = (savedSearch: SavedSearchesFieldsFragment): string => {
-    const urn = savedSearch.data?.urn;
-    if (!urn?.length) return 'personal';
-    if (urn.length === 1 && urn[0] === currentEndUser?.party) return 'personal';
-    if (urn.length === 1) return urn[0]!;
-    return 'all-organizations';
-  };
+  const getSavedSearchGroupId = useCallback(
+    (savedSearch: SavedSearchesFieldsFragment): string => {
+      const urn = savedSearch.data?.urn;
+      if (!urn?.length) return 'personal';
+      if (urn.length === 1 && urn[0] === currentEndUser?.party) return 'personal';
+      if (urn.length === 1) return urn[0]!;
+      return 'all-organizations';
+    },
+    [currentEndUser?.party],
+  );
 
-  const groups: Record<string, BookmarkSettingsGroupProps> = {
-    personal: { title: t('savedSearches.groups.personal') },
-    'all-organizations': { title: t('savedSearches.groups.all_organizations') },
-  };
+  const groups: Record<string, BookmarkSettingsGroupProps> = useMemo(() => {
+    const result: Record<string, BookmarkSettingsGroupProps> = {
+      personal: { title: t('savedSearches.groups.personal') },
+      'all-organizations': { title: t('savedSearches.groups.all_organizations') },
+    };
 
-  for (const savedSearch of endUsersSavedSearches) {
-    const groupId = getSavedSearchGroupId(savedSearch);
-    if (groupId !== 'personal' && groupId !== 'all-organizations' && !groups[groupId]) {
-      groups[groupId] = { title: parties.find((p) => p.party === groupId)?.name ?? groupId };
+    for (const savedSearch of endUsersSavedSearches) {
+      const groupId = getSavedSearchGroupId(savedSearch);
+      if (groupId !== 'personal' && groupId !== 'all-organizations' && !result[groupId]) {
+        result[groupId] = { title: partyGraph.partyByUrn.get(groupId)?.name ?? groupId };
+      }
     }
-  }
+    return result;
+  }, [endUsersSavedSearches, getSavedSearchGroupId, partyGraph, t]);
 
   if (isLoading) {
     const items = Array.from({ length: 3 }, (_, i) => ({
@@ -321,7 +329,7 @@ export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesO
     const bookmarkLink = buildSavedSearchURL(savedSearch);
     const searchId = savedSearch.id.toString();
     const groupId = getSavedSearchGroupId(savedSearch);
-    const params = buildFilterParams(savedSearch, { organizations, serviceResources, locale, t });
+    const params = buildFilterParams(savedSearch, { organizations: orgMap, serviceResourceById, locale, t });
     /* PartyId for person users cannot be exposed in url because in risk of leaking sensitive info */
     const isPersonBookmark =
       savedSearch?.data?.urn?.length === 1 && savedSearch.data?.urn[0]?.includes('urn:altinn:person:identifier-no:');

--- a/packages/frontend/tests/stories/common.ts
+++ b/packages/frontend/tests/stories/common.ts
@@ -1,4 +1,22 @@
 import { type Locator, type Page, expect } from '@playwright/test';
+import { baseURL } from '../';
+
+/**
+ * Sets the AltinnPartyUuid cookie before page load so the app
+ * initializes with the given party pre-selected (simulating a
+ * returning user whose last-used party was persisted in a cookie).
+ */
+export async function setPartyCookie(page: Page, partyUuid: string) {
+  const url = new URL(baseURL);
+  await page.context().addCookies([
+    {
+      name: 'AltinnPartyUuid',
+      value: partyUuid,
+      domain: url.hostname,
+      path: '/',
+    },
+  ]);
+}
 
 export const getSidebar = (page: Page) => page.locator('aside');
 export const getSidebarMenuItem = (page: Page, route: string) => getSidebar(page).locator(`a[href*="${route}?"]`);

--- a/packages/frontend/tests/stories/cookiePartySelection.spec.ts
+++ b/packages/frontend/tests/stories/cookiePartySelection.spec.ts
@@ -1,0 +1,166 @@
+import { baseURL } from '../';
+import { expect, test } from '../fixtures';
+import { expectIsCompanyPage, expectIsPersonPage, setPartyCookie } from './common';
+
+const appURL = `${baseURL}/?mock=true&playwrightId=login-party-context`;
+
+const FIRMA_AS_UUID = 'urn:altinn:organization:uuid:firma-as';
+const FIRMA_AS_URN = 'urn:altinn:organization:identifier-no:1';
+const PERSON_UUID = 'urn:altinn:person:uuid:test-testesen';
+const TESTBEDRIFT_UUID = 'urn:altinn:organization:uuid:testbedrift-main';
+const TESTBEDRIFT_URN = 'urn:altinn:organization:identifier-no:2';
+
+test.describe('Cookie-based party preselection', () => {
+  test('Preselects company party from cookie on load', async ({ page }) => {
+    await setPartyCookie(page, FIRMA_AS_UUID);
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Firma AS should be the selected party (from cookie)
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Firma AS');
+
+    // Should show Firma AS messages, not person messages
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).not.toBeVisible();
+
+    // Should have company colour theme
+    await expectIsCompanyPage(page);
+
+    // URL should have party param set (company selection is stored in URL)
+    const url = new URL(page.url());
+    expect(url.searchParams.get('party')).toBe(FIRMA_AS_URN);
+  });
+
+  test('Can switch from cookie-preselected company to current end user (person)', async ({ page }) => {
+    // Start with Firma AS pre-selected via cookie
+    await setPartyCookie(page, FIRMA_AS_UUID);
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Verify Firma AS is initially selected
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Firma AS');
+    await expectIsCompanyPage(page);
+
+    // Switch to the current end user (Test Testesen)
+    await page.locator('#toolbar-menu-root > button').click();
+    await page.getByRole('option', { name: 'Test Testesen' }).click();
+
+    // Verify person party is now selected
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Test Testesen');
+    await expectIsPersonPage(page);
+
+    // Verify person messages are visible and company messages are hidden
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).not.toBeVisible();
+
+    // Person parties don't store the party in the URL
+    const url = new URL(page.url());
+    expect(url.searchParams.has('party')).toBe(false);
+    expect(url.searchParams.has('allParties')).toBe(false);
+  });
+
+  test('Can switch from cookie-preselected company to another company', async ({ page }) => {
+    // Start with Firma AS pre-selected via cookie
+    await setPartyCookie(page, FIRMA_AS_UUID);
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Verify Firma AS is initially selected
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Firma AS');
+
+    // Switch to Testbedrift AS
+    await page.locator('#toolbar-menu-root > button').click();
+    await page.locator(`[role="option"][data-id="${TESTBEDRIFT_URN}"]`).click();
+
+    // Verify Testbedrift AS is selected
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Testbedrift As');
+    await expectIsCompanyPage(page);
+
+    // Verify Testbedrift messages are visible
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Testbedrift AS', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).not.toBeVisible();
+
+    // URL should reflect the new party
+    const url = new URL(page.url());
+    expect(url.searchParams.get('party')).toBe(TESTBEDRIFT_URN);
+  });
+
+  test('Can switch from cookie-preselected company to all parties', async ({ page }) => {
+    // Start with Firma AS pre-selected via cookie
+    await setPartyCookie(page, FIRMA_AS_UUID);
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Verify Firma AS is initially selected
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Firma AS');
+
+    // Switch to "Alle virksomheter"
+    await page.locator('#toolbar-menu-root > button').click();
+    await page.getByRole('option', { name: 'Alle virksomheter' }).click();
+
+    // All-organizations mode uses person color with neutral theme
+    await expectIsPersonPage(page);
+
+    // Verify all company messages are visible (but not person messages)
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Testbedrift AS', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Innkalling til sesjon' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).not.toBeVisible();
+
+    // URL should have allParties=true, no party param
+    const url = new URL(page.url());
+    expect(url.searchParams.has('party')).toBe(false);
+    expect(url.searchParams.get('allParties')).toBe('true');
+  });
+
+  test('Preselects person party from cookie on load', async ({ page }) => {
+    await setPartyCookie(page, PERSON_UUID);
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Person party should be selected (from cookie)
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Test Testesen');
+    await expectIsPersonPage(page);
+
+    // Should show person messages
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).not.toBeVisible();
+
+    // Person parties don't store party in URL
+    const url = new URL(page.url());
+    expect(url.searchParams.has('party')).toBe(false);
+  });
+
+  test('Preselects parent org with sub-parties from cookie on load', async ({ page }) => {
+    await setPartyCookie(page, TESTBEDRIFT_UUID);
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Testbedrift AS should be selected (from cookie)
+    await expect(page.locator('#toolbar-menu-root')).toContainText(/Testbedrift A[Ss]/i);
+    await expectIsCompanyPage(page);
+
+    // Should show Testbedrift messages (including sub-party messages)
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Testbedrift AS', exact: true })).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: 'This is a message 1 for Testbedrift AS sub party AVD SUB' }),
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'This is a message 1 for Firma AS' })).not.toBeVisible();
+
+    // URL should have party param
+    const url = new URL(page.url());
+    expect(url.searchParams.get('party')).toBe(TESTBEDRIFT_URN);
+  });
+
+  test('Falls back to current end user when cookie has unknown party UUID', async ({ page }) => {
+    // Set a cookie with a UUID that doesn't match any party
+    await setPartyCookie(page, 'urn:altinn:organization:uuid:does-not-exist');
+    await page.goto(appURL);
+    await page.waitForLoadState('networkidle');
+
+    // Should fall back to the current end user (Test Testesen)
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Test Testesen');
+    await expectIsPersonPage(page);
+    await expect(page.getByRole('link', { name: 'Skatten din for 2022' })).toBeVisible();
+  });
+});

--- a/packages/frontend/tests/stories/partiesExtreme.spec.ts
+++ b/packages/frontend/tests/stories/partiesExtreme.spec.ts
@@ -1,0 +1,169 @@
+import { baseURL } from '../';
+import { expect, test } from '../fixtures';
+import { expectIsCompanyPage, expectIsPersonPage, setPartyCookie } from './common';
+
+const appURL = `${baseURL}/?mock=true&playwrightId=parties-extreme`;
+
+/**
+ * Performance-oriented tests for the parties-extreme story (15 000 parties).
+ *
+ * These tests assert that the app remains usable under a large party list:
+ *  – initial load completes within a budget
+ *  – party switching is responsive
+ *  – the account menu can be opened and searched
+ *
+ * A generous timeout (30 s) is set per test so CI doesn't flake, but each
+ * test records and logs real timings so regressions are visible in output.
+ */
+
+/* Give these tests extra room – 15k parties is heavy */
+test.describe.configure({ timeout: 30_000 });
+
+test.describe('Parties extreme (15 000 parties)', () => {
+  test('loads and becomes interactive within performance budget', async ({ page }) => {
+    const start = Date.now();
+    await page.goto(appURL);
+
+    // Wait for the toolbar to show the current end user – that means parties
+    // have been fetched, processed, and the UI has settled.
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Ola Hansen', { timeout: 15_000 });
+    const loadTime = Date.now() - start;
+
+    // The inbox list should render (dialogs come from base mock data)
+    await expect(page.locator('main')).toBeVisible();
+
+    // eslint-disable-next-line no-console -- intentional perf logging
+    console.debug(`[perf] Initial load with 15k parties: ${loadTime}ms`);
+
+    // Fail if it takes more than 10 seconds – a signal something regressed
+    expect(loadTime).toBeLessThan(10_000);
+  });
+
+  test('can open account menu and see parties', async ({ page }) => {
+    await page.goto(appURL);
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Ola Hansen', { timeout: 15_000 });
+
+    const start = Date.now();
+    await page.locator('#toolbar-menu-root > button').click();
+
+    // The account menu should appear
+    const menu = page.locator('#toolbar-menu-listbox');
+    await expect(menu).toBeVisible();
+
+    // Should contain "Alle virksomheter" group and person entries
+    await expect(page.getByRole('option', { name: 'Alle virksomheter' })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'Kari Johansen' })).toBeVisible();
+
+    const menuOpenTime = Date.now() - start;
+    console.debug(`[perf] Account menu open with 15k parties: ${menuOpenTime}ms`);
+
+    expect(menuOpenTime).toBeLessThan(5_000);
+  });
+
+  test('can switch to a company party via search', async ({ page }) => {
+    await page.goto(appURL);
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Ola Hansen', { timeout: 15_000 });
+
+    // Open the account menu
+    await page.locator('#toolbar-menu-root > button').click();
+    await expect(page.locator('#toolbar-menu-listbox')).toBeVisible();
+
+    // Search for a specific company to find it in the 15k list
+    const searchInput = page.getByRole('searchbox', { name: 'Søk etter aktør' });
+    await searchInput.fill('Stavanger');
+
+    // Click the first matching company option
+    const start = Date.now();
+    const firstMatch = page
+      .locator('#toolbar-menu-listbox [role="option"]')
+      .filter({ hasText: /Stavanger/i })
+      .first();
+    await expect(firstMatch).toBeVisible();
+    const matchName = await firstMatch.innerText();
+    await firstMatch.click();
+
+    // Verify company was selected
+    await expectIsCompanyPage(page);
+    await expect(page.locator('#toolbar-menu-root')).toContainText(/Stavanger/i);
+
+    const switchTime = Date.now() - start;
+    console.debug(`[perf] Switch to company party (${matchName.trim().split('\n')[0]}): ${switchTime}ms`);
+
+    expect(switchTime).toBeLessThan(5_000);
+  });
+
+  test('can switch to all organizations', async ({ page }) => {
+    await page.goto(appURL);
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Ola Hansen', { timeout: 15_000 });
+
+    // Open the account menu
+    await page.locator('#toolbar-menu-root > button').click();
+    await expect(page.locator('#toolbar-menu-listbox')).toBeVisible();
+
+    // Select "Alle virksomheter"
+    const start = Date.now();
+    await page.getByRole('option', { name: 'Alle virksomheter' }).click();
+
+    // URL should reflect all parties
+    await expect(page).toHaveURL(/allParties=true/);
+
+    const switchTime = Date.now() - start;
+    console.debug(`[perf] Switch to all organizations with 15k parties: ${switchTime}ms`);
+
+    expect(switchTime).toBeLessThan(5_000);
+  });
+
+  test('can switch back to person after selecting company', async ({ page }) => {
+    // Pre-select a company via cookie so we start on company view
+    await setPartyCookie(page, 'urn:altinn:organization:uuid:000001');
+    await page.goto(appURL);
+
+    // Wait for the company to be fully resolved from cookie before asserting page color
+    await expect(page.locator('#toolbar-menu-root')).toContainText(/Transport/i, { timeout: 15_000 });
+    await expectIsCompanyPage(page);
+
+    // Switch to person (current end user)
+    await page.locator('#toolbar-menu-root > button').click();
+    await expect(page.locator('#toolbar-menu-listbox')).toBeVisible();
+
+    const start = Date.now();
+    await page.getByRole('option', { name: 'Ola Hansen' }).first().click();
+
+    await expectIsPersonPage(page);
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Ola Hansen');
+
+    const switchTime = Date.now() - start;
+    console.debug(`[perf] Switch from company to person: ${switchTime}ms`);
+
+    expect(switchTime).toBeLessThan(7_000);
+  });
+
+  test('account menu search filters 15k parties responsively', async ({ page }) => {
+    await page.goto(appURL);
+    await expect(page.locator('#toolbar-menu-root')).toContainText('Ola Hansen', { timeout: 15_000 });
+
+    // Open the account menu
+    await page.locator('#toolbar-menu-root > button').click();
+    await expect(page.locator('#toolbar-menu-listbox')).toBeVisible();
+
+    // Type in the search field
+    const searchInput = page.getByRole('searchbox', { name: 'Søk etter aktør' });
+    await expect(searchInput).toBeVisible();
+
+    const start = Date.now();
+    await searchInput.fill('Tromsø Bygg');
+
+    // Wait for results to filter — should show matching entries
+    await expect(
+      page
+        .locator('#toolbar-menu-listbox [role="option"]')
+        .filter({ hasText: /Tromsø Bygg/i })
+        .first(),
+    ).toBeVisible();
+
+    const searchTime = Date.now() - start;
+    console.debug(`[perf] Account menu search with 15k parties: ${searchTime}ms`);
+
+    expect(searchTime).toBeLessThan(7_000);
+  });
+});


### PR DESCRIPTION
Updated PR to replace https://github.com/Altinn/dialogporten-frontend/pull/3910

- Replace O(n²) array lookups with precomputed `PartyGraph` (Map-based O(1) lookups by URN/UUID)
- Replace `String.localeCompare()` with cached `Intl.Collator` (~10-50x faster per comparison)
- Eliminate duplicate `buildPartyGraph` call in `useAccounts` — reuse graph from `useParties`
- Cap avatar group items to 10 (was mapping all 15k orgs for an icon showing ~4)
- Cache `formatDisplayName` results in `normalizeFlattenParties`
- Add selector hooks (`usePartiesSelectors`) for fine-grained React Query subscriptions
- Convert array `.find()` to Map `.get()` in dialog utils, saved searches, service resources, and filters

Testing:

- Add Playwright performance tests for 15k parties with timing budgets
- Add cookie-based party preselection tests (person, company, parent org, all orgs, unknown UUID fallback)

Want me to create the PR now?

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
