### PR TITLE
ci: move more lightweight jobs to self-hosted runners

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -171,7 +171,7 @@ jobs:
 
   get-previous-deployed-sha:
     name: Get previous deployed SHA for test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: test
     if: ${{ github.event_name == 'push' }}
     outputs:

--- a/.github/workflows/dispatch-publish-npm-package.yml
+++ b/.github/workflows/dispatch-publish-npm-package.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   check-published-version:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       version-exists: ${{ steps.check-published-version.outputs.version-exists }}
     steps:

--- a/.github/workflows/workflow-build-and-test.yml
+++ b/.github/workflows/workflow-build-and-test.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   typecheck:
     name: 'Typechecking'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: read
       contents: read
@@ -40,7 +40,7 @@ jobs:
 
   linting:
     name: 'Linting'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       actions: read
       contents: read
@@ -59,7 +59,7 @@ jobs:
 
   test:
     name: 'Tests'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: 'Checking Out Code'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -74,7 +74,7 @@ jobs:
 
   build:
     name: 'Builds'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: 'Checking Out Code'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/workflow-deploy-docs.yml
+++ b/.github/workflows/workflow-deploy-docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy-github-pages:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/workflow-get-latest-deployed-version-info-from-github.yml
+++ b/.github/workflows/workflow-get-latest-deployed-version-info-from-github.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   get-versions:
     name: Get Latest Deployed Versions from GitHub Variables
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/workflow-parse-environment.yml
+++ b/.github/workflows/workflow-parse-environment.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   parse-environment:
     name: Parse environment name
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       environment: ${{ steps.parse.outputs.environment }}
     steps:

--- a/.github/workflows/workflow-store-github-env-variable.yml
+++ b/.github/workflows/workflow-store-github-env-variable.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   store-variable:
     name: Store GitHub Environment Variable
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout

--- a/.github/workflows/workflow-tag-issues-with-environment.yml
+++ b/.github/workflows/workflow-tag-issues-with-environment.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   tag-issues-with-environment:
     name: Tag PRs and issues with ${{ inputs.environment-label }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       GH_TOKEN: ${{ github.token }}
       LABEL: ${{ inputs.environment-label }}


### PR DESCRIPTION
Moves more lightweight CI jobs onto the repo-scoped, ephemeral self-hosted runners (Azure Container App Jobs), extending #4357. Only jobs that need no Docker daemon and no cloud/OIDC credentials are moved.

## Hva er endret?
- Build & test (typecheck, lint, test, build) now run on `self-hosted`
- Docs deploy (GitHub Pages) runs on `self-hosted`
- Reusable helper workflows moved: parse-environment, store/get GitHub variables, tag-issues-with-environment, get-previous-deployed-sha
- npm publish: only the lightweight `check-published-version` job moved — the OIDC `publish-to-npm` job stays on `ubuntu-latest`
- Docker image builds, e2e/Playwright, infra/app deploys and Slack/perf jobs are intentionally left on `ubuntu-latest`

## Related Issue(s)
- Follow-up to #4357 (self-hosted runner migration)

### Dokumentasjon / testdekning
- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)