### PR TITLE
feat: Add help pages to side meny and mobile, support language

### DIFF
--- a/packages/frontend/src/auth/url.ts
+++ b/packages/frontend/src/auth/url.ts
@@ -205,6 +205,28 @@ export const getNeedHelpLink = (language?: string) => {
   );
 };
 
+export const getInboxHelpLink = (language?: string) => {
+  return createInfoPortalLink(
+    {
+      nb: '/hjelp/ny-innboks-beta/',
+      en: '/en/help/inbox/',
+      nn: '/nn/hjelp/innboks/',
+    },
+    language,
+  );
+};
+
+export const getProfileHelpLink = (language?: string) => {
+  return createInfoPortalLink(
+    {
+      nb: '/hjelp/oversikt-over-varslingsinnstillinger/',
+      en: '/en/help/contact-information-and-notification-settings/',
+      nn: '/nn/hjelp/kontaktinformasjon-og-varslingsinnstillingar/',
+    },
+    language,
+  );
+};
+
 export const getCookieDomain = () => {
   const hostMap: Record<hostEnv, string> = {
     local: 'app.localhost',

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/inboxMenu.tsx
@@ -5,6 +5,7 @@ import {
   Buildings2Icon,
   ChatExclamationmarkIcon,
   DocPencilIcon,
+  ExternalLinkIcon,
   FileCheckmarkIcon,
   HeartIcon,
   InboxFillIcon,
@@ -20,6 +21,7 @@ import {
   getAboutNewAltinnLink,
   getAccessAMUILink,
   getFrontPageLink,
+  getInboxHelpLink,
   getNeedHelpLink,
   getNewFormLink,
   getStartNewBusinessLink,
@@ -132,6 +134,18 @@ export function buildInboxMenu({
     },
   ];
 
+  const helpPageItem: MenuItemProps = {
+    id: 'help-pages',
+    'data-testid': 'help-pages',
+    groupId: 'shortcuts',
+    icon: ExternalLinkIcon,
+    title: t('floating_dropdown.help_pages'),
+    as: createMenuItemComponent({
+      to: getInboxHelpLink(i18n.language),
+      isExternal: true,
+    }),
+  };
+
   const inboxItems: MenuItemProps[] = [
     {
       id: '1',
@@ -204,7 +218,7 @@ export function buildInboxMenu({
       ...menuGroups,
       shortcuts: menuGroups.shortcuts,
     },
-    items: [...inboxItems, ...shortcuts],
+    items: [...inboxItems, ...shortcuts, helpPageItem],
   };
 
   const mobileMenu: MenuProps = {
@@ -251,6 +265,7 @@ export function buildInboxMenu({
         selected: false,
       },
       ...helpItems,
+      { ...helpPageItem, groupId: 'help' },
       {
         groupId: 'profile-shortcut',
         id: 'profile',

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/profileMenu.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/profileMenu.tsx
@@ -4,6 +4,7 @@ import {
   BellIcon,
   Buildings2Icon,
   ChatExclamationmarkIcon,
+  ExternalLinkIcon,
   HeartIcon,
   InboxFillIcon,
   InboxIcon,
@@ -19,6 +20,7 @@ import {
   getFrontPageLink,
   getNeedHelpLink,
   getNewFormLink,
+  getProfileHelpLink,
   getStartNewBusinessLink,
 } from '../../../auth/url.ts';
 import { i18n } from '../../../i18n/config.ts';
@@ -151,6 +153,18 @@ export function buildProfileMenu({
     },
   ];
 
+  const helpPageItem: MenuItemProps = {
+    id: 'help-pages',
+    'data-testid': 'sidebar-help-pages',
+    groupId: 'shortcuts',
+    icon: ExternalLinkIcon,
+    title: t('floating_dropdown.help_pages'),
+    as: createMenuItemComponent({
+      to: getProfileHelpLink(i18n.language),
+      isExternal: true,
+    }),
+  };
+
   const inboxShortcut: MenuItemProps = {
     id: 'profile-inbox-shortcut',
     groupId: 'shortcuts',
@@ -173,6 +187,7 @@ export function buildProfileMenu({
         iconTheme: idx === 0 ? 'base' : 'tinted',
       })),
       ...shortcuts,
+      helpPageItem,
     ],
   };
 
@@ -242,6 +257,7 @@ export function buildProfileMenu({
     items: [
       ...globalMenuItems,
       ...helpItems,
+      { ...helpPageItem, groupId: 'help' },
       {
         ...profileMenuItem,
         selected: isRouteSelected(pathname, PageRoutes.profile, fromView),

--- a/packages/frontend/src/components/PageLayout/GlobalMenu/shared.tsx
+++ b/packages/frontend/src/components/PageLayout/GlobalMenu/shared.tsx
@@ -27,5 +27,5 @@ export const createMenuItemComponent =
   ({ to, isExternal = false }: { to: string; isExternal?: boolean }): React.FC<MenuItemProps> =>
   (props) => {
     // @ts-ignore
-    return <Link {...props} to={to} {...(isExternal ? { target: '__blank', rel: 'noopener noreferrer' } : {})} />;
+    return <Link {...props} to={to} {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})} />;
   };


### PR DESCRIPTION
<!--- Fortell kort hva PR-en din inneholder i to-tre setninger maks. -->

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

For at23 and tt02 the help pages, profile version for nynorsk and english are not available in info portal. 
I have checked how the URLs look like in prod and took that as a source of truth. 

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4440

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
