### PR TITLE
ci: label PRs and issues with deployment environment

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -17,6 +17,7 @@ permissions:
   id-token: write
   security-events: write
   pages: write
+  issues: write
 
 jobs:
   generate-git-short-sha:
@@ -168,3 +169,47 @@ jobs:
       version: ${{ needs.get-current-version.outputs.version }}-${{ needs.generate-git-short-sha.outputs.gitShortSha }}
     secrets:
       token: ${{ secrets.SWARMIA_DEPLOYMENTS_AUTHORIZATION }}
+
+  get-previous-deployed-sha:
+    name: Get previous deployed SHA for test
+    runs-on: ubuntu-latest
+    environment: test
+    if: ${{ github.event_name == 'push' }}
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Resolve watermark
+        id: resolve
+        env:
+          STORED_SHA: ${{ vars.LATEST_DEPLOYED_SHA }}
+          FALLBACK_SHA: ${{ github.event.before }}
+        run: |
+          if [[ -n "$STORED_SHA" ]]; then
+            echo "Using stored watermark: $STORED_SHA"
+            echo "sha=$STORED_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "No stored watermark; falling back to github.event.before: $FALLBACK_SHA"
+            echo "sha=$FALLBACK_SHA" >> "$GITHUB_OUTPUT"
+          fi
+
+  tag-issues-with-environment:
+    name: Tag deployed PRs and issues for test
+    needs: [deploy-apps, deploy-infrastructure, get-previous-deployed-sha]
+    if: ${{ always() && !failure() && !cancelled() && github.event_name == 'push' && needs.deploy-apps.outputs.deployment_executed == 'true' }}
+    uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
+    with:
+      environment-label: at23
+      from-sha: ${{ needs.get-previous-deployed-sha.outputs.sha }}
+      to-sha: ${{ github.sha }}
+
+  store-latest-deployed-sha:
+    name: Store latest deployed SHA for test
+    needs: [tag-issues-with-environment]
+    if: ${{ always() && !failure() && !cancelled() && needs.tag-issues-with-environment.result == 'success' }}
+    uses: ./.github/workflows/workflow-store-github-env-variable.yml
+    with:
+      variable_name: LATEST_DEPLOYED_SHA
+      variable_value: ${{ github.sha }}
+      environment: test
+    secrets:
+      GH_TOKEN: ${{ secrets.RELEASE_VERSION_STORAGE_PAT }}

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -12,6 +12,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
 
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   check-if-version-exists:
     name: Check if version exists
@@ -166,3 +172,12 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_SUCCESSFUL_RELEASES }}
+
+  tag-issues-with-environment:
+    name: Tag deployed PRs and issues for prod
+    needs: [deploy-apps, deploy-infrastructure]
+    if: ${{ always() && !failure() && !cancelled() && needs.deploy-apps.outputs.deployment_executed == 'true' }}
+    uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
+    with:
+      environment-label: prod
+      version: ${{ inputs.version }}

--- a/.github/workflows/ci-cd-staging.yml
+++ b/.github/workflows/ci-cd-staging.yml
@@ -9,6 +9,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
 
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   get-versions-from-github:
     name: Get Latest Deployed Version Info from GitHub
@@ -163,3 +169,12 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_SUCCESSFUL_RELEASES }}
+
+  tag-issues-with-environment:
+    name: Tag deployed PRs and issues for staging
+    needs: [deploy-apps, deploy-infrastructure]
+    if: ${{ always() && !failure() && !cancelled() && needs.deploy-apps.outputs.deployment_executed == 'true' }}
+    uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
+    with:
+      environment-label: tt02
+      version: ${{ github.event.client_payload.version }}

--- a/.github/workflows/ci-cd-yt01.yml
+++ b/.github/workflows/ci-cd-yt01.yml
@@ -9,6 +9,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
 
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   get-versions-from-github:
     name: Get Latest Deployed Version Info from GitHub
@@ -145,3 +151,12 @@ jobs:
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_FOR_SUCCESSFUL_RELEASES }}
+
+  tag-issues-with-environment:
+    name: Tag deployed PRs and issues for yt01
+    needs: [deploy-apps, deploy-infrastructure]
+    if: ${{ always() && !failure() && !cancelled() && needs.deploy-apps.outputs.deployment_executed == 'true' }}
+    uses: ./.github/workflows/workflow-tag-issues-with-environment.yml
+    with:
+      environment-label: yt01
+      version: ${{ github.event.client_payload.version }}

--- a/.github/workflows/workflow-tag-issues-with-environment.yml
+++ b/.github/workflows/workflow-tag-issues-with-environment.yml
@@ -1,0 +1,136 @@
+name: Tag issues with environment
+
+on:
+  workflow_call:
+    inputs:
+      environment-label:
+        description: "Environment label to apply to pull requests and issues"
+        required: true
+        type: string
+      from-sha:
+        description: "Start of the commit range for push-based pull request discovery"
+        required: false
+        type: string
+      to-sha:
+        description: "End of the commit range for push-based pull request discovery"
+        required: false
+        type: string
+      version:
+        description: "Release version for release-based pull request discovery"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  tag-issues-with-environment:
+    name: Tag PRs and issues with ${{ inputs.environment-label }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      LABEL: ${{ inputs.environment-label }}
+      REPOSITORY: ${{ github.repository }}
+      FROM_SHA: ${{ inputs.from-sha }}
+      TO_SHA: ${{ inputs.to-sha }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Collect pull request numbers
+        id: collect-prs
+        run: |
+          set -euo pipefail
+
+          extract_pull_request_numbers() {
+            grep -oE '\(#[0-9]+\)|\[#([0-9]+)\]|/pull/[0-9]+' |
+              grep -oE '[0-9]+' |
+              sort -u |
+              paste -sd ',' - || true
+          }
+
+          if [[ -n "$VERSION" ]]; then
+            if [[ -n "$FROM_SHA" || -n "$TO_SHA" ]]; then
+              echo "::error::Provide either version or from-sha/to-sha, not both."
+              exit 1
+            fi
+
+            pr_numbers="$(
+              gh api "repos/${REPOSITORY}/releases/tags/v${VERSION}" --jq '.body // ""' | extract_pull_request_numbers
+            )"
+          else
+            if [[ -z "$FROM_SHA" || -z "$TO_SHA" ]]; then
+              echo "::error::Provide both from-sha and to-sha when version is not set."
+              exit 1
+            fi
+
+            pr_numbers="$(
+              gh api "repos/${REPOSITORY}/compare/${FROM_SHA}...${TO_SHA}" --jq '.commits[].commit.message | split("\n")[0]' | extract_pull_request_numbers
+            )"
+          fi
+
+          echo "pr_numbers=${pr_numbers}" >> "$GITHUB_OUTPUT"
+
+          if [[ -z "$pr_numbers" ]]; then
+            echo "No pull requests found for label ${LABEL}."
+          else
+            echo "Found pull requests: ${pr_numbers}"
+          fi
+
+      - name: Ensure label exists
+        if: ${{ steps.collect-prs.outputs.pr_numbers != '' }}
+        run: |
+          gh label create "$LABEL" \
+            --repo "$REPOSITORY" \
+            --color "1D76DB" \
+            --description "Deployed to ${LABEL}" \
+            >/dev/null 2>&1 || true
+
+      - name: Label pull requests and related issues
+        if: ${{ steps.collect-prs.outputs.pr_numbers != '' }}
+        env:
+          PR_NUMBERS: ${{ steps.collect-prs.outputs.pr_numbers }}
+        run: |
+          set -euo pipefail
+
+          extract_issue_numbers() {
+            local pull_request_number="$1"
+            local pull_request_body
+            pull_request_body="$(gh pr view "$pull_request_number" --repo "$REPOSITORY" --json body --jq '.body // ""')"
+
+            printf '%s\n' "$pull_request_body" |
+              awk '
+                /^## Related Issue\(s\)/ { in_section = 1; next }
+                /^## / && in_section { exit }
+                in_section { print }
+              ' |
+              grep -oE '#[0-9]+' |
+              tr -d '#' |
+              sort -u || true
+          }
+
+          IFS=',' read -r -a pull_request_numbers <<< "$PR_NUMBERS"
+
+          for pull_request_number in "${pull_request_numbers[@]}"; do
+            if [[ -z "$pull_request_number" ]]; then
+              continue
+            fi
+
+            gh api --method POST "repos/${REPOSITORY}/issues/${pull_request_number}/labels" -f "labels[]=${LABEL}" >/dev/null
+            echo "Labeled pull request #${pull_request_number} with ${LABEL}."
+
+            issue_numbers="$(extract_issue_numbers "$pull_request_number")"
+            if [[ -z "$issue_numbers" ]]; then
+              echo "No related issues found in pull request #${pull_request_number}."
+              continue
+            fi
+
+            while IFS= read -r issue_number; do
+              if [[ -z "$issue_number" ]]; then
+                continue
+              fi
+
+              gh api --method POST "repos/${REPOSITORY}/issues/${issue_number}/labels" -f "labels[]=${LABEL}" >/dev/null
+              echo "Labeled issue #${issue_number} with ${LABEL}."
+            done <<< "$issue_numbers"
+          done


### PR DESCRIPTION
Adds automatic environment labels to PRs and linked issues whenever a deploy succeeds, mirroring the behavior in `Altinn/dialogporten` so contributors can see at a glance which environments their work has reached.

## Hva er endret?

- New reusable workflow `workflow-tag-issues-with-environment.yml` that:
  - Discovers deployed PRs either from a SHA range (test) or from GitHub Release notes (staging/yt01/prod).
  - Reads each PR's `## Related Issue(s)` section and applies the same label to every linked issue.
  - Auto-creates the label on first use (blue, "Deployed to <env>").
- `ci-cd-main.yml`: after a successful test deploy, tags PRs/issues with `at23`. Uses a stored `LATEST_DEPLOYED_SHA` watermark (falling back to `github.event.before` on first run) and updates it after each successful tagging run.
- `ci-cd-staging.yml`, `ci-cd-yt01.yml`, `ci-cd-prod.yml`: after a successful deploy, tags PRs/issues with `tt02`, `yt01`, and `prod` respectively, using the release version.
- Labels accumulate — a PR ends up carrying one label per environment it has been deployed to.
- Adds the required `issues: write` / `pull-requests: write` permissions to each caller workflow.

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.