### PR TITLE
fix(docker): upgrade Traefik to v3.6.2 for Docker 29.x support

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   reverse-proxy:
     container_name: reverse-proxy
-    image: traefik:v2.10
+    image: traefik:v3.6.2
     command:
       - "--api.dashboard=true"
       - "--providers.docker"
@@ -24,8 +24,7 @@ services:
       - "homarr.relativeSubdomain=dashboard"
       - "homarr.icon=simple-icons:traefikproxy"
       - "traefik.http.routers.dashboard.tls=true"
-      - "traefik.http.routers.dashboard.tls.certresolver=default"
-      - "traefik.http.routers.http-catchall.rule=HostRegexp(`{host:.+}`)"
+      - "traefik.http.routers.http-catchall.rule=HostRegexp(`^.+$`)"
       - "traefik.http.routers.http-catchall.entrypoints=web"
       - "traefik.http.routers.http-catchall.middlewares=redirect-to-https"
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
@@ -47,12 +46,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.homepage.rule=Host(`localhost`)"
-      - "traefik.http.routers.dashboard.tls=true"
-      - "traefik.http.routers.dashboard.tls.certresolver=default"
-      - "traefik.http.routers.http-catchall.rule=HostRegexp(`{host:.+}`)"
-      - "traefik.http.routers.http-catchall.entrypoints=web"
-      - "traefik.http.routers.http-catchall.middlewares=redirect-to-https"
-      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
 
     ports:
       - 3000:3000

--- a/packages/docs/docs/development/https+certs.md
+++ b/packages/docs/docs/development/https+certs.md
@@ -18,10 +18,10 @@ mkcert -install
 
 ## 🔹 Step 2: Generate SSL Certificates
 ```sh
-mkcert -cert-file certs/cert.crt -key-file certs/key.pem app.localhost localhost docs.localhost
+mkcert -cert-file certs/cert.crt -key-file certs/key.pem app.localhost localhost docs.localhost dashboard.localhost pgadmin4.localhost redisinsight.localhost
 ```
 
-This creates a certificate valid for app.localhost, localhost, and docs.localhost.
+This creates a certificate valid for every localhost subdomain Traefik routes: app.localhost, localhost, docs.localhost, dashboard.localhost, pgadmin4.localhost, and redisinsight.localhost.
 
 ## 🔹 Step 3: Convert to PEM Format 
 ```sh


### PR DESCRIPTION
Ran into this after updating to Docker 29. Traefik just stopped picking up containers, no errors, nothing worked. Turns out Docker 29 dropped the old API version (v1.24) that Traefik v2.10 relies on and it now wants v1.44+.

Bumping Traefik to v3.6.2 fixes it since v3 negotiates the API version on its own. v3 is also a lot stricter about config, so I had to clean up a few things that v2 was quietly ignoring:

- updated the `HostRegexp` rule to the new v3 syntax
- removed some dashboard/catch-all router labels that had been copy-pasted onto the homepage service
- dropped a cert-resolver reference that didn't actually point at anything

Tested locally with `make dev` on Docker 29.4.0, dashboard loads and the HTTPS redirect works, no more Traefik errors in the logs.

It's backward compatible, so we are notforced to upgrade Docker to version 29, but it enables us to do so.
I am running OrbStack on latest version which bundles `29.4.0`

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/3941

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
