### PR TITLE
fix(workflow): match related issue URLs in PR body for environment tagger

### DIFF
--- a/.github/workflows/workflow-tag-issues-with-environment.yml
+++ b/.github/workflows/workflow-tag-issues-with-environment.yml
@@ -104,8 +104,8 @@ jobs:
                 /^## / && in_section { exit }
                 in_section { print }
               ' |
-              grep -oE '#[0-9]+' |
-              tr -d '#' |
+              grep -oE "(^|[^/[:alnum:]])#[0-9]+|https?://github\.com/${REPOSITORY}/issues/[0-9]+" |
+              grep -oE '[0-9]+$' |
               sort -u || true
           }
 


### PR DESCRIPTION
## Summary

- The `Tag issues with environment` workflow only matched `#NNNN`-style issue references in the `## Related Issue(s)` section of PR bodies.
- When the related issue is pasted as a full URL (which GitHub auto-converts links to, e.g. https://github.com/Altinn/dialogporten-frontend/issues/4210 in #4211), it was silently skipped — producing `No related issues found in pull request #4211` even though the link is right there.
- This PR extends the extractor in `.github/workflows/workflow-tag-issues-with-environment.yml` to also match full issue URLs for this repository, while still avoiding accidental matches inside cross-repo refs like `owner/repo#123`.

## Test plan

- [x] Verified locally against three inputs: full URL form, `#NNNN` shorthand (including multiple per line), and cross-repo `owner/repo#NNNN` ref (correctly ignored).
- [ ] Confirm next deployment run tags both the PRs and their related issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)