### PR TITLE
fix(useAccounts): avoid re-mapping 15k parties on every party switch (proposal)

### DIFF
--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -116,8 +116,11 @@ export const useParties = (): UsePartiesOutput => {
       handleChangSearchParams(params);
     }
 
-    const partyIdSet = new Set(partyIds);
-    const matchedParties = data?.filter((party) => partyIdSet.has(party.party)) ?? [];
+    const matchedParties: PartyFieldsFragment[] = [];
+    for (const id of partyIds) {
+      const p = partyGraph.partyByUrn.get(id);
+      if (p) matchedParties.push(p);
+    }
     handleSetSelectedParties(matchedParties);
 
     const partyForCookie = allOrgSelected ? currentEndUser : matchedParties[0];

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.spec.ts
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.spec.ts
@@ -3,7 +3,6 @@ import type { PartyFieldsFragment } from 'bff-types-generated';
 import { useTranslation } from 'react-i18next';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCustomWrapper } from '../../../../tests/test-utils.tsx';
-import { useParties } from '../../../api/hooks/useParties.ts';
 import { useProfile } from '../../../pages/Profile';
 import { buildPartyGraph } from '../../../utils/partyGraph.ts';
 import { formatNorwegianId, formatSSN, useAccounts } from './useAccounts.tsx';
@@ -11,10 +10,6 @@ import { formatNorwegianId, formatSSN, useAccounts } from './useAccounts.tsx';
 // Mock dependencies
 vi.mock('react-i18next', () => ({
   useTranslation: vi.fn(),
-}));
-
-vi.mock('../../../api/hooks/useParties.ts', () => ({
-  useParties: vi.fn(),
 }));
 
 vi.mock('../../../pages/Profile', () => ({
@@ -136,10 +131,6 @@ describe('useAccounts', () => {
     vi.clearAllMocks();
 
     (useTranslation as Mock).mockReturnValue({ t: mockT });
-    (useParties as Mock).mockReturnValue({
-      setSelectedPartyIds: mockSetSelectedPartyIds,
-      partyGraph: buildPartyGraph(parties),
-    });
     (useProfile as Mock).mockReturnValue({ favoritesGroup: { parties: [] } });
   });
 
@@ -151,6 +142,8 @@ describe('useAccounts', () => {
           selectedParties: [],
           allOrganizationsSelected: false,
           isLoading: false,
+          partyGraph: buildPartyGraph(parties),
+          setSelectedPartyIds: mockSetSelectedPartyIds,
         }),
       {
         wrapper: createCustomWrapper(),
@@ -172,6 +165,8 @@ describe('useAccounts', () => {
           selectedParties,
           allOrganizationsSelected: false,
           isLoading: false,
+          partyGraph: buildPartyGraph(parties),
+          setSelectedPartyIds: mockSetSelectedPartyIds,
         }),
       {
         wrapper: createCustomWrapper(),
@@ -198,6 +193,8 @@ describe('useAccounts', () => {
           selectedParties,
           allOrganizationsSelected: false,
           isLoading: false,
+          partyGraph: buildPartyGraph(parties),
+          setSelectedPartyIds: mockSetSelectedPartyIds,
         }),
       {
         wrapper: createCustomWrapper(),
@@ -224,6 +221,8 @@ describe('useAccounts', () => {
           selectedParties,
           allOrganizationsSelected: false,
           isLoading: false,
+          partyGraph: buildPartyGraph(parties),
+          setSelectedPartyIds: mockSetSelectedPartyIds,
         }),
       {
         wrapper: createCustomWrapper(),
@@ -254,6 +253,8 @@ describe('useAccounts', () => {
           selectedParties,
           allOrganizationsSelected: false,
           isLoading: false,
+          partyGraph: buildPartyGraph(parties),
+          setSelectedPartyIds: mockSetSelectedPartyIds,
           options,
         }),
       {

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
@@ -12,7 +12,6 @@ import i18n from 'i18next';
 import { type ChangeEvent, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { useParties } from '../../../api/hooks/useParties.ts';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { useFeatureFlag } from '../../../featureFlags';
 import { FixedGlobalQueryParams } from '../../../pages/Inbox/queryParams.ts';
@@ -50,8 +49,8 @@ interface UseAccountsProps {
   options?: UseAccountOptions;
   isLoading?: boolean;
   availableParties?: PartyFieldsFragment[];
-  /** Pre-built party graph to avoid duplicate O(n) graph construction. Falls back to useParties().partyGraph */
-  partyGraph?: PartyGraph;
+  partyGraph: PartyGraph;
+  setSelectedPartyIds: (parties: string[], allOrganizationsSelected: boolean) => void;
 }
 
 interface UseAccountsOutput {
@@ -110,11 +109,11 @@ export const useAccounts = ({
   options: inputOptions,
   isLoading,
   availableParties: _availableParties,
-  partyGraph: externalPartyGraph,
+  partyGraph,
+  setSelectedPartyIds,
 }: UseAccountsProps): UseAccountsOutput => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { setSelectedPartyIds, partyGraph: hookPartyGraph } = useParties();
   const { user, favoritesGroup, shouldShowDeletedEntities } = useProfile();
   const isDeletedUnitsFilterEnabled = useFeatureFlag<boolean>('inbox.enableDeletedUnitsFilter');
   const [searchString, setSearchString] = useState<string>('');
@@ -170,7 +169,6 @@ export const useAccounts = ({
         const ssnOrOrgNo = getSSNOrOrgNo(person.party);
         return {
           id: person.party,
-          selected: !allOrganizationsSelected && person.party === selectedParties[0]?.party,
           searchWords: [person.name, ssnOrOrgNo],
           ssnOrOrgNo,
           name: person.name,
@@ -189,19 +187,17 @@ export const useAccounts = ({
         } as PartyItemProp;
       })
       .sort((a, b) => compareName(a.name, b.name));
-  }, [allOrganizationsSelected, otherPeople, favoritesSet, options.showDescription, t, selectedParties, user]);
+  }, [otherPeople, favoritesSet, options.showDescription, t, user]);
 
-  const availablePartiesGraph = externalPartyGraph ?? hookPartyGraph;
-
-  const currentEndUser = availablePartiesGraph.currentEndUser;
+  const currentEndUser = partyGraph.currentEndUser;
 
   const organizationAccounts = useMemo<PartyItemProp[]>(() => {
     const mapped = organizations.map((party) => {
-      const matchInAvailable = availablePartiesGraph.partyByUrn.get(party.party);
+      const matchInAvailable = partyGraph.partyByUrn.get(party.party);
       const isParent = Array.isArray(matchInAvailable?.subParties);
       const isPreselectedParty = user?.profileSettingPreference?.preselectedPartyUuid === party.partyUuid;
 
-      const parent = isParent ? undefined : availablePartiesGraph.parentByChildUrn.get(party.party);
+      const parent = isParent ? undefined : partyGraph.parentByChildUrn.get(party.party);
 
       const description =
         parent?.name && party?.party
@@ -213,7 +209,6 @@ export const useAccounts = ({
       const orgNo = getSSNOrOrgNo(party.party);
       return {
         id: party.party,
-        selected: !allOrganizationsSelected && party.party === selectedParties[0]?.party,
         searchWords: [orgNo, party.name],
         ssnOrOrgNo: orgNo,
         name: party.name,
@@ -264,16 +259,7 @@ export const useAccounts = ({
     const grouped = parents.flatMap((p) => [p, ...(childrenByParentId.get(p.id) ?? [])]);
 
     return [...grouped, ...children];
-  }, [
-    selectedParties,
-    allOrganizationsSelected,
-    organizations,
-    availablePartiesGraph,
-    favoritesSet,
-    options.showDescription,
-    t,
-    user,
-  ]);
+  }, [organizations, partyGraph, favoritesSet, options.showDescription, t, user]);
 
   /** deleted units filtering - FF: "inbox.enableDeletedUnitsFilter"
    * FF off -> always include deleted parties
@@ -351,12 +337,14 @@ export const useAccounts = ({
       } as AvatarGroupProps,
     };
 
+    const selectedUrn = allOrganizationsSelected ? null : (selectedParties[0]?.party ?? null);
+
     const favorites: PartyItemProp[] = [];
     for (const a of organizationAccounts) {
-      if (a.isFavorite) favorites.push({ ...a, groupId: SettingsType.favorites });
+      if (a.isFavorite) favorites.push({ ...a, groupId: SettingsType.favorites, selected: a.id === selectedUrn });
     }
     for (const a of otherPeopleAccounts) {
-      if (a.isFavorite) favorites.push({ ...a, groupId: SettingsType.favorites });
+      if (a.isFavorite) favorites.push({ ...a, groupId: SettingsType.favorites, selected: a.id === selectedUrn });
     }
 
     const result: PartyItemProp[] = [];
@@ -365,8 +353,12 @@ export const useAccounts = ({
       for (const f of favorites) result.push(f);
     }
     if (options.showGroups && organizationAccounts.length > 1) result.push(allOrganizationsAccount);
-    for (const a of otherPeopleAccounts) result.push(a);
-    for (const a of organizationAccounts) result.push(a);
+    for (const a of otherPeopleAccounts) {
+      result.push(a.id === selectedUrn ? { ...a, selected: true } : a);
+    }
+    for (const a of organizationAccounts) {
+      result.push(a.id === selectedUrn ? { ...a, selected: true } : a);
+    }
 
     let finalAccounts = result;
     if (shouldExcludeDeleted && !includeDeletedParties) {
@@ -411,7 +403,7 @@ export const useAccounts = ({
           search.delete(FixedGlobalQueryParams.party);
           search.delete(FixedGlobalQueryParams.subAccounts);
         } else {
-          const party = availablePartiesGraph.partyByUrn.get(partyId);
+          const party = partyGraph.partyByUrn.get(partyId);
           if (!party) {
             console.error('Selected party not found:', partyId);
             return;
@@ -423,7 +415,7 @@ export const useAccounts = ({
         navigate(`${route}?${search.toString()}`, { replace: true });
       }
     },
-    [selectedParties, queryClient, setSelectedPartyIds, availablePartiesGraph, navigate],
+    [selectedParties, queryClient, setSelectedPartyIds, partyGraph, navigate],
   );
 
   const accountSearch = useMemo(

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -130,6 +130,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const {
     selectedParties,
     selectedPartyIds,
+    setSelectedPartyIds,
     allOrganizationsSelected,
     parties,
     partiesEmptyList,
@@ -190,6 +191,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
     selectedParties,
     allOrganizationsSelected,
     partyGraph,
+    setSelectedPartyIds,
     options: {
       showGroups: true,
     },

--- a/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
+++ b/packages/frontend/src/pages/Profile/PartiesOverviewPage/PartiesOverviewPage.tsx
@@ -148,6 +148,7 @@ export const PartiesOverviewPage = () => {
     allOrganizationsSelected,
     isLoading,
     partyGraph,
+    setSelectedPartyIds,
     options: {
       showFavorites: !isSearching,
     },

--- a/packages/frontend/src/pages/Profile/Settings/useSettings.tsx
+++ b/packages/frontend/src/pages/Profile/Settings/useSettings.tsx
@@ -106,7 +106,14 @@ export const useSettings = ({
   isSelfIdentifiedUser = false,
   disabled = false,
 }: UseSettingsInput = {}): UseSettingsOutput => {
-  const { isLoading: isLoadingParties, parties, selectedParties, allOrganizationsSelected, partyGraph } = useParties();
+  const {
+    isLoading: isLoadingParties,
+    parties,
+    selectedParties,
+    allOrganizationsSelected,
+    partyGraph,
+    setSelectedPartyIds,
+  } = useParties();
   const { user, showClientUnits, setShowClientUnits, shouldShowDeletedEntities, updateShowDeletedEntities } =
     useProfile();
   const { t } = useTranslation();
@@ -172,6 +179,7 @@ export const useSettings = ({
     allOrganizationsSelected,
     selectedParties,
     partyGraph,
+    setSelectedPartyIds,
     options: {
       groups: options?.groups,
       showDescription: true,


### PR DESCRIPTION
Party switching previously triggered full re-mapping + sorting of all 15k items just to flip one selected boolean. Now only a cheap linear pass runs on switch, while the expensive work (formatting, graph lookups, sorting) is memoized until the party list itself changes. setSelectedPartyIds also went from scanning all parties to a single Map lookup.

- Remove selectedParties/allOrganizationsSelected from organizationAccounts
  and otherPeopleAccounts memo deps; apply selected in the cheap
  assembledAccounts pass instead
- Use O(1) partyGraph lookups in setSelectedPartyIds instead of O(n) filter
- Remove redundant useParties() call from useAccounts; pass
  setSelectedPartyIds and partyGraph as props

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
