### PR TITLE
fix(useDialogByIdSubscription): add backoff and visibility-aware reconnect

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogByIdSubscription.spec.ts
+++ b/packages/frontend/src/api/hooks/useDialogByIdSubscription.spec.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react';
+import { DialogEventType } from 'bff-types-generated';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SSEListener = (event: MessageEvent) => void;
+const listeners = new Map<string, SSEListener>();
+
+const mockClose = vi.fn();
+const mockSSECtor = vi.fn();
+
+vi.mock('sse.js', () => {
+  class SSE {
+    constructor(url: string, opts: unknown) {
+      mockSSECtor(url, opts);
+      listeners.clear();
+    }
+    addEventListener(name: string, cb: SSEListener) {
+      listeners.set(name, cb);
+    }
+    close = mockClose;
+  }
+  return { SSE };
+});
+
+const invalidateQueries = vi.fn();
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries }) };
+});
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+vi.mock('../../featureFlags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../featureFlags')>();
+  return {
+    ...actual,
+    useFeatureFlag: () => false,
+  };
+});
+
+import { createCustomWrapper } from '../../../tests/test-utils';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
+import { useDialogByIdSubscription } from './useDialogByIdSubscription';
+
+describe('useDialogByIdSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listeners.clear();
+  });
+
+  const setHidden = (hidden: boolean) => {
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+
+  it('closes connection when tab is hidden and reconnects when visible', () => {
+    const { rerender } = renderHook(({ id, token }) => useDialogByIdSubscription(id, token), {
+      wrapper: createCustomWrapper(),
+      initialProps: { id: undefined as string | undefined, token: undefined as string | undefined },
+    });
+    rerender({ id: 'dialog-1', token: 'tok' });
+
+    // initial connect
+    expect(mockSSECtor).toHaveBeenCalledTimes(1);
+    expect(mockClose).not.toHaveBeenCalled();
+
+    // tab hidden → closes
+    act(() => setHidden(true));
+    expect(mockClose).toHaveBeenCalledTimes(1);
+
+    // tab visible → reconnects
+    act(() => setHidden(false));
+    expect(mockSSECtor).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates queries on DialogUpdated', () => {
+    const { rerender } = renderHook(({ id, token }) => useDialogByIdSubscription(id, token), {
+      wrapper: createCustomWrapper(),
+      initialProps: { id: undefined as string | undefined, token: undefined as string | undefined },
+    });
+    // flip args to trigger the effect past isFirstRender
+    rerender({ id: 'dialog-1', token: 'tok' });
+
+    expect(mockSSECtor).toHaveBeenCalledOnce();
+
+    act(() => {
+      listeners.get('next')?.({
+        data: JSON.stringify({
+          data: { dialogEvents: { type: DialogEventType.DialogUpdated } },
+        }),
+      } as MessageEvent);
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: [QUERY_KEYS.DIALOG_BY_ID] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: [QUERY_KEYS.DIALOGS] });
+  });
+
+  it('does not connect when mock=true', () => {
+    window.history.replaceState({}, '', '/?mock=true');
+    renderHook(() => useDialogByIdSubscription('d', 't'), { wrapper: createCustomWrapper() });
+    expect(mockSSECtor).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/api/hooks/useDialogByIdSubscription.ts
+++ b/packages/frontend/src/api/hooks/useDialogByIdSubscription.ts
@@ -49,16 +49,44 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
     if (!dialogId || !dialogToken || isMock) return;
 
     let cancelled = false;
+    let retryAttempt = 0;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
 
-    const connect = () => {
-      if (cancelled) return;
-      if (!navigator.onLine) return;
+    const clearRetry = () => {
+      if (retryTimeout !== null) {
+        clearTimeout(retryTimeout);
+        retryTimeout = null;
+      }
+    };
 
-      // Close existing connection before creating a new one
+    const closeConnection = () => {
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
         eventSourceRef.current = null;
       }
+    };
+
+    const scheduleReconnect = () => {
+      clearRetry();
+      // Exponential backoff with full jitter: base 1s, max 30s.
+      // Prevents retry storms when many clients reconnect after a transient outage.
+      const base = 1000;
+      const max = 30000;
+      const exp = Math.min(max, base * 2 ** retryAttempt);
+      const delay = Math.random() * exp;
+      retryAttempt = Math.min(retryAttempt + 1, 10);
+      retryTimeout = setTimeout(connect, delay);
+    };
+
+    // Lifecycle: opens on mount / tab becoming visible / network coming online,
+    // closes on unmount / tab hidden, and reconnects with exponential backoff on error.
+    const connect = () => {
+      if (cancelled) return;
+      if (document.hidden) return;
+      if (!navigator.onLine) return;
+
+      clearRetry();
+      closeConnection();
 
       const eventSource = new SSE(config.dialogportenStreamUrl, {
         method: 'POST',
@@ -75,6 +103,11 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
       });
 
       eventSourceRef.current = eventSource;
+
+      eventSource.addEventListener('open', () => {
+        if (cancelled) return;
+        retryAttempt = 0;
+      });
 
       eventSource.addEventListener('next', (event: MessageEvent) => {
         if (cancelled) return;
@@ -107,25 +140,36 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
       eventSource.addEventListener('error', (err: EventSourceEvent) => {
         if (cancelled) return;
         if (err.responseCode === 0) {
-          eventSource.close();
+          closeConnection();
           return;
         }
         logError(err, { context: 'useDialogByIdSubscription.onError', dialogId }, 'EventSource connection error');
-        eventSource.close();
-        setTimeout(connect, 500);
+        closeConnection();
+        scheduleReconnect();
       });
+    };
+
+    const handleVisibilityChange = () => {
+      if (cancelled) return;
+      if (document.hidden) {
+        clearRetry();
+        closeConnection();
+      } else {
+        retryAttempt = 0;
+        connect();
+      }
     };
 
     connect();
     window.addEventListener('online', connect);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       cancelled = true;
+      clearRetry();
       window.removeEventListener('online', connect);
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        eventSourceRef.current = null;
-      }
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      closeConnection();
     };
   }, [dialogId, dialogToken, search, isMock, disableSubscriptions]);
 

--- a/packages/frontend/src/pages/DialogDetailsPage/useDelegation.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/useDelegation.tsx
@@ -29,9 +29,9 @@ export const useDelegation = (dialogId?: string, party?: string, org?: string): 
   const orgsNotReadyToDealWithDelegations = useFeatureFlag<string[]>('auth.orgsNotReadyToDealWithDelegations');
   const { data, isSuccess } = useAuthenticatedQuery<DialogLookupQuery>({
     queryKey: [QUERY_KEYS.DIALOG_DELEGATION_LOOKUP, dialogId],
-    staleTime: 0,
+    staleTime: 600_000,
     refetchInterval: 1_200_000,
-    refetchOnMount: 'always',
+    refetchOnMount: false,
     retry: 3,
     queryFn: async () => graphQLSDK.dialogLookup({ instanceRef: instanceRef }),
     enabled: !!dialogId && !!enableDelegationLink,


### PR DESCRIPTION
This PR does following improvements to subscriptions to dialog:

- Replace flat 500ms retry with exponential backoff (base 1s, max 30s)
plus full jitter to avoid retry storms during transient outages.

- Close the SSE connection on visibilitychange when the tab is hidden
and reconnect when it becomes visible again, so idle background tabs
don't hold connections open.


<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3965

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
