### PR TITLE
fix(inbox): enable dialog query when filtering by service resources

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogs.spec.ts
+++ b/packages/frontend/src/api/hooks/useDialogs.spec.ts
@@ -6,43 +6,33 @@ const createPartyIds = (count: number): string[] => Array.from({ length: count }
 describe('isDialogQueryEnabled', () => {
   it('should be enabled when partyIds and queryPartyURIs are within limit', () => {
     const partyIds = createPartyIds(5);
-    expect(isDialogQueryEnabled({ partyIds, queryPartyURIs: partyIds, serviceResources: [] })).toBe(true);
+    expect(isDialogQueryEnabled({ queryPartyURIs: partyIds, serviceResources: [] })).toBe(true);
   });
 
   it('should be disabled when partyIds is empty', () => {
-    expect(isDialogQueryEnabled({ partyIds: [], queryPartyURIs: [], serviceResources: [] })).toBe(false);
+    expect(isDialogQueryEnabled({ queryPartyURIs: [], serviceResources: [] })).toBe(false);
   });
 
   it('should be enabled when partyIds length equals MAX_DIALOG_PARTY_SIZE', () => {
     const partyIds = createPartyIds(MAX_DIALOG_PARTY_SIZE);
-    expect(isDialogQueryEnabled({ partyIds, queryPartyURIs: partyIds, serviceResources: [] })).toBe(true);
+    expect(isDialogQueryEnabled({ queryPartyURIs: partyIds, serviceResources: [] })).toBe(true);
   });
 
   it('should be disabled when partyIds exceed MAX_DIALOG_PARTY_SIZE', () => {
     const partyIds = createPartyIds(MAX_DIALOG_PARTY_SIZE + 1);
-    expect(isDialogQueryEnabled({ partyIds, queryPartyURIs: partyIds, serviceResources: [] })).toBe(false);
-  });
-
-  it('should be enabled when queryPartyURIs exceed limit but serviceResources are empty', () => {
-    const partyIds = createPartyIds(MAX_DIALOG_PARTY_SIZE);
-    const queryPartyURIs = createPartyIds(MAX_DIALOG_PARTY_SIZE + 1);
-    // When serviceResources is empty, the queryPartyURIs size check is bypassed
-    expect(isDialogQueryEnabled({ partyIds, queryPartyURIs, serviceResources: [] })).toBe(true);
+    expect(isDialogQueryEnabled({ queryPartyURIs: partyIds, serviceResources: [] })).toBe(false);
   });
 
   it('should be disabled when queryPartyURIs exceed limit and serviceResources are present', () => {
-    const partyIds = createPartyIds(MAX_DIALOG_PARTY_SIZE);
     const queryPartyURIs = createPartyIds(MAX_DIALOG_PARTY_SIZE + 1);
-    expect(
-      isDialogQueryEnabled({ partyIds, queryPartyURIs, serviceResources: ['urn:altinn:resource:some-service'] }),
-    ).toBe(false);
+    expect(isDialogQueryEnabled({ queryPartyURIs, serviceResources: ['urn:altinn:resource:some-service'] })).toBe(
+      false,
+    );
   });
 
   it('should be enabled with empty queryPartyURIs when serviceResources are provided', () => {
-    const partyIds = createPartyIds(5);
     expect(
       isDialogQueryEnabled({
-        partyIds,
         queryPartyURIs: [],
         serviceResources: ['urn:altinn:resource:some-service'],
       }),

--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -23,22 +23,30 @@ import { useParties } from './useParties.ts';
 
 /* Number of max parties used to fetch dialogs with party input param from Dialogporten */
 export const MAX_DIALOG_PARTY_SIZE = 100;
+export const MAX_SERVICE_RESOURCE_SIZE = 20;
 
 export type InboxViewType = 'inbox' | 'drafts' | 'sent' | 'archive' | 'bin';
 
 export const isDialogQueryEnabled = ({
-  partyIds,
   queryPartyURIs,
   serviceResources,
 }: {
-  partyIds: string[];
   queryPartyURIs: string[];
   serviceResources: string[];
-}): boolean =>
-  partyIds.length > 0 &&
-  partyIds.length <= MAX_DIALOG_PARTY_SIZE &&
-  (queryPartyURIs.length > 0 || serviceResources.length > 0) &&
-  (queryPartyURIs.length <= MAX_DIALOG_PARTY_SIZE || serviceResources.length <= 0);
+}): boolean => {
+  if (serviceResources.length > 0 && serviceResources.length <= MAX_SERVICE_RESOURCE_SIZE) {
+    if (queryPartyURIs.length > MAX_DIALOG_PARTY_SIZE) {
+      return false;
+    }
+    return true;
+  }
+
+  if (queryPartyURIs.length > 0 && queryPartyURIs.length <= MAX_DIALOG_PARTY_SIZE) {
+    return true;
+  }
+
+  return false;
+};
 
 export const isDialogCountInconclusive = ({
   partyIds,
@@ -132,7 +140,7 @@ export const useDialogs = ({
           searchLanguageCode: i18n.language,
         });
       },
-      enabled: isDialogQueryEnabled({ partyIds, queryPartyURIs, serviceResources }),
+      enabled: isDialogQueryEnabled({ queryPartyURIs, serviceResources }),
       getNextPageParam(lastPage: GetAllDialogsForPartiesQuery): unknown | undefined | null {
         const hasNextPage = lastPage?.searchDialogs?.hasNextPage;
         const continuationToken = lastPage?.searchDialogs?.continuationToken;

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -21,7 +21,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { MAX_COUNT_BULK_DIALOGS, useBulkActions } from '../../api/hooks/useBulkActions.tsx';
-import { type InboxViewType, MAX_DIALOG_PARTY_SIZE, useDialogs } from '../../api/hooks/useDialogs.tsx';
+import {
+  type InboxViewType,
+  MAX_DIALOG_PARTY_SIZE,
+  MAX_SERVICE_RESOURCE_SIZE,
+  isDialogQueryEnabled,
+  useDialogs,
+} from '../../api/hooks/useDialogs.tsx';
 import { useParties } from '../../api/hooks/useParties.ts';
 import { createFiltersURLQuery } from '../../auth';
 import { Notice } from '../../components/Notice';
@@ -80,8 +86,8 @@ export const Inbox = ({ viewType }: InboxProps) => {
     partiesEmptyList,
     isError: unableToLoadParties,
     isLoading: isLoadingParties,
-    organizationLimitReached,
     partyGraph,
+    organizationLimitReached,
   } = useParties();
 
   const { items: savedSearchItems, onSaveSearch, onCloseSavedSearch } = useSavedSearches(selectedPartyIds);
@@ -131,7 +137,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const validSearchString = enteredSearchValue.length > 2 ? enteredSearchValue : undefined;
   const selectedServices = (filterState.service ?? []) as string[];
   const selectedServicesCount = selectedServices.length;
-  const serviceLimitReached = selectedServicesCount > 20;
+  const serviceLimitReached = selectedServicesCount > MAX_SERVICE_RESOURCE_SIZE;
 
   const { accounts, accountSearch, accountGroups, onSelectAccount, currentAccountName } = useAccounts({
     parties,
@@ -162,14 +168,12 @@ export const Inbox = ({ viewType }: InboxProps) => {
   });
   const searchMode = hasValidFilters(filterState) || !!validSearchString;
   const showSubAccountsMenu = subAccounts.length > 0;
-  const isSubPartiesLimitReached =
-    (subAccounts.length > MAX_DIALOG_PARTY_SIZE && !partyIdsOverride.length) ||
-    partyIdsOverride.length > MAX_DIALOG_PARTY_SIZE;
-  const organizationLimitApplies = organizationLimitReached && !hasSubAccountOverrideWithinLimit;
+  const allSubAccountsSelected = partyIdsOverride?.length === 0;
 
-  const isLimitReached =
-    (selectedServicesCount === 0 && (organizationLimitApplies || isSubPartiesLimitReached)) ||
-    selectedServicesCount > 20;
+  const isLimitReached = !isDialogQueryEnabled({
+    queryPartyURIs: allSubAccountsSelected ? (organizationLimitReached ? [] : selectedPartyIds) : partyIdsOverride,
+    serviceResources: selectedServices,
+  });
 
   const subAccountsParamForSave = useMemo(() => {
     if (subAccountsParam) return subAccountsParam;
@@ -407,7 +411,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
         />
         {serviceLimitReached && (
           <Typography variant="subtle" size="sm">
-            <p>{t('inbox.service_limit_reached.description', { count: 20 })} </p>
+            <p>{t('inbox.service_limit_reached.description', { count: MAX_SERVICE_RESOURCE_SIZE })} </p>
           </Typography>
         )}
         <DialogList


### PR DESCRIPTION
Allow isDialogQueryEnabled to return true when 1–20 service resources are selected, and reuse the helper in Inbox to derive isLimitReached. Extract MAX_SERVICE_RESOURCE_SIZE so the limit is shared between the query gate and the UI notice.

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
