### PR TITLE
fix: adapt dueAt to new DialogMetadataDueAtProps and add color logic

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,7 @@
     "i18n:sort": "tsx ./src/i18n/check.ts --sort"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.68.8",
+    "@altinn/altinn-components": "0.68.9",
     "@microsoft/applicationinsights-react-js": "19.3.7",
     "@microsoft/applicationinsights-web": "3.3.9",
     "@navikt/aksel-icons": "^7.37.0",

--- a/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
+++ b/packages/frontend/src/components/DialogDetails/DialogDetails.tsx
@@ -30,6 +30,7 @@ import type { DialogByIdDetails } from '../../api/hooks/useDialogById.tsx';
 import type { DialogEventData } from '../../api/hooks/useDialogByIdSubscription.ts';
 import { useErrorLogger } from '../../hooks/useErrorLogger';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
+import { getDueAtProps } from '../../pages/Inbox/dueAt.ts';
 import { getDialogStatus } from '../../pages/Inbox/status.ts';
 import type { TimelineSegmentWithTransmissions } from '../../utils/transmissions.ts';
 import { ActivityLogModal } from '../ActivityLog/activityLogModal.tsx';
@@ -337,8 +338,10 @@ export const DialogDetails = ({
           loading
           updatedAt={new Date().toISOString()}
           updatedAtLabel={format(new Date(), 'do MMMM yyyy HH.mm').toString()}
-          dueAt={new Date().toISOString()}
-          dueAtLabel={format(new Date(), 'do MMMM yyyy HH.mm').toString()}
+          dueAt={{
+            datetime: new Date().toISOString(),
+            label: format(new Date(), 'do MMMM yyyy HH.mm').toString(),
+          }}
           status={getDialogStatus(DialogStatus.NotApplicable, t)}
           title={'???'}
         />
@@ -371,7 +374,6 @@ export const DialogDetails = ({
 
   const clockPrefix = t('word.clock_prefix');
   const formatString = clockPrefix ? `do MMMM yyyy '${clockPrefix}' HH.mm` : `do MMMM yyyy HH.mm`;
-  const dueAtLabel = dialog.dueAt ? t('dialog.due_at', { date: format(dialog.dueAt, formatString) }) : '';
   const numberOfTransmissionGroups = 3;
   const dialogActions: DialogActionButtonProps[] = dialog.guiActions.map((action) => ({
     id: action.id,
@@ -412,8 +414,7 @@ export const DialogDetails = ({
       <DialogHeader
         updatedAt={dialog.updatedAt}
         updatedAtLabel={format(dialog.updatedAt, formatString)}
-        dueAt={dialog.dueAt}
-        dueAtLabel={dueAtLabel}
+        dueAt={getDueAtProps(dialog.dueAt, dialog.status, t, (date) => format(date, formatString))}
         status={getDialogStatus(dialog.status, t)}
         badge={headerBadge}
         title={dialog.title}

--- a/packages/frontend/src/i18n/resources/nb.json
+++ b/packages/frontend/src/i18n/resources/nb.json
@@ -76,7 +76,7 @@
   "dialog.aria.fetch_more": "Hent og vis flere dialoger",
   "dialog.context_menu.label": "Kontekstmeny for dialog med tittel {title}",
   "dialog.due_at": "Frist: {date}",
-  "dialog.due_at_expired": "Frist utløpt: {date}",
+  "dialog.due_at_expired": "Frist utgått: {date}",
   "dialog.error_message.general": "Kan ikke vise dialogen du prøver å åpne.",
   "dialog.fetch_more": "Vis flere ...",
   "dialog.gui_action.delete_grace_period": "Dialogen kan ikke slettes ennå fordi den er i en bevaringsperiode på {days, plural, =1 {# dag} other {# dager}} etter innsending. Du kan slette den fra {date}.",

--- a/packages/frontend/src/i18n/resources/nn.json
+++ b/packages/frontend/src/i18n/resources/nn.json
@@ -76,7 +76,7 @@
   "dialog.aria.fetch_more": "Hent og vis fleire dialogar",
   "dialog.context_menu.label": "Kontekstmeny for dialog med tittel {title}",
   "dialog.due_at": "Frist: {date}",
-  "dialog.due_at_expired": "Frist utløpt: {date}",
+  "dialog.due_at_expired": "Frist utgått: {date}",
   "dialog.error_message.general": "Dialogen du prøver å opna kan ikkje visast.",
   "dialog.fetch_more": "Vis fleire ...",
   "dialog.gui_action.delete_grace_period": "Dialogen kan ikkje slettast enno fordi han er i ein bevaringsperiode på {days, plural, =1 {# dag} other {# dagar}} etter innsending. Du kan slette han frå {date}.",

--- a/packages/frontend/src/pages/Inbox/dueAt.spec.ts
+++ b/packages/frontend/src/pages/Inbox/dueAt.spec.ts
@@ -1,0 +1,56 @@
+import { DialogStatus } from 'bff-types-generated';
+import type { TFunction } from 'i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getDueAtProps } from './dueAt.ts';
+
+const t = ((key: string) => key) as unknown as TFunction<'translation', undefined>;
+const formatDate = (date: string) => date;
+
+const daysFromNow = (days: number): string => new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+
+describe('getDueAtProps', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns undefined when dueAt is missing', () => {
+    expect(getDueAtProps(undefined, DialogStatus.RequiresAttention, t, formatDate)).toBeUndefined();
+    expect(getDueAtProps(null, DialogStatus.RequiresAttention, t, formatDate)).toBeUndefined();
+  });
+
+  it('returns undefined for an invalid date', () => {
+    expect(getDueAtProps('not-a-date', DialogStatus.RequiresAttention, t, formatDate)).toBeUndefined();
+  });
+
+  it('uses warning when the due date is more than 14 days away', () => {
+    const result = getDueAtProps(daysFromNow(20), DialogStatus.RequiresAttention, t, formatDate);
+    expect(result?.color).toBe('warning');
+    expect(result?.variant).toBeUndefined();
+    expect(result?.label).toBe('dialog.due_at');
+  });
+
+  it('uses danger when the due date is less than 14 days away', () => {
+    const result = getDueAtProps(daysFromNow(5), DialogStatus.RequiresAttention, t, formatDate);
+    expect(result?.color).toBe('danger');
+    expect(result?.label).toBe('dialog.due_at');
+  });
+
+  it('uses danger and the expired label when the due date has passed and action is required', () => {
+    const result = getDueAtProps(daysFromNow(-5), DialogStatus.RequiresAttention, t, formatDate);
+    expect(result?.color).toBe('danger');
+    expect(result?.label).toBe('dialog.due_at_expired');
+  });
+
+  it.each([DialogStatus.Completed, DialogStatus.Awaiting])('uses neutral outline for status %s', (status) => {
+    const result = getDueAtProps(daysFromNow(5), status, t, formatDate);
+    expect(result?.color).toBe('neutral');
+    expect(result?.variant).toBe('outline');
+  });
+
+  it('keeps the expired label but stays neutral for a settled status', () => {
+    const result = getDueAtProps(daysFromNow(-5), DialogStatus.Completed, t, formatDate);
+    expect(result?.color).toBe('neutral');
+    expect(result?.variant).toBe('outline');
+    expect(result?.label).toBe('dialog.due_at_expired');
+  });
+});

--- a/packages/frontend/src/pages/Inbox/dueAt.ts
+++ b/packages/frontend/src/pages/Inbox/dueAt.ts
@@ -1,0 +1,41 @@
+import type { DialogMetadataDueAtProps } from '@altinn/altinn-components';
+import { DialogStatus } from 'bff-types-generated';
+import type { TFunction } from 'i18next';
+
+const DUE_AT_SOON_THRESHOLD_DAYS = 14;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export const isDueAtExpired = (dueAt?: string): boolean => {
+  if (!dueAt) return false;
+  const time = new Date(dueAt).getTime();
+  if (Number.isNaN(time)) return false;
+  return time < Date.now();
+};
+
+const isDueAtSoon = (dueAt: string): boolean => {
+  const time = new Date(dueAt).getTime();
+  if (Number.isNaN(time)) return false;
+  return time - Date.now() < DUE_AT_SOON_THRESHOLD_DAYS * MS_PER_DAY;
+};
+
+const isSettledStatus = (status: DialogStatus): boolean =>
+  status === DialogStatus.Completed || status === DialogStatus.Awaiting;
+
+export const getDueAtProps = (
+  dueAt: string | undefined | null,
+  status: DialogStatus,
+  t: TFunction<'translation', undefined>,
+  formatDate: (date: string) => string,
+): DialogMetadataDueAtProps | undefined => {
+  if (!dueAt) return undefined;
+  if (Number.isNaN(new Date(dueAt).getTime())) return undefined;
+
+  const expired = isDueAtExpired(dueAt);
+  const label = t(expired ? 'dialog.due_at_expired' : 'dialog.due_at', { date: formatDate(dueAt) });
+
+  if (isSettledStatus(status)) {
+    return { datetime: dueAt, label, color: 'neutral', variant: 'outline' };
+  }
+
+  return { datetime: dueAt, label, color: expired || isDueAtSoon(dueAt) ? 'danger' : 'warning' };
+};

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.spec.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.spec.tsx
@@ -6,7 +6,8 @@ import { createCustomWrapper } from '../../../tests/test-utils.tsx';
 import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
 import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
 import type { InboxItemInput } from './InboxItemInput.ts';
-import useGroupedDialogs, { isDueAtExpired } from './useGroupedDialogs.tsx';
+import { isDueAtExpired } from './dueAt.ts';
+import useGroupedDialogs from './useGroupedDialogs.tsx';
 
 vi.mock('react-i18next', () => ({
   useTranslation: vi.fn(),

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -23,6 +23,7 @@ import { useGlobalState } from '../../useGlobalState.ts';
 import { useDialogActions } from '../DialogDetailsPage/useDialogActions.tsx';
 import type { CurrentSeenByLog } from './Inbox.tsx';
 import type { InboxItemInput } from './InboxItemInput.ts';
+import { getDueAtProps } from './dueAt.ts';
 import type { PartyGroup } from './queryParams.ts';
 import { getDialogStatus } from './status.ts';
 
@@ -131,13 +132,6 @@ const getDialogListDescription = ({
 };
 
 const BANKRUPTCY_SERVICE_RESOURCE = 'urn:altinn:resource:app_brg_konkursbehandling';
-
-export const isDueAtExpired = (dueAt?: string): boolean => {
-  if (!dueAt) return false;
-  const time = new Date(dueAt).getTime();
-  if (Number.isNaN(time)) return false;
-  return time < Date.now();
-};
 
 const sortGroupedDialogs = (arr: DialogListItemProps[]) => {
   return arr.sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime());
@@ -321,13 +315,7 @@ const useGroupedDialogs = ({
       extendedStatusLabel: item.extendedStatus,
       updatedAt: item.contentUpdatedAt,
       updatedAtLabel: format(item.contentUpdatedAt, formatString),
-      dueAtLabel: item.dueAt
-        ? t(isDueAtExpired(item.dueAt) ? 'dialog.due_at_expired' : 'dialog.due_at', {
-            date: format(item.dueAt, formatString),
-          })
-        : undefined,
-      dueAtExpired: isDueAtExpired(item.dueAt),
-      dueAt: item.dueAt,
+      dueAt: getDueAtProps(item.dueAt, item.status, t, (date) => format(date, formatString)),
       sentCount: item.fromPartyTransmissionsCount ?? 0,
       receivedCount: item.fromServiceOwnerTransmissionsCount ?? 0,
       ariaLabel: item.title,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,8 +502,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: 0.68.8
-        version: 0.68.8(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 0.68.9
+        version: 0.68.9(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@microsoft/applicationinsights-react-js':
         specifier: 19.3.7
         version: 19.3.7(history@4.10.1)(react@19.2.3)(tslib@2.8.1)
@@ -720,8 +720,8 @@ packages:
     resolution: {integrity: sha512-ZgxV2+5qt3NLeUYBTsi6PLyHcENQWC0iFppFZekHSEDA2wcLdTUjnaJzimTEULHIvJuLRCkUs4JABdhuJktEag==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.68.8':
-    resolution: {integrity: sha512-PZazSYaoGEVyj3fH/VXB3n5v8P3SjYKsc/bOJvE989wZonoEmIMMvR4St+wxFcbZ33woRnrrbFE7VPWsk/O53A==}
+  '@altinn/altinn-components@0.68.9':
+    resolution: {integrity: sha512-29TfUNeKp3o+5tiyup4EQ07mO8LPRhqN05zJalycZn35gxyfGzBrMU9XvRI2a59gLeEtSdLQ1gg2mWx4b7XXKQ==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -10560,7 +10560,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.48.0
 
-  '@altinn/altinn-components@0.68.8(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@altinn/altinn-components@0.68.9(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@digdir/designsystemet-css': 1.14.0
       '@digdir/designsystemet-react': 1.14.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
- more than 14 days away: warning (yellow)
- less than 14 days away: danger (red)
- status Completed/Awaiting: neutral (grey), outline variant
- expired and action still required: danger (red), "Frist utgått" label

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4387


### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
