### PR TITLE
fix(frontend): stabilize account selector inputs, add parties benchmark

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run",
+    "bench": "vitest bench --run",
     "codegen:playwright": "playwright codegen",
     "test:playwright": "npx playwright test --project=playwright",
     "test:playwright:mobile": "npx playwright test --project=playwright-mobile",
@@ -23,7 +24,7 @@
     "doctor": "npx react-doctor@latest"
   },
   "dependencies": {
-    "@altinn/altinn-components": "0.68.9",
+    "@altinn/altinn-components": "0.68.15",
     "@microsoft/applicationinsights-react-js": "19.3.7",
     "@microsoft/applicationinsights-web": "3.3.9",
     "@navikt/aksel-icons": "^7.37.0",

--- a/packages/frontend/src/components/PageLayout/Accounts/accountComputations.ts
+++ b/packages/frontend/src/components/PageLayout/Accounts/accountComputations.ts
@@ -1,0 +1,144 @@
+import { type AccountMenuItemProps, type AvatarType, type BadgeProps, formatDate } from '@altinn/altinn-components';
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import i18n from 'i18next';
+import type { PartyGraph } from '../../../utils/partyGraph.ts';
+
+export interface PartyItemProp extends AccountMenuItemProps {
+  uuid: string;
+  altinnId: number;
+  isPreselectedParty?: boolean;
+  isDeleted?: boolean;
+  parentId?: string | undefined;
+  parentName?: string | undefined;
+  isFavorite?: boolean;
+  isCurrentEndUser?: boolean;
+  badge?: BadgeProps;
+  isParent?: boolean;
+  ssnOrOrgNo?: string;
+}
+
+export type OrgSkeletonItem = { party: PartyFieldsFragment; isParent: boolean; parent?: PartyFieldsFragment };
+
+export interface MapAccountOptions {
+  showDescription?: boolean;
+  t: (key: string) => string;
+}
+
+export const getOrgNo = (partyId: string): string => {
+  if (!partyId.includes('urn:altinn:organization:')) return '';
+  const parts = partyId.split('identifier-no:');
+  return parts[1] ?? '';
+};
+
+export const formatOrgNo = (orgNo: string, includeThinSpace?: boolean): string => {
+  if (!orgNo) return '';
+  if (includeThinSpace ?? true) {
+    return [orgNo.slice(0, 3), orgNo.slice(3, 6), orgNo.slice(6, 9)].join('\u2009');
+  }
+  return orgNo.slice(0, 9);
+};
+
+export const formatNorwegianId = (partyId: string, includeThinSpace?: boolean): string =>
+  formatOrgNo(getOrgNo(partyId), includeThinSpace);
+
+/** Reuse a single Intl.Collator per language – much faster than localeCompare per call */
+let collatorLang = '';
+let collator: Intl.Collator;
+const getCollator = (): Intl.Collator => {
+  if (collatorLang !== i18n.language) {
+    collatorLang = i18n.language;
+    collator = new Intl.Collator(i18n.language, { sensitivity: 'base' });
+  }
+  return collator;
+};
+const compareName = (a: string, b: string) => getCollator().compare(a, b);
+
+/** Cheap skeleton: sorted PartyFieldsFragment refs. No PartyItemProp allocation here. */
+export const buildPersonSkeleton = (otherPeople: PartyFieldsFragment[]): PartyFieldsFragment[] => {
+  return [...otherPeople].sort((a, b) => compareName(a.name, b.name));
+};
+
+/** Cheap skeleton: sorted+grouped org refs. */
+export const buildOrgSkeleton = (organizations: PartyFieldsFragment[], partyGraph: PartyGraph): OrgSkeletonItem[] => {
+  const items: OrgSkeletonItem[] = organizations.map((party) => {
+    const matchInAvailable = partyGraph.partyByUrn.get(party.party);
+    const isParent = Array.isArray(matchInAvailable?.subParties);
+    const parent = isParent ? undefined : partyGraph.parentByChildUrn.get(party.party);
+    return { party, isParent, parent };
+  });
+
+  const parents = items.filter((i) => i.isParent).sort((a, b) => compareName(a.party.name, b.party.name));
+  const childrenByParentParty = new Map<string, OrgSkeletonItem[]>();
+  const orphans: OrgSkeletonItem[] = [];
+
+  for (const item of items) {
+    if (item.isParent) continue;
+    if (item.parent) {
+      const arr = childrenByParentParty.get(item.parent.party) ?? [];
+      arr.push(item);
+      childrenByParentParty.set(item.parent.party, arr);
+    } else {
+      orphans.push(item);
+    }
+  }
+  for (const arr of childrenByParentParty.values()) arr.sort((a, b) => compareName(a.party.name, b.party.name));
+  orphans.sort((a, b) => compareName(a.party.name, b.party.name));
+
+  const grouped = parents.flatMap((p) => [p, ...(childrenByParentParty.get(p.party.party) ?? [])]);
+  return [...grouped, ...orphans];
+};
+
+export const mapPersonToAccount = (
+  person: PartyFieldsFragment,
+  { showDescription, t }: MapAccountOptions,
+): PartyItemProp => {
+  const birthDate = formatDate(person.dateOfBirth ?? undefined);
+  return {
+    id: person.party,
+    searchWords: [person.name],
+    name: person.name,
+    title: person.name,
+    type: 'person' as AccountMenuItemProps['type'],
+    icon: { name: person.name, type: 'person' as AvatarType },
+    isDeleted: person.isDeleted,
+    isCurrentEndUser: false,
+    uuid: person.partyUuid,
+    altinnId: person.partyId,
+    description: showDescription && birthDate ? t('word.born') + birthDate : undefined,
+    badge: person.isDeleted ? { color: 'neutral', label: t('badge.deleted'), variant: 'subtle' } : undefined,
+    groupId: 'persons',
+  } as PartyItemProp;
+};
+
+export const mapOrgItemToAccount = (
+  item: OrgSkeletonItem,
+  { showDescription, t }: MapAccountOptions,
+): PartyItemProp => {
+  const { party, isParent, parent } = item;
+  const orgNo = getOrgNo(party.party);
+  const formattedId = formatOrgNo(orgNo);
+  const description = showDescription
+    ? parent?.name && party?.party
+      ? `↳ ${t('word.orgNo')} ${formattedId}, ${t('profile.account.partOf')} ${parent.name}`
+      : `${t('word.orgNo')} ${formattedId}`
+    : undefined;
+  return {
+    id: party.party,
+    searchWords: [orgNo, party.name],
+    ssnOrOrgNo: orgNo,
+    name: party.name,
+    title: party.name,
+    type: 'company' as AccountMenuItemProps['type'],
+    icon: { name: party.name, type: 'company' as AvatarType, isParent, isDeleted: party.isDeleted },
+    isDeleted: party.isDeleted,
+    isCurrentEndUser: false,
+    uuid: party.partyUuid,
+    disabled: party.hasOnlyAccessToSubParties,
+    isParent,
+    parentId: parent?.party,
+    parentName: parent?.name,
+    description,
+    badge: party.isDeleted ? { color: 'neutral', label: t('badge.deleted'), variant: 'subtle' } : undefined,
+    groupId: parent?.party ?? party.party,
+  } as PartyItemProp;
+};

--- a/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
+++ b/packages/frontend/src/components/PageLayout/Accounts/useAccounts.tsx
@@ -3,13 +3,11 @@ import {
   type AccountSearchProps,
   type AvatarGroupProps,
   type AvatarType,
-  type BadgeProps,
   type MenuItemGroups,
   formatDate,
 } from '@altinn/altinn-components';
 import { useQueryClient } from '@tanstack/react-query';
 import type { PartyFieldsFragment } from 'bff-types-generated';
-import i18n from 'i18next';
 import { type ChangeEvent, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -25,6 +23,17 @@ import { useProfile } from '../../../pages/Profile/useProfile.tsx';
 import { SettingsType } from '../../../pages/Profile/useSettings.tsx';
 import type { PageRoutes } from '../../../pages/routes.ts';
 import type { PartyGraph } from '../../../utils/partyGraph.ts';
+import {
+  type OrgSkeletonItem,
+  type PartyItemProp,
+  buildOrgSkeleton,
+  buildPersonSkeleton,
+  mapOrgItemToAccount,
+  mapPersonToAccount,
+} from './accountComputations.ts';
+
+export { formatNorwegianId, formatOrgNo, getOrgNo } from './accountComputations.ts';
+export type { PartyItemProp } from './accountComputations.ts';
 
 /** Account tile ids for the virtual group tiles. Kept identical to the URL `group` values. */
 export const ACCOUNT_GROUPS_KEYS = {
@@ -43,20 +52,6 @@ interface UseAccountOptions {
    * into PartyItemProp. The full count is returned via `accountsTotal`.
    */
   pagination?: { offset: number; limit: number };
-}
-
-export interface PartyItemProp extends AccountMenuItemProps {
-  uuid: string;
-  altinnId: number;
-  isPreselectedParty?: boolean;
-  isDeleted?: boolean;
-  parentId?: string | undefined;
-  parentName?: string | undefined;
-  isFavorite?: boolean;
-  isCurrentEndUser?: boolean;
-  badge?: BadgeProps;
-  isParent?: boolean;
-  ssnOrOrgNo?: string;
 }
 
 interface UseAccountsProps {
@@ -80,34 +75,6 @@ interface UseAccountsOutput {
   accountsTotal: number;
   searchable: boolean;
 }
-
-export const getOrgNo = (partyId: string): string => {
-  if (!partyId.includes('urn:altinn:organization:')) return '';
-  const parts = partyId.split('identifier-no:');
-  return parts[1] ?? '';
-};
-
-export const formatNorwegianId = (partyId: string, includeThinSpace?: boolean): string => {
-  const orgNo = getOrgNo(partyId);
-  if (!orgNo) return '';
-  const thinSpaceIncluded = includeThinSpace ?? true;
-  if (thinSpaceIncluded) {
-    return [orgNo.slice(0, 3), orgNo.slice(3, 6), orgNo.slice(6, 9)].join('\u2009');
-  }
-  return orgNo.slice(0, 9);
-};
-
-/** Reuse a single Intl.Collator per language – much faster than localeCompare per call */
-let collatorLang = '';
-let collator: Intl.Collator;
-const getCollator = (): Intl.Collator => {
-  if (collatorLang !== i18n.language) {
-    collatorLang = i18n.language;
-    collator = new Intl.Collator(i18n.language, { sensitivity: 'base' });
-  }
-  return collator;
-};
-const compareName = (a: string, b: string) => getCollator().compare(a, b);
 
 export const useAccounts = ({
   parties,
@@ -175,96 +142,23 @@ export const useAccounts = ({
   const preselectedPartyUuid = user?.profileSettingPreference?.preselectedPartyUuid;
   const isPaginated = !!inputOptions?.pagination;
 
-  // Cheap skeleton: sorted PartyFieldsFragment refs. No PartyItemProp allocation here.
-  const personSkeleton = useMemo<PartyFieldsFragment[]>(() => {
-    return [...otherPeople].sort((a, b) => compareName(a.name, b.name));
-  }, [otherPeople]);
+  const personSkeleton = useMemo<PartyFieldsFragment[]>(() => buildPersonSkeleton(otherPeople), [otherPeople]);
 
-  type OrgSkeletonItem = { party: PartyFieldsFragment; isParent: boolean; parent?: PartyFieldsFragment };
-
-  // Cheap skeleton: sorted+grouped org refs.
-  const orgSkeleton = useMemo<OrgSkeletonItem[]>(() => {
-    const items: OrgSkeletonItem[] = organizations.map((party) => {
-      const matchInAvailable = partyGraph.partyByUrn.get(party.party);
-      const isParent = Array.isArray(matchInAvailable?.subParties);
-      const parent = isParent ? undefined : partyGraph.parentByChildUrn.get(party.party);
-      return { party, isParent, parent };
-    });
-
-    const parents = items.filter((i) => i.isParent).sort((a, b) => compareName(a.party.name, b.party.name));
-    const childrenByParentParty = new Map<string, OrgSkeletonItem[]>();
-    const orphans: OrgSkeletonItem[] = [];
-
-    for (const item of items) {
-      if (item.isParent) continue;
-      if (item.parent) {
-        const arr = childrenByParentParty.get(item.parent.party) ?? [];
-        arr.push(item);
-        childrenByParentParty.set(item.parent.party, arr);
-      } else {
-        orphans.push(item);
-      }
-    }
-    for (const arr of childrenByParentParty.values()) arr.sort((a, b) => compareName(a.party.name, b.party.name));
-    orphans.sort((a, b) => compareName(a.party.name, b.party.name));
-
-    const grouped = parents.flatMap((p) => [p, ...(childrenByParentParty.get(p.party.party) ?? [])]);
-    return [...grouped, ...orphans];
-  }, [organizations, partyGraph]);
+  const orgSkeleton = useMemo<OrgSkeletonItem[]>(
+    () => buildOrgSkeleton(organizations, partyGraph),
+    [organizations, partyGraph],
+  );
 
   // Pure mappers. No favorite/preselect deps here — applied as a cheap overlay after.
   const mapPerson = useCallback(
-    (person: PartyFieldsFragment): PartyItemProp => {
-      const birthDate = formatDate(person.dateOfBirth ?? undefined);
-      return {
-        id: person.party,
-        searchWords: [person.name],
-        name: person.name,
-        title: person.name,
-        type: 'person' as AccountMenuItemProps['type'],
-        icon: { name: person.name, type: 'person' as AvatarType },
-        isDeleted: person.isDeleted,
-        isCurrentEndUser: false,
-        uuid: person.partyUuid,
-        altinnId: person.partyId,
-        description: options.showDescription && birthDate ? t('word.born') + birthDate : undefined,
-        badge: person.isDeleted ? { color: 'neutral', label: t('badge.deleted'), variant: 'subtle' } : undefined,
-        groupId: 'persons',
-      } as PartyItemProp;
-    },
+    (person: PartyFieldsFragment): PartyItemProp =>
+      mapPersonToAccount(person, { showDescription: options.showDescription, t }),
     [options.showDescription, t],
   );
 
   const mapOrgItem = useCallback(
-    (item: OrgSkeletonItem): PartyItemProp => {
-      const { party, isParent, parent } = item;
-      const orgNo = getOrgNo(party.party);
-      const formattedId = formatNorwegianId(party.party);
-      const description = options.showDescription
-        ? parent?.name && party?.party
-          ? `↳ ${t('word.orgNo')} ${formattedId}, ${t('profile.account.partOf')} ${parent.name}`
-          : `${t('word.orgNo')} ${formattedId}`
-        : undefined;
-      return {
-        id: party.party,
-        searchWords: [orgNo, party.name],
-        ssnOrOrgNo: orgNo,
-        name: party.name,
-        title: party.name,
-        type: 'company' as AccountMenuItemProps['type'],
-        icon: { name: party.name, type: 'company' as AvatarType, isParent, isDeleted: party.isDeleted },
-        isDeleted: party.isDeleted,
-        isCurrentEndUser: false,
-        uuid: party.partyUuid,
-        disabled: party.hasOnlyAccessToSubParties,
-        isParent,
-        parentId: parent?.party,
-        parentName: parent?.name,
-        description,
-        badge: party.isDeleted ? { color: 'neutral', label: t('badge.deleted'), variant: 'subtle' } : undefined,
-        groupId: parent?.party ?? party.party,
-      } as PartyItemProp;
-    },
+    (item: OrgSkeletonItem): PartyItemProp =>
+      mapOrgItemToAccount(item, { showDescription: options.showDescription, t }),
     [options.showDescription, t],
   );
 

--- a/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
+++ b/packages/frontend/src/components/PageLayout/useHeaderConfig.tsx
@@ -72,36 +72,39 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
     [favoritesGroup?.parties, addFavoriteParty, deleteFavoriteParty, logError],
   );
 
-  const handleSelectAccount = (accountUuid: string) => {
-    const targetRoute = isProfile ? PageRoutes.profile : PageRoutes.inbox;
-    const party = partyGraph.partyByUuid.get(accountUuid);
+  const handleSelectAccount = useCallback(
+    (accountUuid: string) => {
+      const targetRoute = isProfile ? PageRoutes.profile : PageRoutes.inbox;
+      const party = partyGraph.partyByUuid.get(accountUuid);
 
-    if (!party) {
-      console.error('Selected party not found:', accountUuid);
-      return;
-    }
-
-    /* Selected party already selected */
-    if (selectedParties.length === 1 && selectedParties[0].party === party.party) {
-      return;
-    }
-
-    if (party.partyType === 'Person') {
-      setSelectedPartyIds([party.party], null);
-      if (location.pathname.startsWith('/inbox/')) {
-        navigate(PageRoutes.inbox);
+      if (!party) {
+        console.error('Selected party not found:', accountUuid);
+        return;
       }
-    } else {
-      const search = new URLSearchParams(location.search);
-      search.set('party', party.party);
-      search.delete('allParties');
-      search.delete(FixedGlobalQueryParams.group);
-      search.delete(FixedGlobalQueryParams.subAccounts);
-      navigate(`${targetRoute}?${search.toString()}`, {
-        replace: location.pathname === targetRoute,
-      });
-    }
-  };
+
+      /* Selected party already selected */
+      if (selectedParties.length === 1 && selectedParties[0].party === party.party) {
+        return;
+      }
+
+      if (party.partyType === 'Person') {
+        setSelectedPartyIds([party.party], null);
+        if (location.pathname.startsWith('/inbox/')) {
+          navigate(PageRoutes.inbox);
+        }
+      } else {
+        const search = new URLSearchParams(location.search);
+        search.set('party', party.party);
+        search.delete('allParties');
+        search.delete(FixedGlobalQueryParams.group);
+        search.delete(FixedGlobalQueryParams.subAccounts);
+        navigate(`${targetRoute}?${search.toString()}`, {
+          replace: location.pathname === targetRoute,
+        });
+      }
+    },
+    [isProfile, partyGraph, selectedParties, setSelectedPartyIds, location.pathname, location.search, navigate],
+  );
 
   const handleShowDeletedUnitsChange = useCallback(
     async (shouldShow: boolean) => {
@@ -123,8 +126,11 @@ export const useHeaderConfig = (filterState?: FilterState): UseHeaderConfigOutpu
 
   const partyListDTO = useMemo(() => mapPartiesToAuthorizedParties(parties), [parties]);
 
-  const favoriteAccountUuids = (favoritesGroup?.parties ?? []).filter(
-    (uuid): uuid is string => uuid !== null && uuid !== undefined,
+  /* Must be referentially stable: useAccountSelector's full-list materialization memo depends on this
+   * array, so a fresh array per render re-runs that O(n) rebuild on every header render. */
+  const favoriteAccountUuids = useMemo(
+    () => (favoritesGroup?.parties ?? []).filter((uuid): uuid is string => uuid !== null && uuid !== undefined),
+    [favoritesGroup?.parties],
   );
 
   const selfAccountUuid = currentEndUser?.partyUuid;

--- a/packages/frontend/src/mocks/data/stories/parties-extreme-100k/parties.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-extreme-100k/parties.ts
@@ -1,0 +1,4 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { generateParties } from '../parties-extreme/parties.ts';
+
+export const parties: PartyFieldsFragment[] = generateParties(100_000, 300);

--- a/packages/frontend/src/mocks/data/stories/parties-extreme/parties.ts
+++ b/packages/frontend/src/mocks/data/stories/parties-extreme/parties.ts
@@ -151,7 +151,10 @@ function generateOrganization(index: number, partyId: number): PartyFieldsFragme
   };
 }
 
-function generateParties(total: number = TOTAL_PARTIES, personCount: number = PERSON_COUNT): PartyFieldsFragment[] {
+export function generateParties(
+  total: number = TOTAL_PARTIES,
+  personCount: number = PERSON_COUNT,
+): PartyFieldsFragment[] {
   const result: PartyFieldsFragment[] = [];
 
   for (let i = 0; i < personCount && i < total; i++) {

--- a/packages/frontend/src/utils/partiesPipeline.bench.ts
+++ b/packages/frontend/src/utils/partiesPipeline.bench.ts
@@ -1,0 +1,96 @@
+import type { PartyFieldsFragment } from 'bff-types-generated';
+import { bench, describe } from 'vitest';
+import {
+  buildOrgSkeleton,
+  buildPersonSkeleton,
+  mapOrgItemToAccount,
+} from '../components/PageLayout/Accounts/accountComputations.ts';
+import { generateParties } from '../mocks/data/stories/parties-extreme/parties.ts';
+import { normalizeFlattenParties } from './normalizeFlattenParties.ts';
+import { buildPartyGraph } from './partyGraph.ts';
+
+/* Benchmarks the parties post-processing pipeline stage by stage, using the real production
+ * functions on generated data. Run with `pnpm bench`; override the size with
+ * BENCH_PARTY_COUNT=15000 for a quick pass. Mean time per iteration is the number to read.
+ *
+ * Iteration hygiene: normalizeFlattenParties may mutate and pre-sort its input, so it gets a fresh
+ * dataset per iteration (pre-cloned, so cloning cost stays out of the measurement). buildPartyGraph
+ * memoizes per array reference, so it gets a fresh `.slice()` per iteration.
+ */
+const PARTY_COUNT = Number(process.env.BENCH_PARTY_COUNT ?? 100_000);
+const PERSON_COUNT = 300;
+
+const t = (key: string) => key;
+
+const rawParties = generateParties(PARTY_COUNT, PERSON_COUNT);
+const payload = JSON.stringify({ parties: rawParties });
+
+const parseParties = (): PartyFieldsFragment[] => (JSON.parse(payload) as { parties: PartyFieldsFragment[] }).parties;
+
+const NORMALIZE_WARMUP = 1;
+const NORMALIZE_ITERATIONS = 3;
+const freshPool: PartyFieldsFragment[][] = [];
+for (let i = 0; i < NORMALIZE_WARMUP + NORMALIZE_ITERATIONS + 1; i++) {
+  freshPool.push(parseParties());
+}
+const takeFresh = (): PartyFieldsFragment[] => freshPool.pop() ?? parseParties();
+
+const normalized = await normalizeFlattenParties(parseParties());
+const graph = buildPartyGraph(normalized);
+const otherPeople = normalized.filter(
+  (party) => (party.partyType === 'Person' || party.partyType === 'SelfIdentified') && !party.isCurrentEndUser,
+);
+const organizations = normalized.filter((party) => party.partyType === 'Organization');
+const orgSkeleton = buildOrgSkeleton(organizations, graph);
+
+describe(`parties pipeline @ ${PARTY_COUNT} parties (${(payload.length / 1024 / 1024).toFixed(1)}MB payload)`, () => {
+  bench(
+    'JSON.parse of GraphQL payload',
+    () => {
+      parseParties();
+    },
+    { time: 0, iterations: 5, warmupIterations: 1, throws: true },
+  );
+
+  bench(
+    'normalizeFlattenParties',
+    async () => {
+      normalizeFlattenParties(takeFresh());
+    },
+    { time: 0, iterations: NORMALIZE_ITERATIONS, warmupIterations: NORMALIZE_WARMUP, throws: true },
+  );
+
+  bench(
+    'buildPartyGraph',
+    () => {
+      buildPartyGraph(normalized.slice());
+    },
+    { time: 0, iterations: 5, warmupIterations: 1, throws: true },
+  );
+
+  bench(
+    'buildPersonSkeleton (sort persons)',
+    () => {
+      buildPersonSkeleton(otherPeople);
+    },
+    { time: 0, iterations: 5, warmupIterations: 1, throws: true },
+  );
+
+  bench(
+    'buildOrgSkeleton (group + sort orgs)',
+    () => {
+      buildOrgSkeleton(organizations, graph);
+    },
+    { time: 0, iterations: 5, warmupIterations: 1, throws: true },
+  );
+
+  bench(
+    'materialize org PartyItemProps',
+    () => {
+      for (const item of orgSkeleton) {
+        mapOrgItemToAccount(item, { showDescription: true, t });
+      }
+    },
+    { time: 0, iterations: 5, warmupIterations: 1, throws: true },
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,8 +502,8 @@ importers:
   packages/frontend:
     dependencies:
       '@altinn/altinn-components':
-        specifier: 0.68.9
-        version: 0.68.9(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 0.68.15
+        version: 0.68.15(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@microsoft/applicationinsights-react-js':
         specifier: 19.3.7
         version: 19.3.7(history@4.10.1)(react@19.2.3)(tslib@2.8.1)
@@ -714,8 +714,8 @@ packages:
     resolution: {integrity: sha512-ZgxV2+5qt3NLeUYBTsi6PLyHcENQWC0iFppFZekHSEDA2wcLdTUjnaJzimTEULHIvJuLRCkUs4JABdhuJktEag==}
     engines: {node: '>= 14.0.0'}
 
-  '@altinn/altinn-components@0.68.9':
-    resolution: {integrity: sha512-29TfUNeKp3o+5tiyup4EQ07mO8LPRhqN05zJalycZn35gxyfGzBrMU9XvRI2a59gLeEtSdLQ1gg2mWx4b7XXKQ==}
+  '@altinn/altinn-components@0.68.15':
+    resolution: {integrity: sha512-NKGDF5f4bSNUsgI38qtHAmv7lyfidqTqlNPj0MjUBSaPiNv4WOiBHRpjKe1XiMFbM0aq+xCfGAajDSFvCofZgA==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
@@ -10548,7 +10548,7 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.48.0
 
-  '@altinn/altinn-components@0.68.9(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@altinn/altinn-components@0.68.15(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@digdir/designsystemet-css': 1.14.0
       '@digdir/designsystemet-react': 1.14.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
Propoal:

The header's useAccountSelector re-built every account menu item on each render because favoriteAccountUuids got a fresh array identity per render and is a dependency of the library's materialization memo. Memoize it and
handleSelectAccount in useHeaderConfig. Measured at 15k parties (CPU profile, Chromium dev): account switch 1.9s -> 1.1s wall.

- Extract the useAccounts skeleton and materialization logic into pure functions in accountComputations.ts (behavior unchanged, public API kept via re-exports) so benchmarks and tests exercise the real code.

Massive improvements. 

TODO: Waiting for latest version of altinn-components to be published.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4396

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
