### PR TITLE
fix(useDialogByIdSubscription): ensure dialog is refetched on window focus to sync missed updates

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogById.tsx
+++ b/packages/frontend/src/api/hooks/useDialogById.tsx
@@ -14,6 +14,7 @@ import {
   SystemLabel,
 } from 'bff-types-generated';
 import { type TFunction, t } from 'i18next';
+import { useCallback } from 'react';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import type { DialogActionProps } from '../../components';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
@@ -110,6 +111,7 @@ interface UseDialogByIdOutput {
   dataUpdatedAt: number;
   dialog?: DialogByIdDetails;
   isAuthLevelTooLow?: boolean;
+  refreshDialogToken: () => Promise<string | undefined>;
 }
 export const getDialogsById = (id: string): Promise<GetDialogByIdQuery> =>
   graphQLSDK.getDialogById({
@@ -356,12 +358,7 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
     queryKey: [QUERY_KEYS.DIALOG_BY_ID, id],
     staleTime: 0,
     refetchInterval: 1000 * 60 * 9,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: (query) => {
-      if (!query.state.dataUpdatedAt) return true;
-      const NINE_MIN = 9 * 60 * 1000;
-      return Date.now() - query.state.dataUpdatedAt > NINE_MIN;
-    },
+    refetchOnWindowFocus: 'always',
     retry: 3,
     queryFn: async () => {
       const response = await getDialogsById(id!);
@@ -377,8 +374,15 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
     enabled: typeof id !== 'undefined' && partyURIs.length > 0,
   });
 
+  const refreshDialogToken = useCallback(async (): Promise<string | undefined> => {
+    if (!id) return undefined;
+    await queryClient.refetchQueries({ queryKey: [QUERY_KEYS.DIALOG_BY_ID, id] });
+    const freshData = queryClient.getQueryData<GetDialogByIdQuery>([QUERY_KEYS.DIALOG_BY_ID, id]);
+    return freshData?.dialogById?.dialog?.dialogToken ?? undefined;
+  }, [queryClient, id]);
+
   if (isOrganizationsLoading) {
-    return { isLoading: true, isError: false, isSuccess: false, dataUpdatedAt: Date.now() };
+    return { isLoading: true, isError: false, isSuccess: false, dataUpdatedAt: Date.now(), refreshDialogToken };
   }
 
   return {
@@ -397,5 +401,6 @@ export const useDialogById = (parties: PartyFieldsFragment[], id?: string): UseD
     isError,
     isAuthLevelTooLow:
       data?.dialogById?.errors?.some((error) => error.__typename === 'DialogByIdForbiddenAuthLevelTooLow') ?? false,
+    refreshDialogToken,
   };
 };

--- a/packages/frontend/src/api/hooks/useDialogByIdSubscription.spec.ts
+++ b/packages/frontend/src/api/hooks/useDialogByIdSubscription.spec.ts
@@ -46,6 +46,8 @@ import { createCustomWrapper } from '../../../tests/test-utils';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { useDialogByIdSubscription } from './useDialogByIdSubscription';
 
+const mockRefreshDialogToken = vi.fn().mockResolvedValue('fresh-tok');
+
 describe('useDialogByIdSubscription', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,8 +62,8 @@ describe('useDialogByIdSubscription', () => {
     document.dispatchEvent(new Event('visibilitychange'));
   };
 
-  it('closes connection when tab is hidden and reconnects when visible', () => {
-    const { rerender } = renderHook(({ id, token }) => useDialogByIdSubscription(id, token), {
+  it('closes connection when tab is hidden and reconnects when visible', async () => {
+    const { rerender } = renderHook(({ id, token }) => useDialogByIdSubscription(id, token, mockRefreshDialogToken), {
       wrapper: createCustomWrapper(),
       initialProps: { id: undefined as string | undefined, token: undefined as string | undefined },
     });
@@ -75,17 +77,16 @@ describe('useDialogByIdSubscription', () => {
     act(() => setHidden(true));
     expect(mockClose).toHaveBeenCalledTimes(1);
 
-    // tab visible → reconnects
-    act(() => setHidden(false));
+    // tab visible → refreshes token then reconnects
+    await act(async () => setHidden(false));
     expect(mockSSECtor).toHaveBeenCalledTimes(2);
   });
 
   it('invalidates queries on DialogUpdated', () => {
-    const { rerender } = renderHook(({ id, token }) => useDialogByIdSubscription(id, token), {
+    const { rerender } = renderHook(({ id, token }) => useDialogByIdSubscription(id, token, mockRefreshDialogToken), {
       wrapper: createCustomWrapper(),
       initialProps: { id: undefined as string | undefined, token: undefined as string | undefined },
     });
-    // flip args to trigger the effect past isFirstRender
     rerender({ id: 'dialog-1', token: 'tok' });
 
     expect(mockSSECtor).toHaveBeenCalledOnce();
@@ -104,7 +105,7 @@ describe('useDialogByIdSubscription', () => {
 
   it('does not connect when mock=true', () => {
     window.history.replaceState({}, '', '/?mock=true');
-    renderHook(() => useDialogByIdSubscription('d', 't'), { wrapper: createCustomWrapper() });
+    renderHook(() => useDialogByIdSubscription('d', 't', mockRefreshDialogToken), { wrapper: createCustomWrapper() });
     expect(mockSSECtor).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/src/api/hooks/useDialogByIdSubscription.ts
+++ b/packages/frontend/src/api/hooks/useDialogByIdSubscription.ts
@@ -21,7 +21,27 @@ export type DialogEventData = {
   };
 };
 
-export const useDialogByIdSubscription = (dialogId: string | undefined, dialogToken: string | undefined) => {
+/**
+ * Manages a Server-Sent Events (SSE) subscription for real-time dialog updates.
+ *
+ * SSE lifecycle:
+ * 1. Dialog details opened -> SSE connection established with the current dialogToken.
+ * 2. While on the dialog — periodic refetches (every 9 min) silently update the token
+ *    via a ref without tearing down the active SSE connection. TTL for token is 10 minutes.
+ * 3. Tab hidden -> SSE connection closed. Nothing runs in the background.
+ * 4. Tab visible -> dialog is refetched first (fresh data + fresh token), then SSE
+ *    reconnects with the new token. One fetch, one connection, no 401 risk.
+ * 5. Navigating away -> component unmounts, SSE closed, listeners removed.
+ *
+ * The dialogToken is stored in a ref (not an effect dependency) so that token
+ * refreshes from React Query (refetchOnWindowFocus, refetchInterval) never cause
+ * unnecessary SSE reconnections. Only dialogId changes trigger effect re-runs.
+ */
+export const useDialogByIdSubscription = (
+  dialogId: string | undefined,
+  dialogToken: string | undefined,
+  refreshDialogToken: () => Promise<string | undefined>,
+) => {
   const disableSubscriptions = useFeatureFlag<boolean>('dialogporten.disableSubscriptions');
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -32,21 +52,23 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
   const { logError } = useErrorLogger();
 
   const eventSourceRef = useRef<SSE | null>(null);
-  const isFirstRender = useRef(true);
   const onMessageRef = useRef<((eventData: DialogEventData, rawEvent: MessageEvent) => void) | undefined>(undefined);
+  const dialogTokenRef = useRef(dialogToken);
+  dialogTokenRef.current = dialogToken;
+  const refreshDialogTokenRef = useRef(refreshDialogToken);
+  refreshDialogTokenRef.current = refreshDialogToken;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // Flips false→true once when the fresh token arrives, but stays true on subsequent refreshes.
+  // This triggers the effect exactly once for initial connection without reconnecting on every token change.
+  const hasToken = !!dialogToken;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Token tracked via ref to avoid unnecessary reconnections
   useEffect(() => {
-    if (isFirstRender.current) {
-      isFirstRender.current = false;
-      return;
-    }
-
     if (disableSubscriptions) {
       return;
     }
 
-    if (!dialogId || !dialogToken || isMock) return;
+    if (!dialogId || !dialogTokenRef.current || isMock) return;
 
     let cancelled = false;
     let retryAttempt = 0;
@@ -85,6 +107,9 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
       if (document.hidden) return;
       if (!navigator.onLine) return;
 
+      const token = dialogTokenRef.current;
+      if (!token) return;
+
       clearRetry();
       closeConnection();
 
@@ -93,7 +118,7 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
           Accept: 'text/event-stream',
-          Authorization: `Bearer ${dialogToken}`,
+          Authorization: `Bearer ${token}`,
         },
         payload: JSON.stringify({
           query: getSubscriptionQuery(dialogId),
@@ -149,6 +174,24 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
       });
     };
 
+    const refreshAndConnect = () => {
+      refreshDialogTokenRef
+        .current()
+        .then((freshToken) => {
+          if (freshToken) {
+            dialogTokenRef.current = freshToken;
+          }
+        })
+        .catch(() => {
+          // Token refresh failed, will attempt connection with existing token
+        })
+        .finally(() => {
+          if (!cancelled) {
+            connect();
+          }
+        });
+    };
+
     const handleVisibilityChange = () => {
       if (cancelled) return;
       if (document.hidden) {
@@ -156,22 +199,27 @@ export const useDialogByIdSubscription = (dialogId: string | undefined, dialogTo
         closeConnection();
       } else {
         retryAttempt = 0;
-        connect();
+        refreshAndConnect();
       }
     };
 
+    const handleOnline = () => {
+      if (cancelled || document.hidden) return;
+      refreshAndConnect();
+    };
+
     connect();
-    window.addEventListener('online', connect);
+    window.addEventListener('online', handleOnline);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       cancelled = true;
       clearRetry();
-      window.removeEventListener('online', connect);
+      window.removeEventListener('online', handleOnline);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       closeConnection();
     };
-  }, [dialogId, dialogToken, search, isMock, disableSubscriptions]);
+  }, [dialogId, hasToken, search, isMock, disableSubscriptions]);
 
   const onMessageEvent = useCallback((handler: (eventData: DialogEventData, rawEvent: MessageEvent) => void) => {
     onMessageRef.current = handler;

--- a/packages/frontend/src/components/MainContentReference/mainContentReference.caching.spec.tsx
+++ b/packages/frontend/src/components/MainContentReference/mainContentReference.caching.spec.tsx
@@ -1,0 +1,48 @@
+import { QueryClient } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCustomWrapper } from '../../../tests/test-utils.tsx';
+import { EmbeddableMediaType } from '../../api/hooks/useDialogById.tsx';
+import { MainContentReference } from './MainContentReference.tsx';
+
+describe('MainContentReference caching', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('# Hello'),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const contentFetchCount = (spy: ReturnType<typeof vi.fn>, url: string) =>
+    spy.mock.calls.filter((c: unknown[]) => c[0] === url).length;
+
+  it('should not re-fetch content when dialogToken changes', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = createCustomWrapper(queryClient);
+    const contentUrl = 'https://example.com/content';
+    const content = { url: contentUrl, mediaType: EmbeddableMediaType.markdown };
+
+    const { rerender } = render(
+      <MainContentReference content={content} dialogToken="token-1" id="dialog-1" dialogId="dialog-1" />,
+      { wrapper },
+    );
+
+    await waitFor(() => expect(contentFetchCount(fetchSpy, contentUrl)).toBe(1));
+
+    // Re-render with a new token (simulates dialog refetch generating a new token)
+    rerender(<MainContentReference content={content} dialogToken="token-2" id="dialog-1" dialogId="dialog-1" />);
+
+    // Allow any pending queries to fire
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // staleTime: Infinity ensures content is fetched exactly once per dialog visit
+    expect(contentFetchCount(fetchSpy, contentUrl)).toBe(1);
+  });
+});

--- a/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/DialogDetailsPage.tsx
@@ -33,6 +33,7 @@ export const DialogDetailsPage = () => {
     isError,
     isAuthLevelTooLow,
     dataUpdatedAt,
+    refreshDialogToken,
   } = useDialogById(parties, dialogId);
   const isLoading = isLoadingDialog || (!isSuccess && !isError);
   const displayDialogActions = !!(dialogId && dialog && !isLoading);
@@ -92,7 +93,7 @@ export const DialogDetailsPage = () => {
   }, [qc, dialogId]);
 
   const dialogTokenIsFreshAfterMount = dataUpdatedAt > mountAtRef.current ? dialog?.dialogToken : undefined;
-  const { onMessageEvent } = useDialogByIdSubscription(dialog?.id, dialogTokenIsFreshAfterMount);
+  const { onMessageEvent } = useDialogByIdSubscription(dialog?.id, dialogTokenIsFreshAfterMount, refreshDialogToken);
   const previousPath = (location?.state?.fromView ?? '/') + location.search;
   const labelActions = dialogId && dialog ? createLabelUpdateActions(dialogId, dialog.label, dialog.unread) : [];
 


### PR DESCRIPTION
When a tab is backgrounded, the SSE connection is closed and updates are missed. On return, the dialog must be refetched to catch up. One fetch, one SSE reconnect, fresh token

- Refetch dialog before reconnecting SSE on focus (guarantees a fresh token, prevents 401)
- Store dialogToken in a ref so periodic refreshes don't cause unnecessary SSE reconnections
- Remove redundant refetchOnMount: 'always' (implied by staleTime: 0)
- Add test ensuring front-channel embed content is not re-fetched on token change

This solves observations found in 
https://github.com/Altinn/dialogporten-frontend/issues/3965#issuecomment-4223769970

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
