### PR TITLE
ci: run Azure deploy jobs on self-hosted runners

### DIFF
--- a/.github/workflows/run-performance-tests.yml
+++ b/.github/workflows/run-performance-tests.yml
@@ -64,7 +64,7 @@ permissions:
 run-name: ${{ inputs.tag }} ${{ inputs.browserVus }}/${{ inputs.bffVus }}/${{ inputs.duration }}/${{ inputs.parallelism }}
 jobs:
   k6-performance-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: test
     steps:
       - name: Checkout code

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -54,7 +54,9 @@ jobs:
   deploy-migration-job:
     name: Deploy migration job to ${{ inputs.environment }}
     if: ${{ inputs.runMigration }}
-    runs-on: ubuntu-latest
+    # Self-hosted: repo-scoped ephemeral runner (Azure Container App Job).
+    # See Altinn/altinn-platform infrastructure/gh-runners/dialogporten-frontend.tf
+    runs-on: self-hosted
     environment: ${{inputs.environment}}
     permissions:
       id-token: write
@@ -113,20 +115,17 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Start migration job
-        uses: azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
+        # No Docker daemon on self-hosted runners, so call az directly instead of
+        # the azure/CLI action (which executes the script inside a container).
+        # az is preinstalled and already authenticated by the Azure Login step above.
         if: ${{!inputs.dryRun}}
-        with:
-          inlineScript: |
-            az containerapp job start -n ${{ steps.deploy.outputs.name }} -g ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+        run: az containerapp job start -n ${{ steps.deploy.outputs.name }} -g ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
       - name: Verify migration
-        uses: azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         if: ${{!inputs.dryRun}}
         id: verify-migration
         timeout-minutes: 3
-        with:
-          inlineScript: |
-            ./.github/tools/containerAppJobVerifier.sh ${{ steps.deploy.outputs.name }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }} ${{ inputs.version }}
+        run: ./.github/tools/containerAppJobVerifier.sh ${{ steps.deploy.outputs.name }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }} ${{ inputs.version }}
 
       - name: Logout from azure
         if: ${{failure() || success()}}
@@ -135,7 +134,9 @@ jobs:
 
   deploy-apps:
     name: Deploy ${{ matrix.name }} to ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    # Self-hosted: repo-scoped ephemeral runner (Azure Container App Job).
+    # See Altinn/altinn-platform infrastructure/gh-runners/dialogporten-frontend.tf
+    runs-on: self-hosted
     # Should run even though the migration job was skipped
     if: ${{ always() && !cancelled() && !failure() }}
     needs: deploy-migration-job
@@ -206,13 +207,10 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Verify deployment (${{ matrix.name }})
-        uses: azure/CLI@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         if: ${{!inputs.dryRun}}
         id: verify-deployment
         timeout-minutes: 6
-        with:
-          inlineScript: |
-            ./.github/tools/revisionVerifier.sh ${{ steps.deploy.outputs.revisionName }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+        run: ./.github/tools/revisionVerifier.sh ${{ steps.deploy.outputs.revisionName }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
 
       - name: Logout from azure
         if: ${{failure() || success()}}

--- a/.github/workflows/workflow-deploy-apps.yml
+++ b/.github/workflows/workflow-deploy-apps.yml
@@ -118,14 +118,23 @@ jobs:
         # No Docker daemon on self-hosted runners, so call az directly instead of
         # the azure/CLI action (which executes the script inside a container).
         # az is preinstalled and already authenticated by the Azure Login step above.
+        # Expressions are passed via env and referenced as quoted shell vars so
+        # workflow inputs can't be interpolated into the script (injection-safe).
         if: ${{!inputs.dryRun}}
-        run: az containerapp job start -n ${{ steps.deploy.outputs.name }} -g ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+        env:
+          JOB_NAME: ${{ steps.deploy.outputs.name }}
+          RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+        run: az containerapp job start -n "$JOB_NAME" -g "$RESOURCE_GROUP_NAME"
 
       - name: Verify migration
         if: ${{!inputs.dryRun}}
         id: verify-migration
         timeout-minutes: 3
-        run: ./.github/tools/containerAppJobVerifier.sh ${{ steps.deploy.outputs.name }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }} ${{ inputs.version }}
+        env:
+          JOB_NAME: ${{ steps.deploy.outputs.name }}
+          RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+          VERSION: ${{ inputs.version }}
+        run: ./.github/tools/containerAppJobVerifier.sh "$JOB_NAME" "$RESOURCE_GROUP_NAME" "$VERSION"
 
       - name: Logout from azure
         if: ${{failure() || success()}}
@@ -210,7 +219,10 @@ jobs:
         if: ${{!inputs.dryRun}}
         id: verify-deployment
         timeout-minutes: 6
-        run: ./.github/tools/revisionVerifier.sh ${{ steps.deploy.outputs.revisionName }} ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+        env:
+          REVISION_NAME: ${{ steps.deploy.outputs.revisionName }}
+          RESOURCE_GROUP_NAME: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
+        run: ./.github/tools/revisionVerifier.sh "$REVISION_NAME" "$RESOURCE_GROUP_NAME"
 
       - name: Logout from azure
         if: ${{failure() || success()}}

--- a/.github/workflows/workflow-upload-source-maps.yml
+++ b/.github/workflows/workflow-upload-source-maps.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   upload-source-maps:
     name: Upload source maps to Application Insights (${{ inputs.environment }})
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

Migrates the Azure-deploy tier of CI jobs to the repo-scoped, ephemeral self-hosted runners (Azure Container App Jobs), continuing the work from #4357 and #4365.

## Hva er endret?

- Run the deploy jobs in `workflow-deploy-apps.yml` (`deploy-migration-job` and `deploy-apps`) on `self-hosted` instead of `ubuntu-latest`.
- Run `workflow-upload-source-maps.yml` and the manual `run-performance-tests.yml` (k6) on `self-hosted` as well.
- Replace the three `azure/CLI` steps in `workflow-deploy-apps.yml` with direct `az` / verifier-script `run` steps — that action runs `az` inside Docker, which the self-hosted runners don't have; `az` is preinstalled and already authenticated by the Azure Login step, so behaviour is unchanged.
- OIDC `azure/login` is untouched and keeps working: the GitHub OIDC → Azure AD federated credential is matched on repo/environment claims and is independent of runner type.
- ⚠️ Worth validating on a lower environment first: Azure egress (login/ARM, blob storage, AKS API) from the runner subnet wasn't hard-confirmed, and `workflow-deploy-apps.yml` is on the production deploy path.

## Related Issue(s)

- N/A

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->

N/A
