### PR TITLE
fix(modal): remove redundant helper text for title change for saved s…

### DIFF
--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -460,7 +460,6 @@
   "route.titles.saved_searches": "Saved searches",
   "route.titles.sent": "Sent",
   "route.titles.start": "Start",
-  "savedSearches.bookmark.item_input_helper": "Give saved search a title",
   "savedSearches.bookmark.item_input_label": "Give the search a name",
   "savedSearches.bookmark.item_input_placeholder": "No title",
   "savedSearches.bookmark.untitled": "Give saved search a name",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -460,7 +460,6 @@
   "route.titles.saved_searches": "Lagrede søk",
   "route.titles.sent": "Sendt",
   "route.titles.start": "Start",
-  "savedSearches.bookmark.item_input_helper": "Gi bokmerket et navn",
   "savedSearches.bookmark.item_input_label": "Gi søket et navn",
   "savedSearches.bookmark.item_input_placeholder": "Uten tittel",
   "savedSearches.bookmark.untitled": "Gi søket et navn",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -460,7 +460,6 @@
   "route.titles.saved_searches": "Lagra søk",
   "route.titles.sent": "Sendt",
   "route.titles.start": "Start",
-  "savedSearches.bookmark.item_input_helper": "Gje bokmerket eit namn",
   "savedSearches.bookmark.item_input_label": "Gi søket eit namn",
   "savedSearches.bookmark.item_input_placeholder": "Utan tittel",
   "savedSearches.bookmark.untitled": "Gje søket eit namn",

--- a/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
+++ b/packages/frontend/src/pages/SavedSearches/SavedSearchesPage.tsx
@@ -51,7 +51,6 @@ const EditBookmarkModal = ({ search, onClose, onSave }: EditBookmarkModalProps) 
       titleField={{
         label: t('savedSearches.bookmark.item_input_label'),
         placeholder: t('savedSearches.bookmark.item_input_placeholder'),
-        helperText: t('savedSearches.bookmark.item_input_helper'),
         value: title,
         onChange: (e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value),
       }}


### PR DESCRIPTION
…earch

<img width="1414" height="828" alt="image" src="https://github.com/user-attachments/assets/fb533bca-013b-4336-9273-8b31fa064acf" />

Removes helper text "Gi bokmerket et navn"

<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/4241

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
