### PR TITLE
ci: run lightweight jobs on self-hosted runners

### DIFF
--- a/.github/workflows/ci-cd-pull-request.yml
+++ b/.github/workflows/ci-cd-pull-request.yml
@@ -11,7 +11,9 @@ jobs:
   ci-branch-gate:
     name: CI branch gate
     if: ${{ !startsWith(github.head_ref, 'release-please-') }}
-    runs-on: ubuntu-latest
+    # Self-hosted: repo-scoped ephemeral runner (Azure Container App Job).
+    # See Altinn/altinn-platform infrastructure/gh-runners/dialogporten-frontend.tf
+    runs-on: self-hosted
     steps:
       - run: echo "Branch is eligible for full PR CI"
 

--- a/.github/workflows/workflow-check-for-changes.yml
+++ b/.github/workflows/workflow-check-for-changes.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   check-for-changes:
     name: Filter
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       hasInfrastructureChanges: ${{ steps.filter-infra.outputs.infrastructure_any_modified == 'true' || steps.filter-infra.outputs.github_workflows_any_modified == 'true' }}
       hasApplicationChanges: ${{ steps.filter-apps.outputs.applications_any_modified == 'true' || steps.filter-infra.outputs.github_workflows_any_modified == 'true' }}

--- a/.github/workflows/workflow-check-translations.yml
+++ b/.github/workflows/workflow-check-translations.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   check-translations:
-    runs-on: ubuntu-latest
+    # Self-hosted: repo-scoped ephemeral runner (Azure Container App Job).
+    # Only caller is ci-cd-pull-request.yml, so this stays PR-scoped.
+    # See Altinn/altinn-platform infrastructure/gh-runners/dialogporten-frontend.tf
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/workflow-generate-git-short-sha.yml
+++ b/.github/workflows/workflow-generate-git-short-sha.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   generate-git-short-sha:
     name: Generate git short sha
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       gitShortSha: ${{ steps.set-git-short-sha.outputs.gitShortSha }}
     steps:

--- a/.github/workflows/workflow-get-current-version.yml
+++ b/.github/workflows/workflow-get-current-version.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   get-current-version:
     name: Filter
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       version: ${{ steps.set-current-version.outputs.version }}
     steps:


### PR DESCRIPTION
## What

Moves the lightweight, no-Docker CI jobs onto the **repo-scoped ephemeral self-hosted runner** (Azure Container App Job) for `Altinn/dialogporten-frontend`.

Jobs flipped to `runs-on: self-hosted`:
- `ci-branch-gate` and `translations-check` (`pnpm i18n:check` — runner image has Node 24 + corepack), in the PR workflow
- `check-for-changes`, `get-current-version`, `generate-git-short-sha` (reusable workflows)

## Scope

The reusable workflows are set to **always** run on self-hosted. They are also called by the **main/staging/prod/yt01 deploy pipelines and the release-please PR workflow**, so those callers now use the self-hosted runner too — not just `pull_request`.

## ⚠️ Depends on runner registration (merge order)

The self-hosted runner for this repo is registered in **Altinn/altinn-platform#3707** (`infrastructure/gh-runners/dialogporten-frontend.tf`, CIDR `172.17.133.0/24`).

**That PR must be merged and `terraform apply`'d before this one merges**, otherwise these jobs — including the production deploy pipelines — queue with no runner. The `self-hosted` jobs on this PR will stay pending until the runner is live.

## Security note

Public repo: self-hosted runners + fork PRs is a known risk (per the platform RFC), mitigated by ephemeral runners in an isolated VNet. Moved jobs trigger on `pull_request`/push, not `pull_request_target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
