### PR TITLE
feat: source filter service resources from Dialogporten

### DIFF
--- a/packages/bff-types-generated/queries/dpServiceResources.graphql
+++ b/packages/bff-types-generated/queries/dpServiceResources.graphql
@@ -1,0 +1,7 @@
+query getFilterServiceResources($lang: String) {
+  serviceResources: DPServiceResourcesList(lang: $lang) {
+    id
+    title
+    org
+  }
+}

--- a/packages/bff/src/auth/oidc.ts
+++ b/packages/bff/src/auth/oidc.ts
@@ -59,6 +59,19 @@ declare module 'fastify' {
   }
 }
 
+export interface Context {
+  session: {
+    get: (key: string) => SessionStorageToken | string | undefined;
+  };
+  request: {
+    raw: {
+      cookies?: {
+        altinnPersistentContext?: string;
+      };
+    };
+  };
+}
+
 interface IdportenToken {
   access_token: string;
   refresh_token: string;
@@ -90,6 +103,11 @@ export interface SessionStorageToken {
   tokenUpdatedAt: string;
   nonce?: string;
 }
+
+export const getSessionToken = (context: Context): SessionStorageToken | null => {
+  const token = context.session.get('token');
+  return typeof token === 'object' ? token : null;
+};
 
 export const generateSessionId = () => {
   return crypto

--- a/packages/bff/src/graphql/functions/altinn2messages.ts
+++ b/packages/bff/src/graphql/functions/altinn2messages.ts
@@ -1,9 +1,9 @@
 import { logger } from '@altinn/dialogporten-node-logger';
 import axios from 'axios';
+import type { Context, SessionStorageToken } from '../../auth/oidc.js';
 import config from '../../config.ts';
 import { getLanguageFromAltinnContext, languageCodes } from '../types/cookie.ts';
 import type { Altinn2MessageData, Altinn2MessagesResponse } from '../types/index.ts';
-import type { Context, TokenType } from './profile.ts';
 
 export const getAltinn2messages = async (
   context: Context,
@@ -28,7 +28,8 @@ export const getAltinn2messages = async (
   const isCurrentEndUser = isSelfIdentified || selectedAccountIdentifier === context.session.get('pid');
 
   try {
-    const token = typeof context.session.get('token') === 'object' ? (context.session.get('token') as TokenType) : null;
+    const token =
+      typeof context.session.get('token') === 'object' ? (context.session.get('token') as SessionStorageToken) : null;
 
     if (!token?.access_token) {
       throw new Error('Unable to authenticate with Altinn 2 API - no valid token with required scope');

--- a/packages/bff/src/graphql/functions/profile.ts
+++ b/packages/bff/src/graphql/functions/profile.ts
@@ -1,5 +1,6 @@
 import { logger } from '@altinn/dialogporten-node-logger';
 import axios, { isAxiosError } from 'axios';
+import { type Context, getSessionToken } from '../../auth/oidc.js';
 import config from '../../config.ts';
 import { GroupRepository, PartyRepository, ProfileRepository } from '../../db.ts';
 import { Group, Party, ProfileTable } from '../../entities.ts';
@@ -16,34 +17,6 @@ const platformProfileAPI_url = platformBaseURL + '/profile/api/v1/';
 
 const frontendToCoreLang: Record<string, string> = { nb: 'no', nn: 'nn', en: 'en' };
 export const coreToFrontendLang: Record<string, string> = { no: 'nb', nn: 'nn', en: 'en' };
-
-export type TokenType = {
-  access_token: string;
-  access_token_expires_at?: number;
-  id_token?: string;
-  refresh_token?: string;
-  refresh_token_expires_at?: number;
-  scope: string;
-  tokenUpdatedAt?: number;
-};
-
-export interface Context {
-  session: {
-    get: (key: string) => TokenType | string | undefined;
-  };
-  request: {
-    raw: {
-      cookies?: {
-        altinnPersistentContext?: string;
-      };
-    };
-  };
-}
-
-const getSessionToken = (context: Context): TokenType | null => {
-  const token = context.session.get('token');
-  return typeof token === 'object' ? token : null;
-};
 
 export const getOrCreateProfile = async (context: Context): Promise<ProfileTable> => {
   const pid = typeof context.session.get('pid') === 'string' ? (context.session.get('pid') as string) : '';

--- a/packages/bff/src/graphql/types/index.ts
+++ b/packages/bff/src/graphql/types/index.ts
@@ -3,5 +3,6 @@ export * from './altinn2messages.ts';
 export * from './savedSearches.ts';
 export * from './organization.ts';
 export * from './serviceResources/serviceResources.ts';
+export * from './serviceResources/dpServiceResources.ts';
 export * from './mutation.ts';
 export * from './query.ts';

--- a/packages/bff/src/graphql/types/serviceResources/dpServiceResources.ts
+++ b/packages/bff/src/graphql/types/serviceResources/dpServiceResources.ts
@@ -1,0 +1,139 @@
+import { logger } from '@altinn/dialogporten-node-logger';
+import axios from 'axios';
+import { extendType, stringArg } from 'nexus';
+import { type Context, getSessionToken } from '../../../auth/oidc.js';
+import config from '../../../config.js';
+import type { LocalizedText } from './resourceRegistry.ts';
+import {
+  type ServiceResourceResponseDTO,
+  type TransformedServiceResource,
+  getLocalizedTitle,
+  getSupportedLanguage,
+} from './serviceResources.js';
+
+interface DpLocalization {
+  languageCode: string;
+  value: string;
+}
+
+interface DpServiceResourceItem {
+  serviceResource: {
+    id: string;
+    name: DpLocalization[];
+  };
+  serviceOwner: {
+    code: string;
+  };
+}
+
+interface DpServiceResourcesResponse {
+  data?: {
+    serviceResources?: {
+      items?: DpServiceResourceItem[];
+    };
+  };
+  errors?: unknown;
+}
+
+const dpServiceResourcesQuery = `
+  query DPServiceResources {
+    serviceResources {
+      items {
+        serviceResource {
+          id
+          name {
+            languageCode
+            value
+          }
+        }
+        serviceOwner {
+          code
+        }
+      }
+    }
+  }
+`;
+
+function localizationsToLocalizedText(name: DpLocalization[]): LocalizedText {
+  const title: LocalizedText = {};
+  for (const { languageCode, value } of name) {
+    if (languageCode && value) {
+      title[languageCode as keyof LocalizedText] = value;
+    }
+  }
+  return title;
+}
+
+function toAcceptLanguageHeader(langs: string[]): string {
+  return langs.map((lang, index) => (index === 0 ? lang : `${lang};q=${(1 - index * 0.1).toFixed(1)}`)).join(', ');
+}
+
+async function fetchDpServiceResources(context: Context, langs: string[]): Promise<DpServiceResourceItem[]> {
+  const token = getSessionToken(context);
+  if (!token) {
+    logger.error('No token found in session');
+    return [];
+  }
+  const response = await axios({
+    method: 'POST',
+    url: config.dialogporten.graphqlUrl,
+    timeout: 30000,
+    headers: {
+      'content-type': 'application/json',
+      'Accept-Language': toAcceptLanguageHeader(langs),
+      Authorization: `Bearer ${token.access_token}`,
+    },
+    data: JSON.stringify({ query: dpServiceResourcesQuery }),
+  });
+
+  const body = response.data as DpServiceResourcesResponse;
+  if (body.errors) {
+    logger.error(body.errors, 'Dialogporten serviceResources query returned errors');
+    return [];
+  }
+
+  return body.data?.serviceResources?.items ?? [];
+}
+
+/**
+ * Fetches service resources from Dialogporten on demand and reshapes the response
+ * body into the same flat shape as RRServiceResourcesList ({ id, title, org }). Used for the
+ * toolbar/saved-search filters.
+ */
+export async function getDpServiceResources(langs: string[], context: Context): Promise<ServiceResourceResponseDTO[]> {
+  try {
+    const items = await fetchDpServiceResources(context, langs);
+
+    const resources: TransformedServiceResource[] = items.map((item) => ({
+      id: item.serviceResource.id,
+      title: localizationsToLocalizedText(item.serviceResource.name ?? []),
+      org: (item.serviceOwner?.code ?? '').toLowerCase(),
+      resourceType: '',
+    }));
+
+    return resources.map((r) => ({
+      ...r,
+      title: getLocalizedTitle(r.title, langs),
+    }));
+  } catch (error) {
+    logger.error(error, 'Error retrieving Dialogporten service resources:');
+    return [];
+  }
+}
+
+export const DpServiceResourceQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.list.field('DPServiceResourcesList', {
+      type: 'ServiceResource',
+      description: 'List of service resources from Dialogporten, used for filtering dialogs by service',
+      args: {
+        lang: stringArg({ description: 'Preferred language for title', default: 'nb' }),
+      },
+      resolve: async (_, args, context) => {
+        const preferredLangs = getSupportedLanguage('nb', args.lang);
+        return await getDpServiceResources(preferredLangs, context);
+      },
+    });
+  },
+});

--- a/packages/bff/src/graphql/types/serviceResources/serviceResources.ts
+++ b/packages/bff/src/graphql/types/serviceResources/serviceResources.ts
@@ -4,21 +4,21 @@ import config from '../../../config.js';
 import type { LocalizedText, Resource } from './resourceRegistry.ts';
 import { getEnvironmentConfig } from './serviceResourcesConfig.js';
 
-interface TransformedServiceResource {
+export interface TransformedServiceResource {
   id: string;
   title: LocalizedText;
   org: string;
   resourceType: string;
 }
 
-interface ServiceResourceResponseDTO extends Omit<TransformedServiceResource, 'title'> {
+export interface ServiceResourceResponseDTO extends Omit<TransformedServiceResource, 'title'> {
   title: string;
 }
 
 const serviceResourcesRedisKey = 'arbeidsflate-service-resources:v5';
 let refreshTimer: NodeJS.Timeout | null = null;
 
-function getSupportedLanguage(defaultLanguage: 'nb' | 'nn' | 'en', language?: string): string[] {
+export function getSupportedLanguage(defaultLanguage: 'nb' | 'nn' | 'en', language?: string): string[] {
   const supportedLanguages = ['nb', 'nn', 'en'];
   const preferredMapping: Record<string, string[]> = {
     nb: ['nb', 'nn', 'en'],
@@ -35,7 +35,7 @@ function getSupportedLanguage(defaultLanguage: 'nb' | 'nn' | 'en', language?: st
   return preferredMapping[language];
 }
 
-function getLocalizedTitle(title: LocalizedText, langs: string[]): string {
+export function getLocalizedTitle(title: LocalizedText, langs: string[]): string {
   for (const lang of langs) {
     const value = title[lang as keyof LocalizedText];
     if (value) {
@@ -200,13 +200,40 @@ export async function storeServiceResourcesInRedis(filters?: ResourceFilters): P
   }
 }
 
+export interface ServiceResourceQueryFilters {
+  resourceType?: string[];
+  ids?: string[];
+  org?: string[];
+}
+
+export function applyServiceResourceQueryFilters(
+  resources: TransformedServiceResource[],
+  filters?: ServiceResourceQueryFilters,
+): TransformedServiceResource[] {
+  if (!filters) {
+    return resources;
+  }
+
+  let filtered = resources;
+  if (filters.resourceType && filters.resourceType.length > 0) {
+    filtered = filtered.filter((resource) =>
+      filters.resourceType!.some((type) => type.toLowerCase() === resource.resourceType.toLowerCase()),
+    );
+  }
+  if (filters.ids && filters.ids.length > 0) {
+    filtered = filtered.filter((resource) => filters.ids!.includes(resource.id));
+  }
+  if (filters.org && filters.org.length > 0) {
+    filtered = filtered.filter((resource) =>
+      filters.org!.some((org) => org.toLowerCase() === resource.org.toLowerCase()),
+    );
+  }
+  return filtered;
+}
+
 export async function getServiceResourcesFromRedis(
   langs: string[],
-  filters?: {
-    resourceType?: string[];
-    ids?: string[];
-    org?: string[];
-  },
+  filters?: ServiceResourceQueryFilters,
 ): Promise<ServiceResourceResponseDTO[]> {
   try {
     const { default: redisClient } = await import('../../../redisClient.ts');
@@ -219,24 +246,7 @@ export async function getServiceResourcesFromRedis(
       resources = await storeServiceResourcesInRedis(getEnvironmentConfig(config.platformBaseURL));
     }
 
-    // Apply filters if provided
-    if (filters) {
-      if (filters.resourceType && filters.resourceType.length > 0) {
-        resources = resources.filter((resource) =>
-          filters.resourceType!.some((type) => type.toLowerCase() === resource.resourceType.toLowerCase()),
-        );
-      }
-      if (filters.ids && filters.ids.length > 0) {
-        resources = resources.filter((resource) => filters.ids!.includes(resource.id));
-      }
-      if (filters.org && filters.org.length > 0) {
-        resources = resources.filter((resource) =>
-          filters.org!.some((org) => org.toLowerCase() === resource.org.toLowerCase()),
-        );
-      }
-    }
-
-    return resources.map((r) => ({
+    return applyServiceResourceQueryFilters(resources, filters).map((r) => ({
       ...r,
       title: getLocalizedTitle(r.title, langs),
     }));
@@ -276,7 +286,7 @@ export function startServiceResourcesRefresh(): void {
     () => {
       void refreshServiceResourcesInBackground();
     },
-    23 * 60 * 60 * 1000,
+    6 * 60 * 60 * 1000,
   );
 
   logger.info('Service resources background refresh started');

--- a/packages/frontend/src/api/hooks/useServiceResource.ts
+++ b/packages/frontend/src/api/hooks/useServiceResource.ts
@@ -1,11 +1,15 @@
 import { useQueryClient } from '@tanstack/react-query';
-import type { GetServiceResourcesQuery, ServiceResource } from 'bff-types-generated';
+import type { ServiceResource } from 'bff-types-generated';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
-import { fetchServiceResources } from '../queries.ts';
+import { fetchAllServiceResources, fetchConsumerServiceResources } from '../queries.ts';
 import { useParties } from './useParties.ts';
+
+interface ServiceResourcesResult {
+  serviceResources?: (ServiceResource | null)[] | null;
+}
 
 interface UseServiceResourceOutput {
   serviceResources: ServiceResource[];
@@ -14,23 +18,25 @@ interface UseServiceResourceOutput {
   isLoading: boolean;
 }
 
-export const useServiceResource = (): UseServiceResourceOutput => {
+const useServiceResourcesQuery = (
+  queryKeyPrefix: string,
+  queryFn: (variables: { lang: string }) => Promise<ServiceResourcesResult>,
+): UseServiceResourceOutput => {
   const { selectedParties } = useParties();
   const enabled = selectedParties.length > 0;
   const { i18n } = useTranslation();
   const queryClient = useQueryClient();
 
-  /* Drop cache entries for other languages — the dataset is large (~6.5k entries),
-     so keep only the active language. */
+  /* Drop cache entries for other languages because size of dataset, */
   useEffect(() => {
     queryClient.removeQueries({
-      predicate: (query) => query.queryKey[0] === QUERY_KEYS.SERVICE_RESOURCES && query.queryKey[1] !== i18n.language,
+      predicate: (query) => query.queryKey[0] === queryKeyPrefix && query.queryKey[1] !== i18n.language,
     });
-  }, [i18n.language, queryClient]);
+  }, [i18n.language, queryClient, queryKeyPrefix]);
 
-  const { data, isLoading, isSuccess } = useAuthenticatedQuery<GetServiceResourcesQuery>({
-    queryKey: [QUERY_KEYS.SERVICE_RESOURCES, i18n.language],
-    queryFn: () => fetchServiceResources({ lang: i18n.language }),
+  const { data, isLoading, isSuccess } = useAuthenticatedQuery<ServiceResourcesResult>({
+    queryKey: [queryKeyPrefix, i18n.language],
+    queryFn: () => queryFn({ lang: i18n.language }),
     retry: 3,
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: Number.POSITIVE_INFINITY,
@@ -39,6 +45,7 @@ export const useServiceResource = (): UseServiceResourceOutput => {
     refetchOnReconnect: false,
     enabled,
   });
+
   const serviceResources = useMemo(
     () =>
       ((data?.serviceResources ?? []) as ServiceResource[])
@@ -65,3 +72,18 @@ export const useServiceResource = (): UseServiceResourceOutput => {
 
   return { serviceResources, serviceResourceById, isLoading, isSuccess };
 };
+
+/**
+ * Service resources used by the toolbar/saved-search filters, sourced from Dialogporten
+ * (DPServiceResourcesList). Use this when the resource id is passed to Dialogporten as a
+ * filter on dialogs by service.
+ */
+export const useFilterServiceResources = (): UseServiceResourceOutput =>
+  useServiceResourcesQuery(QUERY_KEYS.FILTER_SERVICE_RESOURCES, fetchConsumerServiceResources);
+
+/**
+ * Service resources used by notification settings, sourced from the Altinn Resource Registry
+ * (RRServiceResourcesList). Use this when the user enables explicit notifications per service.
+ */
+export const useNotificationServiceResources = (): UseServiceResourceOutput =>
+  useServiceResourcesQuery(QUERY_KEYS.SERVICE_RESOURCES, fetchAllServiceResources);

--- a/packages/frontend/src/api/queries.ts
+++ b/packages/frontend/src/api/queries.ts
@@ -7,6 +7,8 @@ import {
   type DeleteFavoritePartyMutation,
   type DeleteSavedSearchMutation,
   type GetAllDialogsForPartiesQuery,
+  type GetFilterServiceResourcesQuery,
+  type GetFilterServiceResourcesQueryVariables,
   type GetServiceResourcesQuery,
   type GetServiceResourcesQueryVariables,
   type NotificationSettingsInput,
@@ -248,9 +250,13 @@ export const searchDialogs = (
 export const updateLanguage = (language: string): Promise<UpdateLanguageMutation> =>
   graphQLSDK.UpdateLanguage({ language });
 
-export const fetchServiceResources = (
+export const fetchAllServiceResources = (
   variables?: GetServiceResourcesQueryVariables,
 ): Promise<GetServiceResourcesQuery> => graphQLSDK.getServiceResources(variables);
+
+export const fetchConsumerServiceResources = (
+  variables?: GetFilterServiceResourcesQueryVariables,
+): Promise<GetFilterServiceResourcesQuery> => graphQLSDK.getFilterServiceResources(variables);
 
 export const setShouldShowSubEntities = (
   shouldShowDeletedEntities: boolean,

--- a/packages/frontend/src/constants/queryKeys.ts
+++ b/packages/frontend/src/constants/queryKeys.ts
@@ -16,6 +16,7 @@ export const QUERY_KEYS = {
   PROFILE_PARTIES_WITH_NOTIFICATION_SETTINGS: 'profilePartiesWithNotificationSettings',
   ORGANIZATIONS: 'organizations',
   SERVICE_RESOURCES: 'serviceResources',
+  FILTER_SERVICE_RESOURCES: 'filterServiceResources',
   SEARCH_VALUE: 'searchValue',
   ENTERED_SEARCH_VALUE: 'enteredSearchValue',
   SET_ARCHIVE_LABEL_LOADING: 'setArchiveLabelLoading',

--- a/packages/frontend/src/mocks/handlers.ts
+++ b/packages/frontend/src/mocks/handlers.ts
@@ -510,6 +510,14 @@ const getServiceResourcesMock = graphql.query('getServiceResources', () => {
   });
 });
 
+const getFilterServiceResourcesMock = graphql.query('getFilterServiceResources', () => {
+  return HttpResponse.json({
+    data: {
+      serviceResources: inMemoryStore.services,
+    },
+  });
+});
+
 const dialogAccessInfoMock = graphql.query('dialogAccessInfo', ({ variables }) => {
   const { instanceRef } = variables as { instanceRef: string };
   const dialogId = instanceRef?.replace('urn:altinn:dialog-id:', '');
@@ -597,6 +605,7 @@ export const handlers = [
   mutateAddFavoritePartyMock,
   mutateDeleteFavoritePartyMock,
   getServiceResourcesMock,
+  getFilterServiceResourcesMock,
   dialogAccessInfoMock,
   mockAltinn2Messages,
   mockNotificationsettingsForCurrentUser,

--- a/packages/frontend/src/pages/Inbox/filters.tsx
+++ b/packages/frontend/src/pages/Inbox/filters.tsx
@@ -37,7 +37,6 @@ import {
 import type { Locale } from 'date-fns/locale';
 import { t } from 'i18next';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { getEnvByHost } from '../../auth';
 import { buildOrganizationMap } from '../../utils/organizations.ts';
 import { type OrganizationLookup, getOrganization } from '../../utils/organizations.ts';
 
@@ -55,35 +54,6 @@ export enum DateFilterOption {
   LAST_TWELVE_MONTHS = 'LAST_TWELVE_MONTHS',
   OLDER_THAN_ONE_YEAR = 'OLDER_THAN_ONE_YEAR',
 }
-
-const getSuggestedServiceIds = () => {
-  const envByHost = getEnvByHost();
-  if (envByHost === 'at23' || envByHost === 'local') {
-    return [
-      'urn:altinn:resource:app_hdir_a2-4081-3',
-      'urn:altinn:resource:app_sfd_a2-2975-1',
-      'urn:altinn:resource:app_skd_a2-1051-181125',
-      'urn:altinn:resource:nav-migratedcorrespondence-4503-',
-      'urn:altinn:resource:app_skd_a2-1049-111124',
-    ];
-  }
-  if (envByHost === 'tt02') {
-    return [
-      'urn:altinn:resource:app_skd_a2-1051-130203',
-      'urn:altinn:resource:app_brg_bvr-utv',
-      'urn:altinn:resource:app_dibk_a2-4655-2',
-      'urn:altinn:resource:nav_sykepenger_inntektsmelding',
-    ];
-  }
-  return [
-    'urn:altinn:resource:app_brg_a2-2705-201511',
-    'urn:altinn:resource:app_skd_a2-3736-140122',
-    'urn:altinn:resource:app_skd_a2-1051-130203',
-    'urn:altinn:resource:app_skd_a2-3707-190403',
-    'urn:altinn:resource:app_dibk_a2-4655-4',
-    'urn:altinn:resource:nav_sykepenger_inntektsmelding',
-  ];
-};
 
 export const getDateRange = (unit: 'day' | 'week' | 'month' | 'sixMonths' | 'year') => {
   const now = new Date();
@@ -421,26 +391,14 @@ export const createServiceFilter = ({
   currentFilters = {},
   allOrganizations,
 }: ServiceFilterProps): FilterProps => {
-  const suggestedServiceIds = new Set(getSuggestedServiceIds());
-  const serviceFilters: FilterProps[] = serviceResources
-    .map((s) => ({
-      id: s.id!,
-      name: s.id!,
-      items: [],
-      title: s.title ?? '',
-      groupId: suggestedServiceIds.has(s.id!) ? 'most-relevant' : 'services',
-      description: getOrganization(allOrganizations, s.org ?? '')?.name || '',
-    }))
-    .sort((a, b) => {
-      const groupOrder: Record<string, number> = {
-        'most-relevant': 0,
-        services: 1,
-      };
-      const ga = groupOrder[a.groupId] ?? Number.MAX_SAFE_INTEGER;
-      const gb = groupOrder[b.groupId] ?? Number.MAX_SAFE_INTEGER;
-
-      return ga - gb;
-    });
+  const serviceFilters: FilterProps[] = serviceResources.map((s) => ({
+    id: s.id!,
+    name: s.id!,
+    items: [],
+    title: s.title ?? '',
+    groupId: 'services',
+    description: getOrganization(allOrganizations, s.org ?? '')?.name || '',
+  }));
 
   return {
     id: FilterCategory.SERVICE,
@@ -453,10 +411,9 @@ export const createServiceFilter = ({
     searchable: true,
     groups: {
       selected: {},
-      'most-relevant': {
+      services: {
         title: t('filter_bar.group.choose_service'),
       },
-      services: {},
     },
     items: serviceFilters
       .filter((serviceResource) => serviceResource.id)
@@ -485,8 +442,6 @@ export const createServiceFilter = ({
  * @param allOrganizations
  * @param viewType
  * @param orgsFromSearchState
- * @param serviceResources
- * @param currentFilters - The current filter state to calculate accurate counts
  * @returns {Array} - The array of filter settings.
  */
 

--- a/packages/frontend/src/pages/Inbox/useBookmarkModal.tsx
+++ b/packages/frontend/src/pages/Inbox/useBookmarkModal.tsx
@@ -3,7 +3,7 @@ import type { SavedSearchesFieldsFragment } from 'bff-types-generated';
 import { type ChangeEvent, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
-import { useServiceResource } from '../../api/hooks/useServiceResource.ts';
+import { useFilterServiceResources } from '../../api/hooks/useServiceResource.ts';
 import { useDateFnsLocale } from '../../i18n/useDateFnsLocale.tsx';
 import { buildOrganizationMap } from '../../utils/organizations.ts';
 import { buildFilterParams } from '../SavedSearches/searchUtils.ts';
@@ -43,7 +43,7 @@ export const useBookmarkModal = ({
   const { t } = useTranslation();
   const { organizations } = useOrganizations();
   const orgMap = useMemo(() => buildOrganizationMap(organizations), [organizations]);
-  const { serviceResourceById } = useServiceResource();
+  const { serviceResourceById } = useFilterServiceResources();
   const { locale } = useDateFnsLocale();
 
   const [state, setState] = useState<ModalState>({ kind: 'closed' });

--- a/packages/frontend/src/pages/Inbox/useFilters.tsx
+++ b/packages/frontend/src/pages/Inbox/useFilters.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
 import { useDialogsForRecommendations } from '../../api/hooks/useDialogsForRecommendations.tsx';
-import { useServiceResource } from '../../api/hooks/useServiceResource.ts';
+import { useFilterServiceResources } from '../../api/hooks/useServiceResource.ts';
 import { useDateFnsLocale } from '../../i18n/useDateFnsLocale.tsx';
 import { getOrganization } from '../../utils/organizations.ts';
 import { FilterCategory, createServiceFilter, formatDateRange, getFilters, readFiltersFromURLQuery } from './filters';
@@ -28,7 +28,7 @@ export const useFilters = ({ viewType }: UseFiltersProps): UseFiltersOutput => {
   const dialogsForRecommendations = useDialogsForRecommendations();
   const { locale } = useDateFnsLocale();
   const { organizations } = useOrganizations();
-  const { serviceResources } = useServiceResource();
+  const { serviceResources } = useFilterServiceResources();
   const [params] = useSearchParams();
 
   const currentFilters = useMemo(() => {

--- a/packages/frontend/src/pages/Profile/AccountAlerts/ServiceResourceNotificationsDetails.tsx
+++ b/packages/frontend/src/pages/Profile/AccountAlerts/ServiceResourceNotificationsDetails.tsx
@@ -14,7 +14,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useDeferredValue, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useServiceResource } from '../../../api/hooks/useServiceResource.ts';
+import { useNotificationServiceResources } from '../../../api/hooks/useServiceResource.ts';
 import { updateNotificationsetting } from '../../../api/queries.ts';
 import { QUERY_KEYS } from '../../../constants/queryKeys.ts';
 import { useErrorLogger } from '../../../hooks/useErrorLogger.ts';
@@ -31,7 +31,7 @@ export const ServiceResourceNotificationsDetails = ({
   const { openSnackbar } = useSnackbar();
   const { logError } = useErrorLogger();
   const queryClient = useQueryClient();
-  const { serviceResources, isLoading: isLoadingResources } = useServiceResource();
+  const { serviceResources, isLoading: isLoadingResources } = useNotificationServiceResources();
 
   const notificationSetting = notificationParty?.notificationSettings;
 

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.spec.tsx
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.spec.tsx
@@ -28,7 +28,7 @@ vi.mock('../../api/hooks/useParties.ts', () => ({
 }));
 
 vi.mock('../../api/hooks/useServiceResource.ts', () => ({
-  useServiceResource: vi.fn(() => ({ serviceResourceById: new Map() })),
+  useFilterServiceResources: vi.fn(() => ({ serviceResourceById: new Map() })),
 }));
 
 vi.mock('../Inbox/useOrganizations.ts', () => ({

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
@@ -20,7 +20,7 @@ import { Analytics } from '../../analytics/analytics.ts';
 import { ANALYTICS_EVENTS } from '../../analytics/analyticsEvents.ts';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
 import { useParties } from '../../api/hooks/useParties.ts';
-import { useServiceResource } from '../../api/hooks/useServiceResource.ts';
+import { useFilterServiceResources } from '../../api/hooks/useServiceResource.ts';
 import { createSavedSearch, deleteSavedSearch, fetchSavedSearches, updateSavedSearch } from '../../api/queries.ts';
 import { useAuthenticatedQuery } from '../../auth/useAuthenticatedQuery.tsx';
 import { QUERY_KEYS } from '../../constants/queryKeys.ts';
@@ -124,7 +124,7 @@ export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesO
   const [openedSavedSearch, setOpenedSavedSearch] = useState<string | null>(null);
   const { organizations } = useOrganizations();
   const orgMap = useMemo(() => buildOrganizationMap(organizations), [organizations]);
-  const { serviceResourceById } = useServiceResource();
+  const { serviceResourceById } = useFilterServiceResources();
   const { currentEndUser, setSelectedPartyIds, setSelectedParties, partyGraph } = useParties();
   const { locale } = useDateFnsLocale();
   const navigate = useNavigate();


### PR DESCRIPTION
Tjenesteressurser brukes to steder i Arbeidsflate, og disse er nå skilt fra hverandre:

- **Filter** (verktøylinje / lagrede søk): hentes nå fra **Dialogporten**.
- **Varslinger** (notification settings): bruker fortsatt **Altinn Ressursregister**.

Per nå vil de listene være nokså like. Faktisk så vil nok listen fra Dialogporten være mer fullstendig.
Dialogporten skal gjøre endringer (uten at Arbeidsflate trenger å gjøre noe) som vil gi en mindre, mer spisset liste til bruker basert på dialoger som bruker har tilgang/fullmakt til.


### Endringer

- **BFF:** Ny `DPServiceResourcesList`-query som henter tjenesteressurser fra Dialogporten **per request** (ingen Redis-cache, ingen cron-jobb). Kallet autentiseres med brukerens egen sesjons-token, og responsen omformes server-side til samme flate form som RR (`{ id, title, org }`).
- **Accept-Language:** `fetchDpServiceResources` sender nå `Accept-Language`-header basert på brukerens språk, slik at Dialogporten kan lokalisere tittelen, og det er mindre data for hver spørring.
- **Frontend:** `useServiceResource` er splittet i to hooks — `useFilterServiceResources` (Dialogporten) og `useNotificationServiceResources` (Ressursregister) — med egne query-keys.
- **Tjenestefilter:** Fjernet «foreslåtte tjenester» (`most-relevant`-gruppa med hardkodede IDer). Alle tjenester ligger nå i én gruppe med tittel **«Velg tjeneste»**.
- **Opprydding:** Sentralisert `Context` / `getSessionToken` / `SessionStorageToken` i `auth/oidc.ts` (fjernet duplikater fra `profile.ts`).



## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4301

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
