### PR TITLE
fix(account): users with preselected party are randomly switched from person to the preselected one

### DIFF
--- a/packages/frontend/src/api/hooks/useParties.ts
+++ b/packages/frontend/src/api/hooks/useParties.ts
@@ -1,4 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query';
 import type { PartyFieldsFragment } from 'bff-types-generated';
 import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -56,8 +55,11 @@ const createPartyParams = (searchParamString: string, key: string, value: string
 };
 
 export const useParties = (): UsePartiesOutput => {
-  const queryClient = useQueryClient();
   const [cookiePartyUuid] = useGlobalState(QUERY_KEYS.ALTINN_COOKIE, '');
+  const [hasInitializedPartySelection, setHasInitializedPartySelection] = useGlobalState(
+    QUERY_KEYS.HAS_INITIALIZED_PARTY_SELECTION,
+    false,
+  );
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [allOrganizationsSelected, setAllOrganizationsSelected] = useGlobalState<boolean>(
@@ -151,10 +153,10 @@ export const useParties = (): UsePartiesOutput => {
 
   const initializePartySelection = () => {
     // Synchronous guard — prevents multiple hook instances from initializing
-    if (queryClient.getQueryData(['hasInitializedPartySelection'])) {
+    if (hasInitializedPartySelection) {
       return;
     }
-    queryClient.setQueryData(['hasInitializedPartySelection'], true);
+    setHasInitializedPartySelection(true);
 
     if (getSelectedAllPartiesFromQueryParams(searchParams)) {
       selectAllOrganizations();
@@ -205,7 +207,7 @@ export const useParties = (): UsePartiesOutput => {
   // Handle URL-driven account switching (after initialization)
   // biome-ignore lint/correctness/useExhaustiveDependencies: Only react to party-related param changes
   useEffect(() => {
-    if (!isSuccess || !data?.length || !queryClient.getQueryData(['hasInitializedPartySelection'])) {
+    if (!isSuccess || !data?.length || !hasInitializedPartySelection) {
       return;
     }
 

--- a/packages/frontend/src/constants/queryKeys.ts
+++ b/packages/frontend/src/constants/queryKeys.ts
@@ -35,4 +35,5 @@ export const QUERY_KEYS = {
   DIALOG_REDIRECT_LOOKUP: 'dialogRedirectLookup',
   BULK_MODE: 'bulkMode',
   BULK_MODE_SELECTED_IDS: 'bulkModeSelectedIds',
+  HAS_INITIALIZED_PARTY_SELECTION: 'hasInitializedPartySelection',
 };


### PR DESCRIPTION
A real 🤦 

This was the issue

**t = 0s**
User logs in. The `AltinnPartyUuid` cookie contains a preselected party UUID (set by another Altinn auth). This is stored in a long-lived cache.

**t = 5s**
`initializePartySelection()` runs and sets `hasInitializedPartySelection = true`.
Since there is no `party` parameter in the URL, the cookie value is used → the preselected party is selected.

**t = 15s**
User manually switches to themselves (person).
`setSelectedPartyIds` updates:

* `document.cookie`
* `SELECTED_PARTIES` cache

…but **does NOT update the `ALTINN_COOKIE` cache**.

**t = 300s (5 minutes)**
React Query’s garbage collector removes `hasInitializedPartySelection` (which is short-lived) from the cache
(no active observers, default `gcTime = 5 min` expired).

**t = 300s+**
User navigates to “Trash” (`/bin`).
A new `<Inbox key="bin">` is mounted → `useParties()` hook mounts → `useEffect([isSuccess, data])` runs.

`initializePartySelection()` is called again.
The guard is gone → full re-initialization happens.

Since the user (person) is selected:

* No `party` parameter in the URL
* Falls back to cookie check:

```ts
const partyFromCookie = cookiePartyUuid 
  ? partyGraph.partyByUuid.get(cookiePartyUuid) 
  : undefined;
```

`cookiePartyUuid` is still the original value from app startup → the preselected party.

`setSelectedPartyIds([partyFromCookie.party], false)`
→ **the user is switched back to the preselected party**.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3962

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
