### PR TITLE
fix(ci): make source map upload succeed on workflow rerun

### DIFF
--- a/.github/workflows/workflow-upload-source-maps.yml
+++ b/.github/workflows/workflow-upload-source-maps.yml
@@ -74,7 +74,8 @@ jobs:
                 --container-name "${{ secrets.AZURE_SOURCE_MAPS_CONTAINER_NAME }}" \
                 --name "$mapfile" \
                 --file "$mapfile" \
-                --auth-mode login
+                --auth-mode login \
+                --overwrite
               
               echo "Uploaded $mapfile successfully"
             fi


### PR DESCRIPTION
Re-running the "Upload Source Maps" workflow no longer fails when the source maps for that version were already uploaded.

## Hva er endret?

- Source map upload to Azure Blob Storage now overwrites an existing blob instead of erroring out, so re-running the workflow no longer fails with `BlobAlreadyExists`.
- The upload step is now idempotent: blob names are keyed by version + commit hash, so a re-run uploads byte-identical content and can safely overwrite.
- No behavior change on the first (successful) run — only reruns, which previously errored, are affected.

## Related Issue(s)

- N/A

### Dokumentasjon / testdekning

- [x] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [x] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)

N/A