### PR TITLE
fix(infra): lock down source maps storage account to Entra-only access

### DIFF
--- a/.azure/modules/applicationInsights/create.bicep
+++ b/.azure/modules/applicationInsights/create.bicep
@@ -17,7 +17,7 @@ resource appInsightsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-
   location: location
 }
 
-resource sourceMapStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource sourceMapStorageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' = {
   name: sourceMapStorageAccountName
   location: location
   sku: {
@@ -26,6 +26,12 @@ resource sourceMapStorageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' 
   kind: 'StorageV2'
   properties: {
     allowBlobPublicAccess: false
+    // Source maps are written by CI (az ... --auth-mode login) and read by App Insights
+    // via the developers group's Storage Blob Data Reader role. Both use Entra ID, so
+    // shared-key/account-key access can be disabled entirely.
+    allowSharedKeyAccess: false
+    defaultToOAuthAuthentication: true
+    allowCrossTenantReplication: false
     minimumTlsVersion: 'TLS1_2'
     supportsHttpsTrafficOnly: true
     encryption: {


### PR DESCRIPTION
## What

Further locks down the **source maps storage account** (the `…sourcemaps…` account created in `.azure/modules/applicationInsights/create.bicep`). This account exists only so Application Insights can resolve minified exception stack traces to original source.

## Why

`#3163` disabled shared-key access on the storage module used by the Postgres backup vault, but that module isn't used for the source maps account — so this account still allowed account-key (shared-key) access. Both of its access paths already use **Entra ID**:

- **Write (CI):** `workflow-upload-source-maps.yml` runs `az storage blob upload … --auth-mode login` using the federated `AZURE_CLIENT_ID`.
- **Read (App Insights):** the `hidden-link:Insights.Sourcemap.Storage` tag + the developers group's **Storage Blob Data Reader** role assignment.

A repo-wide search found no account key / connection string / `listKeys()` referencing this account, so disabling shared-key access removes an unused, weaker auth path rather than changing any behavior.

## Changes

In `.azure/modules/applicationInsights/create.bicep` on `sourceMapStorageAccount`:

- `allowSharedKeyAccess: false` — disable account-key auth (the headline lockdown)
- `defaultToOAuthAuthentication: true` — portal/CLI default to Entra instead of trying keys first
- `allowCrossTenantReplication: false` — block cross-tenant object replication
- Bumped API version `2023-01-01` → `2025-01-01` to match the shared `modules/storageAccount` module

All four properties are mutable on an existing account, so they apply on the next deploy with no resource recreation.

## Deliberately not included (separate decisions)

- **`requireInfrastructureEncryption: true`** — immutable after creation; would require recreating the existing source maps accounts.
- **Network lockdown** (`publicNetworkAccess: 'Disabled'` / `networkAcls` deny) — needs a private endpoint + testing so it doesn't break the self-hosted CI uploader or the App Insights portal read path.

## Verification

- `az bicep build` on the module passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
