### PR TITLE
feat(infra): renumber VNet to 10.1.0.0/16 and add parallel Postgres v2

### DIFF
--- a/.azure/infrastructure/main.bicep
+++ b/.azure/infrastructure/main.bicep
@@ -275,6 +275,33 @@ module postgresql '../modules/postgreSql/create.bicep' = {
   }
 }
 
+module postgresqlV2 '../modules/postgreSql/create.bicep' = {
+  scope: resourceGroup
+  name: 'postgresqlV2'
+  params: {
+    namePrefix: namePrefix
+    nameSuffix: '-v2'
+    writeConnectionStringSecret: false
+    subnetId: vnet.outputs.postgresqlSubnetId
+    location: location
+    keyVaultName: environmentKeyVault.outputs.name
+    srcKeyVault: srcKeyVault
+    srcSecretName: 'dialogportenPgAdminPasswordV2${environment}'
+    administratorLoginPassword: contains(keyVaultSourceKeys, 'dialogportenPgAdminPassword${environment}')
+      ? srcKeyVaultResource.getSecret('dialogportenPgAdminPassword${environment}')
+      : secrets.dialogportenPgAdminPassword
+    privateDnsZoneArmResourceId: postgresqlPrivateDnsZone.outputs.id
+    sku: postgresConfiguration.sku
+    storage: postgresConfiguration.storage
+    highAvailability: postgresConfiguration.?highAvailability
+    availabilityZone: postgresConfiguration.availabilityZone
+    backupRetentionDays: postgresConfiguration.backupRetentionDays
+    postgresVersion: postgresConfiguration.version
+    tags: tags
+    enableBackupVault: false
+  }
+}
+
 module sshJumper '../modules/ssh-jumper/main.bicep' = {
   scope: resourceGroup
   name: 'sshJumper'
@@ -286,6 +313,7 @@ module sshJumper '../modules/ssh-jumper/main.bicep' = {
     sshPublicKey: secrets.sourceKeyVaultSshJumperSshPublicKey
     adminLoginGroupObjectId: entraDevelopersGroupId
     vmSize: sshJumperVmSize
+    defaultSubnetAddressPrefix: vnet.outputs.defaultSubnetAddressPrefix
   }
 }
 

--- a/.azure/modules/postgreSql/create.bicep
+++ b/.azure/modules/postgreSql/create.bicep
@@ -23,6 +23,12 @@ param tags object
 @description('Whether to provision a storage account + container for PostgreSQL restore backups')
 param enableBackupVault bool = false
 
+@description('Suffix appended to the server name, e.g. "-v2". Allows a second instance alongside the original.')
+param nameSuffix string = ''
+
+@description('Whether to write the databaseConnectionString secret to Key Vault. Set false for the v2 server until cutover.')
+param writeConnectionStringSecret bool = true
+
 @export()
 type Sku = {
   name: 'Standard_B1ms' | 'Standard_B2s' | 'Standard_B4ms' | 'Standard_B8ms' | 'Standard_B12ms' | 'Standard_B16ms' | 'Standard_B20ms' | 'Standard_D2ads_v5' | 'Standard_D4ads_v5' | 'Standard_D8ads_v5'
@@ -87,7 +93,7 @@ module saveAdmPassword '../keyvault/upsertSecret.bicep' = {
 }
 
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
-  name: '${namePrefix}-postgres'
+  name: '${namePrefix}-postgres${nameSuffix}'
   location: location
   properties: {
     version: postgresVersion
@@ -147,7 +153,7 @@ module backupVaultStorageContainer '../storageContainer/main.bicep' = if (enable
 
 var secretName = 'databaseConnectionString'
 var secretValue = 'postgres://${administratorLogin}:${administratorLoginPassword}@${postgres.properties.fullyQualifiedDomainName}:5432/${databaseName}?ssl=true'
-module psqlConnectionObject '../keyvault/upsertSecret.bicep' = {
+module psqlConnectionObject '../keyvault/upsertSecret.bicep' = if (writeConnectionStringSecret) {
   name: secretName
   params: {
     destKeyVaultName: keyVaultName
@@ -158,4 +164,4 @@ module psqlConnectionObject '../keyvault/upsertSecret.bicep' = {
 }
 
 output serverName string = postgres.name
-output connectionStringSecretUri string = psqlConnectionObject.outputs.secretUri
+output connectionStringSecretUri string = psqlConnectionObject.?outputs.secretUri ?? ''

--- a/.azure/modules/ssh-jumper/main.bicep
+++ b/.azure/modules/ssh-jumper/main.bicep
@@ -20,6 +20,9 @@ param adminLoginGroupObjectId string
 @description('The VM size for the SSH Jumper virtual machine')
 param vmSize string = 'Standard_B1ms'
 
+@description('The address prefix of the default subnet, used to compute a static private IP via cidrHost')
+param defaultSubnetAddressPrefix string
+
 var name = '${namePrefix}-ssh-jumper'
 
 resource publicIp 'Microsoft.Network/publicIPAddresses@2023-11-01' = {
@@ -50,8 +53,8 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2024-01-01' = {
         name: '${name}-ipconfig'
         type: 'Microsoft.Network/networkInterfaces/ipConfigurations'
         properties: {
-          privateIPAddress: '10.0.0.4'
-          privateIPAllocationMethod: 'Dynamic'
+          privateIPAddress: cidrHost(defaultSubnetAddressPrefix, 4)
+          privateIPAllocationMethod: 'Static'
           publicIPAddress: {
             id: publicIp.id
             properties: {

--- a/.azure/modules/vnet/main.bicep
+++ b/.azure/modules/vnet/main.bicep
@@ -11,15 +11,15 @@ param tags object
 param applicationGatewayWhitelistedIps array = []
 
 // Network address ranges
-var vnetAddressPrefix = '10.0.0.0/16'
+var vnetAddressPrefix = '10.1.0.0/16'
 
 // Subnet address ranges
-var defaultSubnetAddressPrefix = '10.0.0.0/24'
-var applicationGatewaySubnetAddressPrefix = '10.0.1.0/24'
-var containerAppEnvSubnetAddressPrefix = '10.0.2.0/23' // required size for the container app environment is /23
-var postgresqlSubnetAddressPrefix = '10.0.4.0/24'
-var redisSubnetAddressPrefix = '10.0.5.0/24'
-var sshJumperSubnetAddressPrefix = '10.0.6.0/24'
+var defaultSubnetAddressPrefix = '10.1.0.0/24'
+var applicationGatewaySubnetAddressPrefix = '10.1.1.0/24'
+var containerAppEnvSubnetAddressPrefix = '10.1.2.0/23' // required size for the container app environment is /23
+var postgresqlSubnetAddressPrefix = '10.1.4.0/24'
+var redisSubnetAddressPrefix = '10.1.5.0/24'
+var sshJumperSubnetAddressPrefix = '10.1.6.0/24'
 
 var commonHttpProperties = {
   protocol: '*'
@@ -185,7 +185,7 @@ resource containerAppEnvironmentNSG 'Microsoft.Network/networkSecurityGroups@202
           protocol: '*'
           sourcePortRange: '*'
           sourceAddressPrefix: '*'
-          destinationAddressPrefix: '10.0.0.62'
+          destinationAddressPrefix: cidrHost(defaultSubnetAddressPrefix, 62)
           access: 'Allow'
           priority: 130
           direction: 'Inbound'
@@ -434,6 +434,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-09-01' = {
 
 output virtualNetworkName string = virtualNetwork.name
 output virtualNetworkId string = virtualNetwork.id
+output defaultSubnetAddressPrefix string = defaultSubnetAddressPrefix
 output defaultSubnetId string = resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetwork.name, 'default')
 output applicationGatewaySubnetId string = resourceId(
   'Microsoft.Network/virtualNetworks/subnets',


### PR DESCRIPTION
## Summary

- **VNet renumbering**: all subnets shifted from `10.0.x.x` → `10.1.x.x` to unblock private peering with the backend VNet (which also uses `10.0.0.0/16`).
- **Postgres v2 alongside v1**: new `postgres-v2` server added in the new `postgresqlSubnet`. Two new params on `create.bicep` — `nameSuffix` and `writeConnectionStringSecret` — prevent resource-name collisions and Key Vault secret overwrites. v1 is left running until v2 is seeded, verified, and cut over (see rollout steps in plan-v2.md).
- **SSH jumper static IP**: private IP now computed via `cidrHost(defaultSubnetAddressPrefix, 4)` and allocation changed to `Static`. NSG rule 188 similarly uses `cidrHost(defaultSubnetAddressPrefix, 62)`.

## Posture change to review

Line 188 NSG rule (`container-app-environment`) — `destinationAddressPrefix` changes from `'10.0.0.62'` to `cidrHost(defaultSubnetAddressPrefix, 62)` (evaluates to `10.1.0.62`). Same /32 posture, just computed from the subnet CIDR rather than hardcoded. Reviewer should confirm `.62` is still the correct host in the new default subnet.

## Rollout

Per-environment, one at a time (yt01 → dev → test → staging → prod). See `.context/attachments/plan-v2.md` for the full step-by-step including pre-flight, seed procedure, cutover order, and rollback story.

**Key constraint:** no app schema migrations between step 3 (v2 seed) and step 6 (v1 retirement) — rollback only works if schemas remain interchangeable.

## Test Plan

- [x] `az bicep build` on all four modified files — zero errors
- [x] `grep -rn '10\.0\.' .azure` — zero matches in source
- [ ] `az deployment group what-if` against yt01 (run before applying to any env)
- [ ] Post-deploy: SSH jumper private IP is `10.1.0.4`; v2 Postgres FQDN resolves into `10.1.4.x`
- [ ] Frontend reachable; auth flow completes; Inbox loads; no 5xx spike

🤖 Generated with [Claude Code](https://claude.com/claude-code)