### PR TITLE
feat: Replace ChangeReporteeAndRedirect endpoint from A2 to A3

### DIFF
--- a/packages/frontend/src/auth/url.ts
+++ b/packages/frontend/src/auth/url.ts
@@ -47,8 +47,8 @@ export const getStoredURL = (): string | null => {
   return null;
 };
 
-export const createMessageBoxLink = () => {
-  return getFrontPageURL() + '/ui/Messagebox/';
+export const createMessageBoxLink = (partyUuid?: string) => {
+  return createChangePartyAndRedirect(partyUuid, getFrontPageURL() + '/ui/Messagebox/');
 };
 
 export type hostEnv = 'local' | 'at23' | 'tt02' | 'yt' | 'prod';

--- a/packages/frontend/src/auth/url.ts
+++ b/packages/frontend/src/auth/url.ts
@@ -47,9 +47,8 @@ export const getStoredURL = (): string | null => {
   return null;
 };
 
-export const createMessageBoxLink = (currentPartyUuid?: string) => {
-  const url = getFrontPageURL() + '/ui/Messagebox/';
-  return createChangeReporteeAndRedirect(currentPartyUuid, url);
+export const createMessageBoxLink = () => {
+  return getFrontPageURL() + '/ui/Messagebox/';
 };
 
 export type hostEnv = 'local' | 'at23' | 'tt02' | 'yt' | 'prod';
@@ -86,21 +85,25 @@ const getFrontPageURL = () => {
   return hostMap[getEnvByHost()] || hostMap.prod;
 };
 
-export const createChangeReporteeAndRedirect = (currentPartyUuid?: string, goTo?: string) => {
-  const frontPageURL = getFrontPageURL();
-  const url = new URL('/ui/Reportee/ChangeReporteeAndRedirect', frontPageURL);
-
-  if (currentPartyUuid) {
-    url.searchParams.set('P', currentPartyUuid);
+export const createChangePartyAndRedirect = (partyUuid?: string, goTo?: string) => {
+  const hostMap: Record<hostEnv, string> = {
+    local: 'https://am.ui.at23.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect/',
+    at23: 'https://am.ui.at23.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect/',
+    tt02: 'https://am.ui.tt02.altinn.no/accessmanagement/api/v1/reportee/changeandredirect/',
+    yt: 'https://am.ui.at23.altinn.cloud/accessmanagement/api/v1/reportee/changeandredirect/',
+    prod: 'https://am.ui.altinn.no/accessmanagement/api/v1/reportee/changeandredirect/',
+  };
+  const url = new URL(hostMap[getEnvByHost()]);
+  if (partyUuid) {
+    url.searchParams.set('partyUuid', partyUuid);
   }
-
   if (goTo) {
     url.searchParams.set('goTo', goTo);
   }
   return url.toString();
 };
 
-export const getAccessAMUILink = (currentPartyUuid?: string, changeReporteeAndRedirect?: boolean) => {
+export const getAccessAMUILink = () => {
   const hostMap: Record<hostEnv, string> = {
     local: 'https://am.ui.at23.altinn.cloud/accessmanagement/ui',
     at23: 'https://am.ui.at23.altinn.cloud/accessmanagement/ui',
@@ -108,10 +111,6 @@ export const getAccessAMUILink = (currentPartyUuid?: string, changeReporteeAndRe
     yt: 'https://am.ui.at23.altinn.cloud/accessmanagement/ui', // there is no am ui in yt
     prod: 'https://am.ui.altinn.no/accessmanagement/ui',
   };
-
-  if (changeReporteeAndRedirect) {
-    return createChangeReporteeAndRedirect(currentPartyUuid, hostMap[getEnvByHost()]);
-  }
 
   return hostMap[getEnvByHost()];
 };
@@ -130,7 +129,7 @@ type LinkPathConfig = {
   nn: string;
 };
 
-const createInfoPortalLink = (pathConfig: LinkPathConfig, currentPartyUuid?: string, language?: string) => {
+const createInfoPortalLink = (pathConfig: LinkPathConfig, language?: string) => {
   const baseHost = INFO_PORTAL_HOST_MAP[getEnvByHost()];
 
   let path: string;
@@ -142,69 +141,64 @@ const createInfoPortalLink = (pathConfig: LinkPathConfig, currentPartyUuid?: str
     path = pathConfig.nb;
   }
 
-  return createChangeReporteeAndRedirect(currentPartyUuid, baseHost + path);
+  return baseHost + path;
 };
 
-export const getNewFormLink = (currentPartyUuid?: string, language?: string) => {
+export const getNewFormLink = (language?: string) => {
   return createInfoPortalLink(
     {
       nb: '/skjemaoversikt/',
       en: '/en/forms-overview/',
       nn: '/nn/skjemaoversikt/',
     },
-    currentPartyUuid,
     language,
   );
 };
 
-export const getFrontPageLink = (currentPartyUuid?: string, language?: string) => {
-  return createChangeReporteeAndRedirect(currentPartyUuid, getInfoSiteURL(language));
+export const getFrontPageLink = (language?: string) => {
+  return getInfoSiteURL(language);
 };
 
-export const getAboutNewAltinnLink = (currentPartyUuid?: string, language?: string) => {
+export const getAboutNewAltinnLink = (language?: string) => {
   return createInfoPortalLink(
     {
       nb: '/nyheter/om-nye-altinn/',
       en: '/en/news/About-the-new-Altinn/',
       nn: '/nn/nyheiter/om-nye-altinn/',
     },
-    currentPartyUuid,
     language,
   );
 };
 
-export const getAlternativeLoginLink = (currentPartyUuid?: string, language?: string) => {
+export const getAlternativeLoginLink = (language?: string) => {
   return createInfoPortalLink(
     {
       nb: '/hjelp/innlogging/logg-inn-uten-f-d-nr/',
       en: '/nn/hjelp/innlogging/alternativ-innlogging-i-altinn/',
       nn: '/en/help/logging-in/altinn-alternative-log-in-methods/',
     },
-    currentPartyUuid,
     language,
   );
 };
 
-export const getStartNewBusinessLink = (currentPartyUuid?: string, language?: string) => {
+export const getStartNewBusinessLink = (language?: string) => {
   return createInfoPortalLink(
     {
       nb: '/starte-og-drive/',
       en: '/en/start-and-run-business/',
       nn: '/nn/starte-og-drive/',
     },
-    currentPartyUuid,
     language,
   );
 };
 
-export const getNeedHelpLink = (currentPartyUuid?: string, language?: string) => {
+export const getNeedHelpLink = (language?: string) => {
   return createInfoPortalLink(
     {
       nb: '/hjelp/',
       en: '/en/help/',
       nn: '/nn/hjelp/',
     },
-    currentPartyUuid,
     language,
   );
 };
@@ -259,31 +253,31 @@ const getFooterPathForLanguage = (path: string, language?: string): string => {
   return path;
 };
 
-export const getFooterLink = (currentPartyUuid: string, path: string, language?: string) => {
+export const getFooterLink = (path: string, language?: string) => {
   const mappedPath = getFooterPathForLanguage(path, language);
-  return createChangeReporteeAndRedirect(currentPartyUuid, getInfoSiteURL(language) + mappedPath);
+  return getInfoSiteURL(language) + mappedPath;
 };
 
-export const getFooterLinks = (currentPartyUuid: string, language?: string) => {
+export const getFooterLinks = (language?: string) => {
   return [
     {
-      href: `${getFooterLink(currentPartyUuid, '/hjelp/', language)}`,
+      href: getFooterLink('/hjelp/', language),
       resourceId: 'footer.nav.help_contact',
     },
     {
-      href: `${getFooterLink(currentPartyUuid, '/om-altinn/', language)}`,
+      href: getFooterLink('/om-altinn/', language),
       resourceId: 'footer.nav.about_altinn',
     },
     {
-      href: `${getFooterLink(currentPartyUuid, '/om-altinn/driftsmeldinger/', language)}`,
+      href: getFooterLink('/om-altinn/driftsmeldinger/', language),
       resourceId: 'footer.nav.service_announcements',
     },
     {
-      href: `${getFooterLink(currentPartyUuid, '/om-altinn/personvern/', language)}`,
+      href: getFooterLink('/om-altinn/personvern/', language),
       resourceId: 'footer.nav.privacy_policy',
     },
     {
-      href: `${getFooterLink(currentPartyUuid, '/om-altinn/tilgjengelighet/', language)}`,
+      href: getFooterLink('/om-altinn/tilgjengelighet/', language),
       resourceId: 'footer.nav.accessibility',
     },
   ];

--- a/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
+++ b/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
@@ -1,20 +1,18 @@
 import { FloatingDropdown as FloatingDropdownAc } from '@altinn/altinn-components';
 import { ExternalLinkIcon, LeaveIcon, QuestionmarkIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
-import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors';
 import { createMessageBoxLink, getNeedHelpLink } from '../../auth';
 import { i18n } from '../../i18n/config';
 
 export const FloatingDropdown = () => {
   const { t } = useTranslation();
-  const currentPartyUuid = useCurrentPartyUuid();
 
   const handleGoBack = () => {
-    window.location.href = createMessageBoxLink(currentPartyUuid);
+    window.location.href = createMessageBoxLink();
   };
 
   const handleGoToHelp = () => {
-    window.location.href = getNeedHelpLink(currentPartyUuid, i18n.language);
+    window.location.href = getNeedHelpLink(i18n.language);
   };
 
   const items = [

--- a/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
+++ b/packages/frontend/src/components/FloatingDropdown/FloatingDropdown.tsx
@@ -1,14 +1,16 @@
 import { FloatingDropdown as FloatingDropdownAc } from '@altinn/altinn-components';
 import { ExternalLinkIcon, LeaveIcon, QuestionmarkIcon } from '@navikt/aksel-icons';
 import { useTranslation } from 'react-i18next';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink, getNeedHelpLink } from '../../auth';
 import { i18n } from '../../i18n/config';
 
 export const FloatingDropdown = () => {
   const { t } = useTranslation();
+  const currentPartyUuid = useCurrentPartyUuid();
 
   const handleGoBack = () => {
-    window.location.href = createMessageBoxLink();
+    window.location.href = createMessageBoxLink(currentPartyUuid);
   };
 
   const handleGoToHelp = () => {

--- a/packages/frontend/src/components/PageLayout/Footer/useFooter.tsx
+++ b/packages/frontend/src/components/PageLayout/Footer/useFooter.tsx
@@ -1,12 +1,10 @@
 import type { FooterProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors';
 import { getFooterLinks } from '../../../auth';
 
 export const useFooter = (): FooterProps => {
   const { t, i18n } = useTranslation();
-  const currentPartyUuid = useCurrentPartyUuid();
-  const footerLinks = getFooterLinks(currentPartyUuid || '', i18n.language);
+  const footerLinks = getFooterLinks(i18n.language);
 
   return {
     address: t('footer.address'),

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
@@ -37,14 +37,12 @@ export function buildInboxMenu({
   pathname,
   currentSearchQuery,
   fromView,
-  currentPartyUuid,
 }: {
   t: (key: string, vars?: Record<string, string>) => string;
   currentEndUserName?: string;
   pathname: string;
   currentSearchQuery: string;
   fromView?: string;
-  currentPartyUuid?: string;
 }): UseGlobalMenuProps {
   const menuGroups = {
     shortcuts: {
@@ -86,7 +84,7 @@ export function buildInboxMenu({
       icon: LeaveIcon,
       title: t('altinn.beta.exit'),
       as: createMenuItemComponent({
-        to: createMessageBoxLink(currentPartyUuid),
+        to: createMessageBoxLink(),
       }),
     },
     {
@@ -96,7 +94,7 @@ export function buildInboxMenu({
       icon: PlusIcon,
       title: t('altinn.new_schema'),
       as: createMenuItemComponent({
-        to: getNewFormLink(currentPartyUuid, i18n.language),
+        to: getNewFormLink(i18n.language),
       }),
     },
   ];
@@ -109,7 +107,7 @@ export function buildInboxMenu({
       icon: InformationSquareIcon,
       title: t('global_menu.about_altinn'),
       as: createMenuItemComponent({
-        to: getAboutNewAltinnLink(currentPartyUuid, i18n.language),
+        to: getAboutNewAltinnLink(i18n.language),
       }),
     },
     {
@@ -119,7 +117,7 @@ export function buildInboxMenu({
       icon: Buildings2Icon,
       title: t('global_menu.start_business'),
       as: createMenuItemComponent({
-        to: getStartNewBusinessLink(currentPartyUuid, i18n.language),
+        to: getStartNewBusinessLink(i18n.language),
       }),
     },
     {
@@ -129,7 +127,7 @@ export function buildInboxMenu({
       icon: ChatExclamationmarkIcon,
       title: t('global_menu.need_help'),
       as: createMenuItemComponent({
-        to: getNeedHelpLink(currentPartyUuid, i18n.language),
+        to: getNeedHelpLink(i18n.language),
       }),
     },
   ];
@@ -240,7 +238,7 @@ export function buildInboxMenu({
         size: 'lg',
         icon: PadlockLockedFillIcon,
         as: 'a',
-        href: getAccessAMUILink(currentPartyUuid, true),
+        href: getAccessAMUILink(),
         title: t('altinn.access_management'),
         selected: false,
         badge: {
@@ -256,7 +254,7 @@ export function buildInboxMenu({
         icon: MenuGridIcon,
         title: t('global_menu.all_forms_services'),
         as: createMenuItemComponent({
-          to: getNewFormLink(currentPartyUuid, i18n.language),
+          to: getNewFormLink(i18n.language),
         }),
         selected: false,
       },
@@ -267,7 +265,7 @@ export function buildInboxMenu({
         icon: MagnifyingGlassIcon,
         title: t('global_menu.altinn_search'),
         as: createMenuItemComponent({
-          to: `${getFrontPageLink(currentPartyUuid)}/sok?`,
+          to: `${getFrontPageLink()}/sok?`,
         }),
         selected: false,
       },

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
@@ -37,12 +37,14 @@ export function buildInboxMenu({
   pathname,
   currentSearchQuery,
   fromView,
+  currentPartyUuid,
 }: {
   t: (key: string, vars?: Record<string, string>) => string;
   currentEndUserName?: string;
   pathname: string;
   currentSearchQuery: string;
   fromView?: string;
+  currentPartyUuid?: string;
 }): UseGlobalMenuProps {
   const menuGroups = {
     shortcuts: {
@@ -84,7 +86,7 @@ export function buildInboxMenu({
       icon: LeaveIcon,
       title: t('altinn.beta.exit'),
       as: createMenuItemComponent({
-        to: createMessageBoxLink(),
+        to: createMessageBoxLink(currentPartyUuid),
       }),
     },
     {

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/profileMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/profileMenu.tsx
@@ -33,14 +33,12 @@ export function buildProfileMenu({
   pathname,
   currentSearchQuery,
   fromView,
-  currentPartyUuid,
 }: {
   t: (key: string, vars?: Record<string, string>) => string;
   currentEndUserName?: string;
   pathname: string;
   currentSearchQuery: string;
   fromView?: string;
-  currentPartyUuid?: string;
 }): UseGlobalMenuProps {
   const menuGroups = {
     shortcuts: {
@@ -127,7 +125,7 @@ export function buildProfileMenu({
       size: 'sm',
       title: t('global_menu.about_altinn'),
       as: createMenuItemComponent({
-        to: getAboutNewAltinnLink(currentPartyUuid, i18n.language),
+        to: getAboutNewAltinnLink(i18n.language),
       }),
     },
     {
@@ -138,7 +136,7 @@ export function buildProfileMenu({
       size: 'sm',
       title: t('global_menu.start_business'),
       as: createMenuItemComponent({
-        to: getStartNewBusinessLink(currentPartyUuid, i18n.language),
+        to: getStartNewBusinessLink(i18n.language),
       }),
     },
     {
@@ -149,7 +147,7 @@ export function buildProfileMenu({
       size: 'sm',
       title: t('global_menu.need_help'),
       as: createMenuItemComponent({
-        to: getNeedHelpLink(currentPartyUuid, i18n.language),
+        to: getNeedHelpLink(i18n.language),
       }),
     },
   ];
@@ -192,7 +190,7 @@ export function buildProfileMenu({
       selected: false,
       icon: PadlockLockedFillIcon,
       as: 'a',
-      href: getAccessAMUILink(currentPartyUuid, true),
+      href: getAccessAMUILink(),
       title: t('altinn.access_management'),
       badge: {
         label: t('word.beta'),
@@ -207,7 +205,7 @@ export function buildProfileMenu({
       icon: MenuGridIcon,
       title: t('global_menu.all_forms_services'),
       as: createMenuItemComponent({
-        to: getNewFormLink(currentPartyUuid, i18n.language),
+        to: getNewFormLink(i18n.language),
       }),
       selected: false,
     },
@@ -218,7 +216,7 @@ export function buildProfileMenu({
       icon: MagnifyingGlassIcon,
       title: t('global_menu.altinn_search'),
       as: createMenuItemComponent({
-        to: `${getFrontPageLink(currentPartyUuid)}/sok?`,
+        to: `${getFrontPageLink()}/sok?`,
       }),
       selected: false,
     },

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { useCurrentEndUser, useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors.ts';
+import { useCurrentEndUser } from '../../../api/hooks/usePartiesSelectors.ts';
 import { PageRoutes } from '../../../pages/routes.ts';
 import { buildInboxMenu } from './inboxMenu.tsx';
 import { buildProfileMenu } from './profileMenu.tsx';
@@ -18,7 +18,6 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
   const fromView = (state as { fromView?: string })?.fromView;
   const { t } = useTranslation();
   const currentEndUser = useCurrentEndUser();
-  const currentPartyUuid = useCurrentPartyUuid();
 
   const inboxMenus = buildInboxMenu({
     t,
@@ -26,7 +25,6 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
     pathname,
     currentSearchQuery,
     fromView,
-    currentPartyUuid,
   });
 
   const profileMenus = buildProfileMenu({
@@ -35,7 +33,6 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
     pathname,
     currentSearchQuery,
     fromView,
-    currentPartyUuid,
   });
 
   return isProfile ? profileMenus : inboxMenus;

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/useGlobalMenu.tsx
@@ -1,7 +1,7 @@
 import type { MenuProps } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { useCurrentEndUser } from '../../../api/hooks/usePartiesSelectors.ts';
+import { useCurrentEndUser, useCurrentPartyUuid } from '../../../api/hooks/usePartiesSelectors.ts';
 import { PageRoutes } from '../../../pages/routes.ts';
 import { buildInboxMenu } from './inboxMenu.tsx';
 import { buildProfileMenu } from './profileMenu.tsx';
@@ -18,6 +18,7 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
   const fromView = (state as { fromView?: string })?.fromView;
   const { t } = useTranslation();
   const currentEndUser = useCurrentEndUser();
+  const currentPartyUuid = useCurrentPartyUuid();
 
   const inboxMenus = buildInboxMenu({
     t,
@@ -25,6 +26,7 @@ export const useGlobalMenu = (): UseGlobalMenuProps => {
     pathname,
     currentSearchQuery,
     fromView,
+    currentPartyUuid,
   });
 
   const profileMenus = buildProfileMenu({

--- a/packages/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/packages/frontend/src/components/PageLayout/PageLayout.tsx
@@ -15,7 +15,7 @@ import i18n from 'i18next';
 import { useEffect, useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, type LinkProps, Outlet, useLocation, useSearchParams } from 'react-router-dom';
-import { useCurrentEndUser, useCurrentPartyUuid, useSelectedProfile } from '../../api/hooks/usePartiesSelectors.ts';
+import { useCurrentEndUser, useSelectedProfile } from '../../api/hooks/usePartiesSelectors.ts';
 import { getFrontPageLink } from '../../auth';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
 import { getSearchStringFromQueryParams } from '../../pages/Inbox/queryParams.ts';
@@ -45,7 +45,6 @@ export const PageLayout: React.FC = () => {
   const [bulkMode, setBulkMode] = useGlobalState<boolean>(QUERY_KEYS.BULK_MODE, false);
   const selectedProfile = useSelectedProfile();
   const currentEndUser = useCurrentEndUser();
-  const currentPartyUuid = useCurrentPartyUuid();
   const [allOrganizationsSelected] = useGlobalState<boolean>(QUERY_KEYS.ALL_ORGANIZATIONS_SELECTED, false);
   const [selectedParties] = useGlobalState<PartyFieldsFragment[]>(QUERY_KEYS.SELECTED_PARTIES, []);
   const [isErrorState] = useGlobalState<boolean>(QUERY_KEYS.ERROR_STATE, false);
@@ -81,7 +80,7 @@ export const PageLayout: React.FC = () => {
       {
         label: t('route.titles.start'),
         as: (props: LinkProps) => {
-          return <Link {...props} to={getFrontPageLink(currentPartyUuid, i18n.language)} />;
+          return <Link {...props} to={getFrontPageLink(i18n.language)} />;
         },
       },
     ];
@@ -151,7 +150,7 @@ export const PageLayout: React.FC = () => {
     }
 
     return steps;
-  }, [currentPartyUuid, location.pathname, fromView, docTitle]);
+  }, [location.pathname, fromView, docTitle]);
 
   const escalateBannerSeverity = new Date() >= new Date(2026, 5, 2); // Escalate to warning on June 2nd, 2026
   const bannerLink = getBannerLink(i18n.language);

--- a/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
+++ b/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
@@ -171,7 +171,7 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
   const commonProps = {
     logo: {
       as: (props: LinkProps) => {
-        return <Link {...props} to={getFrontPageLink(currentPartyUuid, i18n.language)} />;
+        return <Link {...props} to={getFrontPageLink(i18n.language)} />;
       },
     },
     locale: {

--- a/packages/frontend/src/components/SINotice/SINotice.tsx
+++ b/packages/frontend/src/components/SINotice/SINotice.tsx
@@ -1,11 +1,10 @@
 import { Alert, Flex } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
-import { useCurrentPartyUuid, useSelfIdentifiedUserType } from '../../api/hooks/usePartiesSelectors.ts';
+import { useSelfIdentifiedUserType } from '../../api/hooks/usePartiesSelectors.ts';
 import { getAlternativeLoginLink } from '../../auth';
 
 export const SINotice = () => {
   const { t, i18n } = useTranslation();
-  const currentPartyUuid = useCurrentPartyUuid();
   const selfIdentifiedUserType = useSelfIdentifiedUserType();
   switch (selfIdentifiedUserType) {
     case 'Email':
@@ -13,16 +12,14 @@ export const SINotice = () => {
         <Alert variant="info" heading={t('inbox.si_notice.email.title')}>
           <Flex direction="col">
             {t('inbox.si_notice.email.body')}
-            <a href={getAlternativeLoginLink(i18n.language, currentPartyUuid)}>
-              {t('inbox.si_notice.email.link_text')}
-            </a>
+            <a href={getAlternativeLoginLink(i18n.language)}>{t('inbox.si_notice.email.link_text')}</a>
           </Flex>
         </Alert>
       );
     case 'Legacy':
       return (
         <Alert variant="info" heading={t('inbox.si_notice.legacy.title')}>
-          <a href={getAlternativeLoginLink(i18n.language, currentPartyUuid)}>{t('inbox.si_notice.legacy.link_text')}</a>
+          <a href={getAlternativeLoginLink(i18n.language)}>{t('inbox.si_notice.legacy.link_text')}</a>
         </Alert>
       );
     default:

--- a/packages/frontend/src/pages/Inbox/AlertBanner.tsx
+++ b/packages/frontend/src/pages/Inbox/AlertBanner.tsx
@@ -1,6 +1,7 @@
 import { DsAlert, DsParagraph, Heading } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink } from '../../auth';
 import { useAlertBanner } from '../../hooks/useAlertBanner.ts';
 
@@ -10,8 +11,9 @@ interface AlertBannerProps {
 
 export const AlertBanner = ({ showAlertBanner }: AlertBannerProps) => {
   const { t } = useTranslation();
+  const currentPartyUuid = useCurrentPartyUuid();
   const alertBannerContent = useAlertBanner();
-  const linkUrl = alertBannerContent?.link?.url || createMessageBoxLink();
+  const linkUrl = alertBannerContent?.link?.url || createMessageBoxLink(currentPartyUuid);
   const linkText = alertBannerContent?.link?.text || t('inbox.historical_messages_date_warning_link');
   const isExternal = linkUrl.startsWith('http://') || linkUrl.startsWith('https://');
 

--- a/packages/frontend/src/pages/Inbox/AlertBanner.tsx
+++ b/packages/frontend/src/pages/Inbox/AlertBanner.tsx
@@ -1,7 +1,6 @@
 import { DsAlert, DsParagraph, Heading } from '@altinn/altinn-components';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { useCurrentPartyUuid } from '../../api/hooks/usePartiesSelectors.ts';
 import { createMessageBoxLink } from '../../auth';
 import { useAlertBanner } from '../../hooks/useAlertBanner.ts';
 
@@ -11,9 +10,8 @@ interface AlertBannerProps {
 
 export const AlertBanner = ({ showAlertBanner }: AlertBannerProps) => {
   const { t } = useTranslation();
-  const currentPartyUuid = useCurrentPartyUuid();
   const alertBannerContent = useAlertBanner();
-  const linkUrl = alertBannerContent?.link?.url || createMessageBoxLink(currentPartyUuid);
+  const linkUrl = alertBannerContent?.link?.url || createMessageBoxLink();
   const linkText = alertBannerContent?.link?.text || t('inbox.historical_messages_date_warning_link');
   const isExternal = linkUrl.startsWith('http://') || linkUrl.startsWith('https://');
 

--- a/packages/frontend/tests/stories/common.ts
+++ b/packages/frontend/tests/stories/common.ts
@@ -19,7 +19,7 @@ export async function setPartyCookie(page: Page, partyUuid: string) {
 }
 
 export const getSidebar = (page: Page) => page.locator('aside');
-export const getSidebarMenuItem = (page: Page, route: string) => getSidebar(page).locator(`a[href*="${route}?"]`);
+export const getSidebarMenuItem = (page: Page, route: string) => getSidebar(page).locator(`a[href^="${route}?"]`);
 export const getSearchbarInput = (page: Page) => page.locator("[name='Søk']");
 
 export async function performSearch(page: Page, query: string, action?: 'clear' | 'click' | 'enter') {


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->
Code written with the help of AI, please have a deeper check @seanes 

Replace the deprecated Altinn 2 ChangeReporteeAndRedirect endpoint (decommissioned June 19) with the new Altinn 3 equivalent, and switch Portal/AM UI links to direct navigation per the issue scope.

  Changes:
  - auth/url.ts: Removed createChangeReporteeAndRedirect. Added createChangePartyAndRedirect using the new Altinn 3 endpoint (am.ui.<env>/accessmanagement/api/v1/reportee/changeandredirect/). All Portal, info portal, footer, and AM UI link-building functions now return direct URLs — no redirect endpoint needed since party cookies are already kept in sync by updatePartyCookies.
  - Caller files (FloatingDropdown, AlertBanner, useFooter, SINotice, inboxMenu, profileMenu, useGlobalMenu, useHeaderConfig, PageLayout): Updated to match the simplified function signatures, removing the now-unnecessary currentPartyUuid argument that was only ever passed through to the old redirect endpoint.
  - SINotice: Fixed a pre-existing argument order bug in the getAlternativeLoginLink call.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/4013

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
