### PR TITLE
fix(inbox): correct party/service limit handling to avoid blank inbox

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogs.spec.ts
+++ b/packages/frontend/src/api/hooks/useDialogs.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { MAX_DIALOG_PARTY_SIZE, isDialogCountInconclusive, isDialogQueryEnabled } from './useDialogs.tsx';
+import {
+  MAX_DIALOG_PARTY_SIZE,
+  MAX_SERVICE_RESOURCE_SIZE,
+  isDialogCountInconclusive,
+  isDialogQueryEnabled,
+} from './useDialogs.tsx';
 
 const createPartyIds = (count: number): string[] => Array.from({ length: count }, (_, i) => `urn:altinn:party:${i}`);
+const createServiceResources = (count: number): string[] =>
+  Array.from({ length: count }, (_, i) => `urn:altinn:resource:service-${i}`);
 
 describe('isDialogQueryEnabled', () => {
   it('should be enabled when partyIds and queryPartyURIs are within limit', () => {
@@ -37,6 +44,21 @@ describe('isDialogQueryEnabled', () => {
         serviceResources: ['urn:altinn:resource:some-service'],
       }),
     ).toBe(true);
+  });
+
+  it('should be enabled when serviceResources length equals MAX_SERVICE_RESOURCE_SIZE', () => {
+    const serviceResources = createServiceResources(MAX_SERVICE_RESOURCE_SIZE);
+    expect(isDialogQueryEnabled({ queryPartyURIs: createPartyIds(5), serviceResources })).toBe(true);
+  });
+
+  it('should be disabled when serviceResources exceed MAX_SERVICE_RESOURCE_SIZE', () => {
+    const serviceResources = createServiceResources(MAX_SERVICE_RESOURCE_SIZE + 1);
+    expect(isDialogQueryEnabled({ queryPartyURIs: createPartyIds(5), serviceResources })).toBe(false);
+  });
+
+  it('should be disabled when serviceResources exceed limit even with empty queryPartyURIs', () => {
+    const serviceResources = createServiceResources(MAX_SERVICE_RESOURCE_SIZE + 1);
+    expect(isDialogQueryEnabled({ queryPartyURIs: [], serviceResources })).toBe(false);
   });
 });
 

--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -34,18 +34,15 @@ export const isDialogQueryEnabled = ({
   queryPartyURIs: string[];
   serviceResources: string[];
 }): boolean => {
-  if (serviceResources.length > 0 && serviceResources.length <= MAX_SERVICE_RESOURCE_SIZE) {
-    if (queryPartyURIs.length > MAX_DIALOG_PARTY_SIZE) {
-      return false;
-    }
-    return true;
+  if (serviceResources.length > MAX_SERVICE_RESOURCE_SIZE) {
+    return false;
   }
 
-  if (queryPartyURIs.length > 0 && queryPartyURIs.length <= MAX_DIALOG_PARTY_SIZE) {
-    return true;
+  if (serviceResources.length > 0) {
+    return queryPartyURIs.length <= MAX_DIALOG_PARTY_SIZE;
   }
 
-  return false;
+  return queryPartyURIs.length > 0 && queryPartyURIs.length <= MAX_DIALOG_PARTY_SIZE;
 };
 
 export const isDialogCountInconclusive = ({
@@ -76,6 +73,7 @@ interface UseDialogsOutput {
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   isQueryEnabled: boolean;
+  partyLimitExceeded: boolean;
 }
 
 export const useDialogs = ({
@@ -91,17 +89,29 @@ export const useDialogs = ({
   const { selectedParties, allOrganizationsSelected, partyGraph } = useParties();
   const format = useFormat();
 
-  const partiesToUse =
-    allOrganizationsSelected && !shouldShowDeletedEntities
-      ? selectedParties.filter((party) => !party.isDeleted)
-      : selectedParties;
+  const partiesToUse = useMemo(() => {
+    if (shouldShowDeletedEntities) return selectedParties;
+
+    const withoutDeletedSubParties = selectedParties.map((party) => ({
+      ...party,
+      subParties: party.subParties?.filter((subParty) => !subParty.isDeleted) ?? party.subParties,
+    }));
+
+    return allOrganizationsSelected
+      ? withoutDeletedSubParties.filter((party) => !party.isDeleted)
+      : withoutDeletedSubParties;
+  }, [selectedParties, allOrganizationsSelected, shouldShowDeletedEntities]);
 
   const isPartyIdsOverridden = partyIdsOverride.length > 0;
-  const partyIds = isPartyIdsOverridden ? partyIdsOverride : getPartyIds(partiesToUse);
+  const partyIds = useMemo(
+    () => (isPartyIdsOverridden ? partyIdsOverride : getPartyIds(partiesToUse)),
+    [isPartyIdsOverridden, partyIdsOverride, partiesToUse],
+  );
   const previousTokensRef = useRef<string>('');
   const viewTypeKey = viewType ?? 'global';
   const queryPartyURIs = allOrganizationsSelected && !isPartyIdsOverridden && serviceResources?.length ? [] : partyIds;
   const isQueryEnabled = isDialogQueryEnabled({ queryPartyURIs, serviceResources });
+  const partyLimitExceeded = queryPartyURIs.length > MAX_DIALOG_PARTY_SIZE;
 
   const queryVariables = normalizeFilterDefaults({
     filters: {
@@ -220,5 +230,6 @@ export const useDialogs = ({
     hasNextPage: isQueryEnabled ? (data?.pages?.[data?.pages.length - 1]?.searchDialogs?.hasNextPage ?? false) : false,
     isFetchingNextPage,
     isQueryEnabled,
+    partyLimitExceeded,
   };
 };

--- a/packages/frontend/src/i18n/resources/en.json
+++ b/packages/frontend/src/i18n/resources/en.json
@@ -214,6 +214,8 @@
   "inbox.heading.title.inbox": "{count, plural, =0 {No results} one {# result} other {# results}}",
   "inbox.heading.title.sent": "{count, plural, =0 {Nothing sent} one {# sent} other {# sent}}",
   "inbox.service_limit_reached.description": "Select max {count} services to see the content.",
+  "inbox.party_limit_reached.description": "You have selected more than {count} organisations. Select fewer organisations to see messages.",
+  "inbox.dialogs_error.description": "An error has occurred: We were unable to fetch your content here.",
   "inbox.historical_messages_date_warning": "Due to a technical issue, some historical messages are displayed with incorrect dates in the new inbox. We are working to fix this. In the meantime, the old inbox can be used.",
   "inbox.no_parties_found": "No parties found",
   "inbox.old_inbox_notification": "You have forms to fill out in the old inbox",

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -214,6 +214,8 @@
   "inbox.heading.title.inbox": "{count, plural, =0 {Ingen treff} one {# treff} other {# treff}}",
   "inbox.heading.title.sent": "{count, plural, =0 {Ingen sendt} one {# sendt} other {# sendt}}",
   "inbox.service_limit_reached.description": "Velg maks {count} tjenester for å se innholdet.",
+  "inbox.party_limit_reached.description": "Du har valgt flere enn {count} virksomheter. Velg færre virksomheter for å se meldinger.",
+  "inbox.dialogs_error.description": "En feil har oppstått: Vi klarte ikke å hente innholdet ditt her.",
   "inbox.historical_messages_date_warning": "Pga en teknisk feil vises en del historiske meldinger med feil dato i den nye innboksen. Vi jobber med å rette dette. Inntil videre kan den gamle innboksen benyttes.",
   "inbox.no_parties_found": "Fant ingen aktører",
   "inbox.old_inbox_notification": "Du har skjema til utfylling i gammel innboks",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -214,6 +214,8 @@
   "inbox.heading.title.inbox": "{count, plural, =0 {Ingen treff} one {# treff} other {# treff}}",
   "inbox.heading.title.sent": "{count, plural, =0 {Ingen sendt} one {# sendt} other {# sendt}}",
   "inbox.service_limit_reached.description": "Vel maks {count} tenester for å sjå innhaldet.",
+  "inbox.party_limit_reached.description": "Du har valt fleire enn {count} verksemder. Vel færre verksemder for å sjå meldingar.",
+  "inbox.dialogs_error.description": "Det har oppstått ein feil: Vi klarte ikkje å hente innhaldet ditt her.",
   "inbox.historical_messages_date_warning": "På grunn av ein teknisk feil blir ein del historiske meldingar viste med feil dato i den nye innboksen. Vi jobbar med å rette dette. Inntil vidare kan den gamle innboksen nyttast.",
   "inbox.no_parties_found": "Ingen aktørar funne",
   "inbox.old_inbox_notification": "Du har skjema til utfylling i gammal innboks",

--- a/packages/frontend/src/mocks/data/stories/parties-over-100-navigator-disabled/features.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-over-100-navigator-disabled/features.ts
@@ -1,0 +1,14 @@
+/**
+ * Same as the base feature flags but with the AccountNavigator disabled, so that
+ * exceeding the party limit has no paginator fallback and the party-limit notice
+ * must be shown instead.
+ */
+export const features = {
+  'dialogporten.disableFlipNamesPatch': false,
+  'inbox.enableAltinn2Messages': true,
+  'inbox.enableAlertBanner': false,
+  'dialogporten.disableSubscriptions': false,
+  'inbox.accountNavigatorEnabled': false,
+  'SI.emailAccount.enableConnectLink': true,
+  'profil.enableSIPhoneEdit': true,
+};

--- a/packages/frontend/src/mocks/data/stories/parties-over-100-navigator-disabled/parties.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-over-100-navigator-disabled/parties.ts
@@ -1,13 +1,12 @@
 import type { PartyFieldsFragment, SubPartyFieldsFragment } from 'bff-types-generated';
 
 /**
- * A single parent organization ("STORSELSKAP AS") that has more than
- * MAX_DIALOG_PARTY_SIZE (100) sub-units. Selecting the parent expands
- * (via getPartyIds) into parent + all sub-units, exceeding the 100-party
- * query limit. Used to verify the inbox clears the previously selected
- * view's dialogs instead of leaving them hanging.
+ * A parent organization with more than MAX_DIALOG_PARTY_SIZE (100) active sub-units,
+ * combined with features.ts disabling the AccountNavigator. Selecting the parent
+ * exceeds the limit, but with no navigator to page out of it the inbox must instead
+ * show the party-limit notice. Used to verify that fallback message.
  */
-const SUBUNIT_COUNT = 99;
+const SUBUNIT_COUNT = 120;
 
 const pad = (n: number) => n.toString().padStart(3, '0');
 

--- a/packages/frontend/src/mocks/data/stories/parties-over-100-with-deleted-subunits/dialogs.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-over-100-with-deleted-subunits/dialogs.ts
@@ -1,0 +1,51 @@
+import { DialogStatus, type SearchDialogFieldsFragment, SystemLabel } from 'bff-types-generated';
+
+const makeDialog = (id: string, party: string, title: string): SearchDialogFieldsFragment => ({
+  hasUnopenedContent: false,
+  serviceResource: 'default',
+  serviceResourceType: 'correspondenceservice',
+  id,
+  endUserContext: { systemLabels: [SystemLabel.Default] },
+  party,
+  org: 'digdir',
+  progress: null,
+  isContentSeen: true,
+  fromServiceOwnerTransmissionsCount: 0,
+  fromPartyTransmissionsCount: 0,
+  contentUpdatedAt: '2024-01-15T11:34:00.000Z',
+  guiAttachmentCount: 0,
+  status: DialogStatus.RequiresAttention,
+  createdAt: '2023-12-23T23:00:00.000Z',
+  seenSinceLastContentUpdate: [],
+  content: {
+    title: {
+      mediaType: 'text/plain',
+      value: [{ value: title, languageCode: 'nb' }],
+    },
+    summary: {
+      mediaType: 'text/plain',
+      value: [{ value: title, languageCode: 'nb' }],
+    },
+    senderName: null,
+    extendedStatus: null,
+  },
+});
+
+/**
+ * Dialogs only exist on active org parties (the person has none). When the
+ * query is disabled under "Alle virksomheter" these never show; selecting a
+ * single active sub-unit re-enables the query and reveals them, proving the
+ * blank inbox is a limit problem and not genuinely empty data.
+ */
+export const dialogs: SearchDialogFieldsFragment[] = [
+  makeDialog(
+    '019241f7-5b00-7000-0000-000000000001',
+    'urn:altinn:organization:identifier-no:1',
+    'Melding til hovedenhet',
+  ),
+  makeDialog(
+    '019241f7-5b00-7000-0000-000000000002',
+    'urn:altinn:organization:identifier-sub:1',
+    'Melding til STORSELSKAP AVD 001',
+  ),
+];

--- a/packages/frontend/src/mocks/data/stories/parties-over-100-with-deleted-subunits/parties.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-over-100-with-deleted-subunits/parties.ts
@@ -1,0 +1,88 @@
+import type { PartyFieldsFragment, SubPartyFieldsFragment } from 'bff-types-generated';
+
+/**
+ * Reproduces the "blank inbox under 'Alle virksomheter'" bug where the
+ * subunit filter shows a count *within* the 100-limit (here: 99 units),
+ * yet the dialog query is silently disabled.
+ *
+ * Why it happens:
+ *   - The visible count (`filteredSubAccounts` in useSubAccounts) excludes
+ *     deleted units when shouldShowDeletedEntities is false (see profile.ts).
+ *   - But getPartyIds() rebuilds the party list from each parent's
+ *     `.subParties` array WITHOUT an isDeleted filter, so the deleted
+ *     sub-units are re-added to the URNs actually sent to the API.
+ *
+ * Result with this dataset:
+ *   - Subunit filter label:  1 parent + 98 active sub-units      = "99 enheter"
+ *   - getPartyIds() sends:    99 + 4 deleted sub-units            = 103 URNs
+ *   - 103 > MAX_DIALOG_PARTY_SIZE (100) -> isQueryEnabled = false
+ *     -> isLimitReached -> DialogList renders no items AND no
+ *        "Ingen treff" title/description.
+ *   - AccountNavigator stays hidden because it is keyed off the same
+ *     under-counted 99 (< 100), so the user has no pagination escape hatch.
+ *
+ * Manual testing:
+ *   /?mock=true&playwrightId=parties-over-100-with-deleted-subunits
+ *   - Select "Alle virksomheter" -> blank inbox (the bug).
+ *   - Select a single active sub-unit from the sub-unit menu (e.g.
+ *     "STORSELSKAP AVD 001") -> its dialog appears, proving data exists.
+ */
+const ACTIVE_SUBUNIT_COUNT = 98;
+const DELETED_SUBUNIT_COUNT = 4;
+
+const pad = (n: number) => n.toString().padStart(3, '0');
+
+const generateSubUnits = (): SubPartyFieldsFragment[] => {
+  const active = Array.from({ length: ACTIVE_SUBUNIT_COUNT }, (_, i) => {
+    const num = i + 1;
+    return {
+      party: `urn:altinn:organization:identifier-sub:${num}`,
+      partyType: 'Organization',
+      name: `STORSELSKAP AVD ${pad(num)}`,
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: `urn:altinn:organization:uuid:storselskap-sub-${pad(num)}`,
+      partyId: 2000 + num,
+    } satisfies SubPartyFieldsFragment;
+  });
+
+  const deleted = Array.from({ length: DELETED_SUBUNIT_COUNT }, (_, i) => {
+    const num = i + 1;
+    return {
+      party: `urn:altinn:organization:identifier-sub-deleted:${num}`,
+      partyType: 'Organization',
+      name: `STORSELSKAP NEDLAGT AVD ${pad(num)}`,
+      isCurrentEndUser: false,
+      isDeleted: true,
+      partyUuid: `urn:altinn:organization:uuid:storselskap-sub-deleted-${pad(num)}`,
+      partyId: 2900 + num,
+    } satisfies SubPartyFieldsFragment;
+  });
+
+  return [...active, ...deleted];
+};
+
+export const parties: PartyFieldsFragment[] = [
+  {
+    party: 'urn:altinn:person:identifier-no:1',
+    partyType: 'Person',
+    subParties: [],
+    name: 'STORTEST PERSON',
+    isCurrentEndUser: true,
+    isDeleted: false,
+    partyUuid: 'urn:altinn:person:uuid:stortest-person',
+    partyId: 1,
+    hasOnlyAccessToSubParties: false,
+  },
+  {
+    party: 'urn:altinn:organization:identifier-no:1',
+    partyType: 'Organization',
+    subParties: generateSubUnits(),
+    name: 'STORSELSKAP AS',
+    isCurrentEndUser: false,
+    isDeleted: false,
+    partyUuid: 'urn:altinn:organization:uuid:storselskap-as',
+    partyId: 1000,
+    hasOnlyAccessToSubParties: false,
+  },
+];

--- a/packages/frontend/src/mocks/data/stories/parties-over-100-with-deleted-subunits/profile.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-over-100-with-deleted-subunits/profile.ts
@@ -1,0 +1,58 @@
+import type { Profile } from 'bff-types-generated';
+
+/**
+ * Same as the base profile but with shouldShowDeletedEntities = false.
+ * This is the setting that triggers the bug: deleted sub-units are hidden
+ * from the visible count yet still counted by getPartyIds(). With the base
+ * profile's `true`, deleted units are also counted in the visible list, so
+ * the counts match and the divergence disappears.
+ */
+export const profile: Profile = {
+  updatedAt: '1727691732707',
+  language: 'nb',
+  user: {
+    userId: 20625133,
+    userUuid: '8666f00a-deda-4d00-a02d-092effc1170d',
+    userName: '',
+    email: 'nullstilt@altinn.xyz',
+    isReserved: false,
+    phoneNumber: '+4748995855',
+    externalIdentity: '',
+    partyId: 1,
+    profileSettingPreference: {
+      shouldShowDeletedEntities: false,
+      preselectedPartyUuid: null,
+    },
+    party: {
+      partyId: 1,
+      partyUuid: 'urn:altinn:person:uuid:stortest-person',
+      partyTypeName: 1,
+      orgNumber: '',
+      ssn: '22816298923',
+      unitType: null,
+      name: 'STORTEST PERSON',
+      isDeleted: false,
+      onlyHierarchyElementWithNoAccess: false,
+      person: {
+        ssn: '22816298923',
+        name: 'STORTEST PERSON',
+        firstName: 'STORTEST',
+        middleName: '',
+        lastName: 'PERSON',
+        telephoneNumber: '',
+        mobileNumber: '',
+        mailingAddress: 'Kirkegata 25',
+        mailingPostalCode: '4307',
+        mailingPostalCity: 'SANDNES',
+        addressMunicipalNumber: '1108',
+        addressMunicipalName: 'SANDNES',
+        addressStreetName: 'Kirkegata',
+        addressHouseNumber: '0025',
+        addressHouseLetter: '',
+        addressPostalCode: '4307',
+        addressCity: 'SANDNES',
+        dateOfDeath: null,
+      },
+    },
+  },
+};

--- a/packages/frontend/src/mocks/data/stories/party-parent-with-deleted-subunits/dialogs.ts
+++ b/packages/frontend/src/mocks/data/stories/party-parent-with-deleted-subunits/dialogs.ts
@@ -1,0 +1,51 @@
+import { DialogStatus, type SearchDialogFieldsFragment, SystemLabel } from 'bff-types-generated';
+
+const makeDialog = (id: string, party: string, title: string): SearchDialogFieldsFragment => ({
+  hasUnopenedContent: false,
+  serviceResource: 'default',
+  serviceResourceType: 'correspondenceservice',
+  id,
+  endUserContext: { systemLabels: [SystemLabel.Default] },
+  party,
+  org: 'digdir',
+  progress: null,
+  isContentSeen: true,
+  fromServiceOwnerTransmissionsCount: 0,
+  fromPartyTransmissionsCount: 0,
+  contentUpdatedAt: '2024-01-15T11:34:00.000Z',
+  guiAttachmentCount: 0,
+  status: DialogStatus.RequiresAttention,
+  createdAt: '2023-12-23T23:00:00.000Z',
+  seenSinceLastContentUpdate: [],
+  content: {
+    title: {
+      mediaType: 'text/plain',
+      value: [{ value: title, languageCode: 'nb' }],
+    },
+    summary: {
+      mediaType: 'text/plain',
+      value: [{ value: title, languageCode: 'nb' }],
+    },
+    senderName: null,
+    extendedStatus: null,
+  },
+});
+
+/**
+ * Dialogs only exist on active org parties (the person has none). When the
+ * query is disabled under "Alle virksomheter" these never show; selecting a
+ * single active sub-unit re-enables the query and reveals them, proving the
+ * blank inbox is a limit problem and not genuinely empty data.
+ */
+export const dialogs: SearchDialogFieldsFragment[] = [
+  makeDialog(
+    '019241f7-5b00-7000-0000-000000000001',
+    'urn:altinn:organization:identifier-no:1',
+    'Melding til hovedenhet',
+  ),
+  makeDialog(
+    '019241f7-5b00-7000-0000-000000000002',
+    'urn:altinn:organization:identifier-sub:1',
+    'Melding til STORSELSKAP AVD 001',
+  ),
+];

--- a/packages/frontend/src/mocks/data/stories/party-parent-with-deleted-subunits/parties.ts
+++ b/packages/frontend/src/mocks/data/stories/party-parent-with-deleted-subunits/parties.ts
@@ -1,0 +1,87 @@
+import type { PartyFieldsFragment, SubPartyFieldsFragment } from 'bff-types-generated';
+
+/**
+ * Reproduces the "blank inbox when selecting a single parent" variant, where the
+ * problem flips depending on the "show deleted entities" setting.
+ *
+ * "STORSELSKAP AS" has 80 active + 40 deleted sub-units (120 total). Select the
+ * parent directly (NOT "Alle virksomheter").
+ *
+ * With shouldShowDeletedEntities = false (see profile.ts):
+ *   - Visible sub-unit list / AccountNavigator count = parent + 80 active = 81 (< 100)
+ *     -> AccountNavigator hidden.
+ *   - getPartyIds() (before the fix) = parent + 80 + 40 deleted = 121 (> 100)
+ *     -> query disabled -> blank inbox, and no navigator to escape with.
+ *   After the fix, getPartyIds() also drops deleted sub-units -> 81 -> query runs.
+ *
+ * With shouldShowDeletedEntities = true:
+ *   - Both counts include the deleted units = 121 (> 100)
+ *     -> query genuinely over the limit AND AccountNavigator shown (paginate out).
+ *
+ * This is why, before the fix, the navigator only appeared when "show deleted" was on:
+ * the navigator is keyed off the deleted-filtered visible count, while the query limit
+ * counted the deleted units regardless.
+ *
+ * Manual testing:
+ *   /?mock=true&playwrightId=party-parent-with-deleted-subunits
+ *   - Account menu -> select "STORSELSKAP AS".
+ */
+const ACTIVE_SUBUNIT_COUNT = 80;
+const DELETED_SUBUNIT_COUNT = 40;
+
+const pad = (n: number) => n.toString().padStart(3, '0');
+
+const generateSubUnits = (): SubPartyFieldsFragment[] => {
+  const active = Array.from({ length: ACTIVE_SUBUNIT_COUNT }, (_, i) => {
+    const num = i + 1;
+    return {
+      party: `urn:altinn:organization:identifier-sub:${num}`,
+      partyType: 'Organization',
+      name: `STORSELSKAP AVD ${pad(num)}`,
+      isCurrentEndUser: false,
+      isDeleted: false,
+      partyUuid: `urn:altinn:organization:uuid:storselskap-sub-${pad(num)}`,
+      partyId: 2000 + num,
+    } satisfies SubPartyFieldsFragment;
+  });
+
+  const deleted = Array.from({ length: DELETED_SUBUNIT_COUNT }, (_, i) => {
+    const num = i + 1;
+    return {
+      party: `urn:altinn:organization:identifier-sub-deleted:${num}`,
+      partyType: 'Organization',
+      name: `STORSELSKAP NEDLAGT AVD ${pad(num)}`,
+      isCurrentEndUser: false,
+      isDeleted: true,
+      partyUuid: `urn:altinn:organization:uuid:storselskap-sub-deleted-${pad(num)}`,
+      partyId: 2900 + num,
+    } satisfies SubPartyFieldsFragment;
+  });
+
+  return [...active, ...deleted];
+};
+
+export const parties: PartyFieldsFragment[] = [
+  {
+    party: 'urn:altinn:person:identifier-no:1',
+    partyType: 'Person',
+    subParties: [],
+    name: 'STORTEST PERSON',
+    isCurrentEndUser: true,
+    isDeleted: false,
+    partyUuid: 'urn:altinn:person:uuid:stortest-person',
+    partyId: 1,
+    hasOnlyAccessToSubParties: false,
+  },
+  {
+    party: 'urn:altinn:organization:identifier-no:1',
+    partyType: 'Organization',
+    subParties: generateSubUnits(),
+    name: 'STORSELSKAP AS',
+    isCurrentEndUser: false,
+    isDeleted: false,
+    partyUuid: 'urn:altinn:organization:uuid:storselskap-as',
+    partyId: 1000,
+    hasOnlyAccessToSubParties: false,
+  },
+];

--- a/packages/frontend/src/mocks/data/stories/party-parent-with-deleted-subunits/profile.ts
+++ b/packages/frontend/src/mocks/data/stories/party-parent-with-deleted-subunits/profile.ts
@@ -1,0 +1,58 @@
+import type { Profile } from 'bff-types-generated';
+
+/**
+ * Same as the base profile but with shouldShowDeletedEntities = false.
+ * This is the setting that triggers the bug: deleted sub-units are hidden
+ * from the visible count yet still counted by getPartyIds(). With the base
+ * profile's `true`, deleted units are also counted in the visible list, so
+ * the counts match and the divergence disappears.
+ */
+export const profile: Profile = {
+  updatedAt: '1727691732707',
+  language: 'nb',
+  user: {
+    userId: 20625133,
+    userUuid: '8666f00a-deda-4d00-a02d-092effc1170d',
+    userName: '',
+    email: 'nullstilt@altinn.xyz',
+    isReserved: false,
+    phoneNumber: '+4748995855',
+    externalIdentity: '',
+    partyId: 1,
+    profileSettingPreference: {
+      shouldShowDeletedEntities: false,
+      preselectedPartyUuid: null,
+    },
+    party: {
+      partyId: 1,
+      partyUuid: 'urn:altinn:person:uuid:stortest-person',
+      partyTypeName: 1,
+      orgNumber: '',
+      ssn: '22816298923',
+      unitType: null,
+      name: 'STORTEST PERSON',
+      isDeleted: false,
+      onlyHierarchyElementWithNoAccess: false,
+      person: {
+        ssn: '22816298923',
+        name: 'STORTEST PERSON',
+        firstName: 'STORTEST',
+        middleName: '',
+        lastName: 'PERSON',
+        telephoneNumber: '',
+        mobileNumber: '',
+        mailingAddress: 'Kirkegata 25',
+        mailingPostalCode: '4307',
+        mailingPostalCity: 'SANDNES',
+        addressMunicipalNumber: '1108',
+        addressMunicipalName: 'SANDNES',
+        addressStreetName: 'Kirkegata',
+        addressHouseNumber: '0025',
+        addressHouseLetter: '',
+        addressPostalCode: '4307',
+        addressCity: 'SANDNES',
+        dateOfDeath: null,
+      },
+    },
+  },
+};

--- a/packages/frontend/src/mocks/handlers.ts
+++ b/packages/frontend/src/mocks/handlers.ts
@@ -131,6 +131,11 @@ const getAllDialogsforCountMock = graphql.query('getAllDialogsForCount', ({ vari
 });
 
 const getAllDialogsForPartiesMock = graphql.query('getAllDialogsForParties', ({ variables }) => {
+  // Test hook: force the dialog query to fail so the inbox error state can be exercised.
+  if (new URLSearchParams(window.location.search).get('simulateDialogsError') === 'true') {
+    return HttpResponse.json({ errors: [{ message: 'Simulated dialogs error' }] }, { status: 500 });
+  }
+
   const items = filterDialogs({
     inMemoryStore,
     partyURIs: variables.partyURIs,

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -51,12 +51,7 @@ import { AlertBanner } from './AlertBanner.tsx';
 import { Altinn2ActiveSchemasNotification } from './Altinn2ActiveSchemasNotification.tsx';
 import { FilterCategory, hasValidFilters, readFiltersFromURLQuery } from './filters';
 import styles from './inbox.module.css';
-import {
-  FixedGlobalQueryParams,
-  VariableGlobalQueryParams,
-  encodeSubAccountIds,
-  getSelectedSubAccountsFromQueryParams,
-} from './queryParams.ts';
+import { FixedGlobalQueryParams, VariableGlobalQueryParams, encodeSubAccountIds } from './queryParams.ts';
 import { useBookmarkModal } from './useBookmarkModal.tsx';
 import { useFilters } from './useFilters.tsx';
 import useGroupedDialogs from './useGroupedDialogs.tsx';
@@ -156,9 +151,6 @@ export const Inbox = ({ viewType }: InboxProps) => {
     },
   });
 
-  const partyIdsFromParams = useMemo(() => getSelectedSubAccountsFromQueryParams(searchParams), [searchParams]);
-  const hasSubAccountOverrideWithinLimit =
-    !!partyIdsFromParams.length && partyIdsFromParams.length <= MAX_DIALOG_PARTY_SIZE;
   const {
     subAccounts,
     getSubAccountLabel,
@@ -171,10 +163,11 @@ export const Inbox = ({ viewType }: InboxProps) => {
     selectedParties,
     allOrganizationsSelected,
     selectedServicesCount,
-    hasSubAccountOverrideWithinLimit,
   });
   const searchMode = hasValidFilters(filterState) || !!validSearchString;
   const showSubAccountsMenu = subAccounts.length > 0;
+  const accountNavigatorEnabled = useFeatureFlag<boolean>('inbox.accountNavigatorEnabled');
+  const accountNavigatorVisible = !accountNavigatorHidden && accountNavigatorEnabled;
 
   const subAccountsParamForSave = useMemo(() => {
     if (subAccountsParam) return subAccountsParam;
@@ -207,10 +200,12 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const {
     dialogs,
     isLoading: isLoadingDialogs,
+    isError: isErrorDialogs,
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
     isQueryEnabled,
+    partyLimitExceeded,
   } = useDialogs({
     viewType,
     filterState,
@@ -220,6 +215,9 @@ export const Inbox = ({ viewType }: InboxProps) => {
   });
 
   const isLimitReached = !isQueryEnabled;
+  /* Suppress the list's empty-state heading when we already show a limit notice or an error,
+     so we never render a misleading "no messages" alongside those. */
+  const hideListHeader = isLimitReached || isErrorDialogs;
 
   const onCloseBulkMode = useCallback(() => {
     setBulkMode(false);
@@ -274,8 +272,8 @@ export const Inbox = ({ viewType }: InboxProps) => {
   });
 
   const dialogItems = useMemo(() => {
-    return isLimitReached ? [] : groupedDialogs;
-  }, [groupedDialogs, isLimitReached]);
+    return hideListHeader ? [] : groupedDialogs;
+  }, [groupedDialogs, hideListHeader]);
 
   const dialogListGroups = useMemo(() => {
     const firstKey = Object.keys(groups)[0];
@@ -423,14 +421,25 @@ export const Inbox = ({ viewType }: InboxProps) => {
           subAccounts={subAccounts}
           partyIdsOverride={partyIdsOverride}
         />
-        {serviceLimitReached && (
+        {/* Show a single notice: a fetch error takes priority, then the service limit, then the
+            party limit — and the party limit only when the AccountNavigator isn't already offering
+            a way out (it explains itself). */}
+        {isErrorDialogs ? (
+          <DsAlert data-color="danger">
+            <DsParagraph>{t('inbox.dialogs_error.description')}</DsParagraph>
+          </DsAlert>
+        ) : serviceLimitReached ? (
           <Typography variant="subtle" size="sm">
             <p>{t('inbox.service_limit_reached.description', { count: MAX_SERVICE_RESOURCE_SIZE })} </p>
           </Typography>
-        )}
+        ) : partyLimitExceeded && !accountNavigatorVisible ? (
+          <Typography variant="subtle" size="sm">
+            <p>{t('inbox.party_limit_reached.description', { count: MAX_DIALOG_PARTY_SIZE })}</p>
+          </Typography>
+        ) : null}
         <DialogList
           title={
-            isLimitReached ? undefined : searchMode ? (
+            hideListHeader ? undefined : searchMode ? (
               isLoading ? (
                 <Heading as="h2" loading>
                   {t('word.loading')}
@@ -445,7 +454,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
           sortGroupBy={sortGroupBy}
           isLoading={isLoading}
           highlightWords={highlightWords}
-          description={isLimitReached ? undefined : description}
+          description={hideListHeader ? undefined : description}
         />
         {hasNextPage && (
           <Button aria-label={t('dialog.aria.fetch_more')} onClick={fetchNextPage} variant="outline" size="lg">

--- a/packages/frontend/src/pages/Inbox/useSubAccounts.tsx
+++ b/packages/frontend/src/pages/Inbox/useSubAccounts.tsx
@@ -12,7 +12,6 @@ interface UseSubAccountsProps {
   selectedParties: PartyFieldsFragment[];
   allOrganizationsSelected: boolean;
   selectedServicesCount: number;
-  hasSubAccountOverrideWithinLimit: boolean;
 }
 
 interface UseSubAccountsOutput {
@@ -43,7 +42,6 @@ export const useSubAccounts = ({
   selectedParties,
   allOrganizationsSelected,
   selectedServicesCount,
-  hasSubAccountOverrideWithinLimit,
 }: UseSubAccountsProps): UseSubAccountsOutput => {
   const { t } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -120,9 +118,17 @@ export const useSubAccounts = ({
     return subAccountsAndAll.filter((item) => !item.disabled);
   }, [subAccountsAndAll]);
 
+  /*
+   * Only suppress the navigator for a service filter when the query bypasses the party list
+   * entirely — i.e. the "Alle virksomheter" path with no sub-account override, where it sends an
+   * empty party list (all parties) and runs without paginating. As soon as parties are sent (a
+   * single selected parent, or an override), a service filter can push the count over
+   * MAX_DIALOG_PARTY_SIZE and disable the query, so the navigator must stay available as the way out.
+   */
+  const hasSubAccountOverride = selectedSubAccountIds.length > 0;
   const accountNavigatorHidden =
     filteredSubAccounts.length < MAX_DIALOG_PARTY_SIZE ||
-    (selectedServicesCount > 0 && !hasSubAccountOverrideWithinLimit);
+    (allOrganizationsSelected && selectedServicesCount > 0 && !hasSubAccountOverride);
   const showPageLabel = !accountNavigatorHidden;
 
   const allLabel = allOrganizationsSelected ? t('parties.labels.all_organizations') : t('parties.labels.all_units');

--- a/packages/frontend/tests/stories/deletedSubunitsPartyCount.spec.ts
+++ b/packages/frontend/tests/stories/deletedSubunitsPartyCount.spec.ts
@@ -1,0 +1,64 @@
+import { type Page, expect } from '@playwright/test';
+import { test } from '../fixtures';
+import { appUrlWithPlaywrightId } from '../index';
+
+/**
+ * Regression tests for the bug where deleted sub-units were counted toward
+ * MAX_DIALOG_PARTY_SIZE (100) even though they are hidden from the user
+ * (shouldShowDeletedEntities = false). getPartyIds() re-derived the query URNs
+ * from each parent's subParties without filtering deleted ones, so the count
+ * sent to the API exceeded 100 while the visible list stayed under it — the
+ * dialog query was silently disabled and the inbox went blank.
+ *
+ * After the fix, deleted sub-units are excluded from the query party set, so it
+ * matches the visible list and the dialogs load.
+ */
+
+const PARENT_DIALOG = 'Melding til hovedenhet';
+const SUBUNIT_DIALOG = 'Melding til STORSELSKAP AVD 001';
+const PARTY_LIMIT_NOTICE = 'Du har valgt flere enn';
+
+const openAccountMenu = async (page: Page) => {
+  await page.locator('#toolbar-menu-root > button').click();
+  await expect(page.locator('#toolbar-menu-listbox')).toBeVisible();
+};
+
+test.describe('"Alle virksomheter" with deleted sub-units (parties-over-100-with-deleted-subunits)', () => {
+  // Parent + 98 active + 4 deleted sub-units. Visible = 99, but the unfixed query counted 103.
+  const appURL = appUrlWithPlaywrightId('parties-over-100-with-deleted-subunits');
+
+  test('loads dialogs instead of a blank inbox (deleted sub-units not counted)', async ({ page }) => {
+    await page.goto(appURL);
+
+    await openAccountMenu(page);
+    await page.getByRole('option', { name: 'Alle virksomheter' }).click();
+    await expect(page).toHaveURL(/allParties=true/);
+
+    // 99 parties ≤ 100 → the query runs and the dialogs show
+    await expect(page.getByRole('link', { name: PARENT_DIALOG })).toBeVisible();
+    await expect(page.getByRole('link', { name: SUBUNIT_DIALOG })).toBeVisible();
+
+    // Under the limit: no party-limit notice and no page navigation
+    await expect(page.getByText(PARTY_LIMIT_NOTICE)).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Side 1', exact: true })).toBeHidden();
+  });
+});
+
+test.describe('Single parent with deleted sub-units (party-parent-with-deleted-subunits)', () => {
+  // Parent + 80 active + 40 deleted sub-units. Visible = 81, but the unfixed query counted 121.
+  const appURL = appUrlWithPlaywrightId('party-parent-with-deleted-subunits');
+
+  test('loads dialogs instead of a blank inbox (deleted sub-units not counted)', async ({ page }) => {
+    await page.goto(appURL);
+
+    await openAccountMenu(page);
+    await page.getByRole('option', { name: 'Storselskap AS', exact: true }).click();
+
+    // 81 parties ≤ 100 → the query runs and the dialogs show
+    await expect(page.getByRole('link', { name: PARENT_DIALOG })).toBeVisible();
+    await expect(page.getByRole('link', { name: SUBUNIT_DIALOG })).toBeVisible();
+
+    await expect(page.getByText(PARTY_LIMIT_NOTICE)).toBeHidden();
+    await expect(page.getByRole('button', { name: 'Side 1', exact: true })).toBeHidden();
+  });
+});

--- a/packages/frontend/tests/stories/inboxLimitNotices.spec.ts
+++ b/packages/frontend/tests/stories/inboxLimitNotices.spec.ts
@@ -1,0 +1,59 @@
+import { type Page, expect } from '@playwright/test';
+import { test } from '../fixtures';
+import { appURLInbox, appUrlWithPlaywrightId } from '../index';
+
+/**
+ * Covers the notices shown when the dialog query cannot run, so the inbox is never
+ * a silent blank:
+ *  - the party limit (>100) with the AccountNavigator disabled,
+ *  - the service-resource limit (>20 services),
+ *  - a failed dialog fetch.
+ */
+
+const PARTY_LIMIT_NOTICE = 'Du har valgt flere enn';
+const SERVICE_LIMIT_NOTICE = 'Velg maks 20 tjenester';
+const DIALOGS_ERROR_NOTICE = 'En feil har oppstått';
+
+const openAccountMenu = async (page: Page) => {
+  await page.locator('#toolbar-menu-root > button').click();
+  await expect(page.locator('#toolbar-menu-listbox')).toBeVisible();
+};
+
+test.describe('Party limit with the AccountNavigator disabled', () => {
+  const appURL = appUrlWithPlaywrightId('parties-over-100-navigator-disabled');
+
+  test('shows the party-limit notice instead of a blank inbox', async ({ page }) => {
+    await page.goto(appURL);
+
+    // Parent has 120 active sub-units (> 100) and the navigator feature flag is off
+    await openAccountMenu(page);
+    await page.getByRole('option', { name: 'Storselskap AS', exact: true }).click();
+
+    await expect(page.getByText(PARTY_LIMIT_NOTICE)).toBeVisible();
+    // No paginator to fall back on (flag disabled)
+    await expect(page.getByRole('button', { name: 'Side 1', exact: true })).toBeHidden();
+  });
+});
+
+test.describe('Service-resource limit (> 20 services)', () => {
+  // 21 service filters pushed in via the URL — over MAX_SERVICE_RESOURCE_SIZE (20).
+  const manyServices = Array.from({ length: 21 }, (_, i) => `service=urn:altinn:resource:svc-${i}`).join('&');
+  const appURL = `${appURLInbox}&${manyServices}`;
+
+  test('shows the service-limit notice and does not run the query', async ({ page }) => {
+    await page.goto(appURL);
+
+    await expect(page.getByText(SERVICE_LIMIT_NOTICE)).toBeVisible();
+  });
+});
+
+test.describe('Failed dialog fetch', () => {
+  const appURL = `${appURLInbox}&simulateDialogsError=true`;
+
+  test('shows an error notice instead of an empty inbox', async ({ page }) => {
+    await page.goto(appURL);
+
+    // The query retries before failing, so allow extra time for the error state
+    await expect(page.getByText(DIALOGS_ERROR_NOTICE)).toBeVisible({ timeout: 20000 });
+  });
+});


### PR DESCRIPTION
Originally reported for orgs with "vis slettede" off and >100 sub-units: the inbox went blank with no dialogs and no message. Root cause was a party count that diverged from what the user sees — and digging in surfaced a few related gaps, so the scope grew a bit.

**Changes**
- Deleted sub-units no longer count toward the 100-party limit (query count now matches the visible list) — both for "Alle virksomheter" and a single selected parent.
- Enforce the >20 service-resource limit in `isDialogQueryEnabled` (previously only shown as a message while the query still ran).
- Show the `AccountNavigator` whenever the query is party-limited, incl. with a service filter or over-limit sub-account override.
- Add a party-limit notice and a dialog-fetch error notice; coordinate so at most one notice shows (error > service > party), and hide the party notice when the navigator already offers a way out.
- Memoize `partiesToUse`/`partyIds`; drop the now-unused `hasSubAccountOverrideWithinLimit` prop.

**Tests**
- Mock stories + Playwright coverage: deleted sub-units under the limit, party-limit notice with navigator disabled, service limit, and the dialog error state.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/4306

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
