### PR TITLE
chore(frontend): make inbox dialog list memoization actually hold

### DIFF
--- a/packages/frontend/src/api/hooks/useDialogs.tsx
+++ b/packages/frontend/src/api/hooks/useDialogs.tsx
@@ -208,7 +208,7 @@ export const useDialogs = ({
     previousPartyIdsRef.current = partyIds;
   }, [data, selectedParties]);
 
-  const content = data?.pages.flatMap((page) => page.searchDialogs?.items ?? []) || [];
+  const content = useMemo(() => data?.pages.flatMap((page) => page.searchDialogs?.items ?? []) ?? [], [data]);
   const lastPage = data?.pages?.[data?.pages.length - 1];
   const dialogCountInconclusive = isDialogCountInconclusive({
     partyIds,
@@ -216,7 +216,10 @@ export const useDialogs = ({
     itemsIsNull: lastPage?.searchDialogs?.items === null,
   });
   const orgMap = useMemo(() => buildOrganizationMap(organizations), [organizations]);
-  const dialogs = mapDialogToInboxItems(content, partyGraph, orgMap, format, disableFlipNamesPatch);
+  const dialogs = useMemo(
+    () => mapDialogToInboxItems(content, partyGraph, orgMap, format, disableFlipNamesPatch),
+    [content, partyGraph, orgMap, format, disableFlipNamesPatch],
+  );
   /*  isFetching && isPlaceholderData is used to determine if we are fetching the initial data for the query key */
   const isActuallyLoading = isLoading || (isFetching && isPlaceholderData);
 

--- a/packages/frontend/src/pages/DialogDetailsPage/useDialogActions.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/useDialogActions.tsx
@@ -13,6 +13,8 @@ import { useGlobalState } from '../../useGlobalState.ts';
 import { getNavigationOrigin } from '../../utils/viewType.ts';
 import { pruneSearchQueryParams } from '../Inbox/queryParams.ts';
 
+const EXCLUSIVE_LABELS = [SystemLabel.Default, SystemLabel.Archive, SystemLabel.Bin];
+
 export const useDialogActions = () => {
   const { t } = useTranslation();
   const { openSnackbar } = useSnackbar();
@@ -23,8 +25,6 @@ export const useDialogActions = () => {
   const [archiveLoading, setArchiveLoading] = useGlobalState<boolean>(QUERY_KEYS.SET_ARCHIVE_LABEL_LOADING, false);
   const [deleteLoading, setDeleteLoading] = useGlobalState<boolean>(QUERY_KEYS.SET_DELETE_LABEL_LOADING, false);
   const [undoLoading, setUndoLoading] = useGlobalState<boolean>(QUERY_KEYS.SET_UNDO_LABEL_LOADING, false);
-
-  const EXCLUSIVE_LABELS = [SystemLabel.Default, SystemLabel.Archive, SystemLabel.Bin];
 
   const handleUpdateLabel = useCallback(
     async (
@@ -61,96 +61,112 @@ export const useDialogActions = () => {
     [openSnackbar, t, queryClient],
   );
 
-  return (dialogId: string, currentLabels: SystemLabel[], isUnread: boolean): MenuItemProps[] => {
-    const currentLabel = (currentLabels || []).find((label) => EXCLUSIVE_LABELS.includes(label)) || SystemLabel.Default;
-    const items: MenuItemProps[] = [];
+  return useCallback(
+    (dialogId: string, currentLabels: SystemLabel[], isUnread: boolean): MenuItemProps[] => {
+      const currentLabel =
+        (currentLabels || []).find((label) => EXCLUSIVE_LABELS.includes(label)) || SystemLabel.Default;
+      const items: MenuItemProps[] = [];
 
-    if (dialogId && !isUnread) {
-      items.push({
-        id: 'mark-as-unread',
-        groupId: 'mark-as-unread',
-        icon: EyeClosedIcon,
-        title: t('dialog.toolbar.mark_as_unread'),
-        'aria-label': t('dialog.toolbar.mark_as_unread'),
-        as: 'button',
-        onClick: () => {
-          if (location.pathname.startsWith('/inbox/')) {
-            // Escape before a subscription of dialog cases a refetch and removes the label
-            const navigationOrigin = getNavigationOrigin(state);
-            navigate(navigationOrigin + pruneSearchQueryParams(search.toString()));
-          }
-          void handleUpdateLabel(
-            dialogId,
-            SystemLabel.MarkedAsUnopened,
-            'dialog.toolbar.toast.mark_as_unread_success',
-            'dialog.toolbar.toast.mark_as_unread_failed',
-            setDeleteLoading,
-          );
-        },
-        disabled: undoLoading,
-      });
-    }
+      if (dialogId && !isUnread) {
+        items.push({
+          id: 'mark-as-unread',
+          groupId: 'mark-as-unread',
+          icon: EyeClosedIcon,
+          title: t('dialog.toolbar.mark_as_unread'),
+          'aria-label': t('dialog.toolbar.mark_as_unread'),
+          as: 'button',
+          onClick: () => {
+            if (location.pathname.startsWith('/inbox/')) {
+              // Escape before a subscription of dialog cases a refetch and removes the label
+              const navigationOrigin = getNavigationOrigin(state);
+              navigate(navigationOrigin + pruneSearchQueryParams(search.toString()));
+            }
+            void handleUpdateLabel(
+              dialogId,
+              SystemLabel.MarkedAsUnopened,
+              'dialog.toolbar.toast.mark_as_unread_success',
+              'dialog.toolbar.toast.mark_as_unread_failed',
+              setDeleteLoading,
+            );
+          },
+          disabled: undoLoading,
+        });
+      }
 
-    if ([SystemLabel.Archive, SystemLabel.Bin].includes(currentLabel) && dialogId) {
-      items.push({
-        id: 'undo',
-        groupId: 'system-labels',
-        icon: InboxIcon,
-        title: t('dialog.toolbar.move_undo'),
-        'aria-label': t('dialog.toolbar.move_undo'),
-        as: 'button',
-        onClick: () =>
-          handleUpdateLabel(
-            dialogId,
-            SystemLabel.Default,
-            'dialog.toolbar.toast.move_to_inbox_success',
-            'dialog.toolbar.toast.move_to_inbox_failed',
-            setUndoLoading,
-          ),
-        disabled: archiveLoading,
-      });
-    }
+      if ([SystemLabel.Archive, SystemLabel.Bin].includes(currentLabel) && dialogId) {
+        items.push({
+          id: 'undo',
+          groupId: 'system-labels',
+          icon: InboxIcon,
+          title: t('dialog.toolbar.move_undo'),
+          'aria-label': t('dialog.toolbar.move_undo'),
+          as: 'button',
+          onClick: () =>
+            handleUpdateLabel(
+              dialogId,
+              SystemLabel.Default,
+              'dialog.toolbar.toast.move_to_inbox_success',
+              'dialog.toolbar.toast.move_to_inbox_failed',
+              setUndoLoading,
+            ),
+          disabled: archiveLoading,
+        });
+      }
 
-    if (currentLabel !== SystemLabel.Archive && dialogId) {
-      items.push({
-        id: 'archive',
-        groupId: 'system-labels',
-        icon: ArchiveIcon,
-        title: t('dialog.toolbar.move_to_archive'),
-        'aria-label': t('dialog.toolbar.move_to_archive'),
-        as: 'button',
-        onClick: () =>
-          handleUpdateLabel(
-            dialogId,
-            SystemLabel.Archive,
-            'dialog.toolbar.toast.move_to_archive_success',
-            'dialog.toolbar.toast.move_to_archive_failed',
-            setArchiveLoading,
-          ),
-        disabled: deleteLoading,
-      });
-    }
+      if (currentLabel !== SystemLabel.Archive && dialogId) {
+        items.push({
+          id: 'archive',
+          groupId: 'system-labels',
+          icon: ArchiveIcon,
+          title: t('dialog.toolbar.move_to_archive'),
+          'aria-label': t('dialog.toolbar.move_to_archive'),
+          as: 'button',
+          onClick: () =>
+            handleUpdateLabel(
+              dialogId,
+              SystemLabel.Archive,
+              'dialog.toolbar.toast.move_to_archive_success',
+              'dialog.toolbar.toast.move_to_archive_failed',
+              setArchiveLoading,
+            ),
+          disabled: deleteLoading,
+        });
+      }
 
-    if (currentLabel !== SystemLabel.Bin && dialogId) {
-      items.push({
-        id: 'delete',
-        groupId: 'system-labels',
-        icon: TrashIcon,
-        title: t('dialog.toolbar.move_to_bin'),
-        'aria-label': t('dialog.toolbar.move_to_bin'),
-        as: 'button',
-        onClick: () =>
-          handleUpdateLabel(
-            dialogId,
-            SystemLabel.Bin,
-            'dialog.toolbar.toast.move_to_bin_success',
-            'dialog.toolbar.toast.move_to_bin_failed',
-            setDeleteLoading,
-          ),
-        disabled: undoLoading,
-      });
-    }
+      if (currentLabel !== SystemLabel.Bin && dialogId) {
+        items.push({
+          id: 'delete',
+          groupId: 'system-labels',
+          icon: TrashIcon,
+          title: t('dialog.toolbar.move_to_bin'),
+          'aria-label': t('dialog.toolbar.move_to_bin'),
+          as: 'button',
+          onClick: () =>
+            handleUpdateLabel(
+              dialogId,
+              SystemLabel.Bin,
+              'dialog.toolbar.toast.move_to_bin_success',
+              'dialog.toolbar.toast.move_to_bin_failed',
+              setDeleteLoading,
+            ),
+          disabled: undoLoading,
+        });
+      }
 
-    return items;
-  };
+      return items;
+    },
+    [
+      t,
+      handleUpdateLabel,
+      archiveLoading,
+      deleteLoading,
+      undoLoading,
+      setArchiveLoading,
+      setDeleteLoading,
+      setUndoLoading,
+      navigate,
+      state,
+      search,
+    ],
+  );
 };

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.memo.spec.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.memo.spec.tsx
@@ -1,0 +1,112 @@
+import { QueryClient } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { DialogStatus } from 'bff-types-generated';
+import { SystemLabel } from 'bff-types-generated';
+import { useReducer } from 'react';
+import { useTranslation } from 'react-i18next';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCustomWrapper } from '../../../tests/test-utils.tsx';
+import type { InboxViewType } from '../../api/hooks/useDialogs.tsx';
+import { QUERY_KEYS } from '../../constants/queryKeys.ts';
+import { useFormat } from '../../i18n/useDateFnsLocale.tsx';
+import { useGlobalState } from '../../useGlobalState.ts';
+import type { InboxItemInput } from './InboxItemInput.ts';
+import useGroupedDialogs from './useGroupedDialogs.tsx';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: vi.fn(),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../i18n/useDateFnsLocale.tsx', () => ({
+  useFormat: vi.fn(),
+}));
+
+const makeItem = (id: string, contentUpdatedAt: string): InboxItemInput => ({
+  id,
+  party: 'urn:altinn:person:identifier-no:14886498226',
+  title: `Dialog ${id}`,
+  summary: 'summary',
+  sender: { name: 'Digitaliseringsdirektoratet', type: 'company' },
+  recipient: { name: 'Hjelpelinje Ordinær', type: 'person' },
+  isContentSeen: false,
+  unread: true,
+  seenSinceLastContentUpdate: [],
+  fromServiceOwnerTransmissionsCount: 0,
+  fromPartyTransmissionsCount: 0,
+  contentUpdatedAt,
+  guiAttachmentCount: 0,
+  createdAt: contentUpdatedAt,
+  status: 'NEW' as DialogStatus,
+  label: [SystemLabel.Default],
+  org: 'digdir',
+  seenByLabel: 'Sett av deg',
+  seenByOthersCount: 0,
+  viewType: 'inbox' as InboxViewType,
+  viewTypes: ['inbox'],
+  seenByLog: { collapsible: true, endUserLabel: 'Sett av deg', items: [] },
+});
+
+const items = [makeItem('dialog-1', '2025-02-24T14:00:21.642Z'), makeItem('dialog-2', '2025-02-24T13:55:45.689Z')];
+
+const onSeenByLogModalChange = () => {};
+const onAccessInfoModalChange = () => {};
+
+describe('useGroupedDialogs memoization', () => {
+  const t = vi.fn((key) => key);
+  const format = vi.fn((date) => date.toString());
+
+  beforeEach(() => {
+    (useTranslation as Mock).mockReturnValue({ t });
+    (useFormat as Mock).mockReturnValue(format);
+  });
+
+  it('keeps groupedDialogs identity across re-renders and recomputes on bulk selection', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(
+      () => {
+        const [, forceRender] = useReducer((n: number) => n + 1, 0);
+        const [bulkMode] = useGlobalState<boolean>(QUERY_KEYS.BULK_MODE, false);
+        const grouped = useGroupedDialogs({
+          items,
+          displaySearchResults: false,
+          viewType: 'inbox',
+          isLoading: false,
+          hasNextPage: false,
+          onSeenByLogModalChange,
+          onAccessInfoModalChange,
+          applicablePartyCount: 1,
+        });
+        return { grouped, forceRender, bulkMode };
+      },
+      { wrapper: createCustomWrapper(queryClient) },
+    );
+
+    const first = result.current.grouped.groupedDialogs;
+    act(() => {
+      result.current.forceRender();
+    });
+    expect(result.current.grouped.groupedDialogs).toBe(first);
+
+    act(() => {
+      queryClient.setQueryData([QUERY_KEYS.BULK_MODE], true);
+      queryClient.setQueryData([QUERY_KEYS.BULK_MODE_SELECTED_IDS], ['dialog-1']);
+    });
+
+    await waitFor(() => expect(result.current.bulkMode).toBe(true));
+    await waitFor(() => {
+      const afterSelection = result.current.grouped.groupedDialogs;
+      expect(afterSelection).not.toBe(first);
+      expect(afterSelection.find((d) => d.id === 'dialog-1')?.selected).toBe(true);
+      expect(afterSelection.find((d) => d.id === 'dialog-2')?.selected).toBe(false);
+    });
+
+    act(() => {
+      queryClient.setQueryData([QUERY_KEYS.BULK_MODE_SELECTED_IDS], ['dialog-1', 'dialog-2']);
+    });
+
+    await waitFor(() =>
+      expect(result.current.grouped.groupedDialogs.find((d) => d.id === 'dialog-2')?.selected).toBe(true),
+    );
+  });
+});

--- a/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
+++ b/packages/frontend/src/pages/Inbox/useGroupedDialogs.tsx
@@ -11,7 +11,7 @@ import { CheckmarkIcon, InformationSquareIcon } from '@navikt/aksel-icons';
 import { SystemLabel } from 'bff-types-generated';
 import type { TFunction } from 'i18next';
 import type { ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Trans } from 'react-i18next';
 import { Link, type LinkProps, useSearchParams } from 'react-router-dom';
@@ -133,9 +133,29 @@ const getDialogListDescription = ({
 
 const BANKRUPTCY_SERVICE_RESOURCE = 'urn:altinn:resource:app_brg_konkursbehandling';
 
-const sortGroupedDialogs = (arr: DialogListItemProps[]) => {
-  return arr.sort((a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime());
+const sortGroupedDialogs = (arr: DialogListItemProps[]): DialogListItemProps[] => {
+  return arr
+    .map((item) => ({ item, updatedAt: new Date(item.updatedAt ?? 0).getTime() }))
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map(({ item }) => item);
 };
+
+const getSearchTitle = (
+  t: TFunction,
+  viewType: InboxViewType,
+  count: number,
+  hasNextPage: boolean,
+  filterScope: FilterScope,
+) =>
+  (hasNextPage ? t('word.moreThan') : '') +
+  t(`inbox.heading.title.${viewType}`, { count }) +
+  (viewType !== 'archive' && viewType !== 'bin' && filterScope !== 'ALL'
+    ? t(`inbox.heading.scope.${filterScope}`)
+    : '');
+
+const DialogListItemLink = ({ href = '', ...props }: Omit<LinkProps, 'to'> & { href?: string }) => (
+  <Link state={{ fromView: location.pathname }} {...props} to={`${href}${location.search}`} />
+);
 
 const stripTitlelessSingleGroup = (
   groups: Record<string, DialogListGroupPropsSort>,
@@ -187,12 +207,6 @@ const useGroupedDialogs = ({
   const [bulkedIds, setBulkedIds] = useGlobalState<string[]>(QUERY_KEYS.BULK_MODE_SELECTED_IDS, []);
   const collapseGroups = !!displaySearchResults;
   const filterScope = (searchParams.get('systemLabel') || 'ALL') as FilterScope;
-  const getSearchTitle = (viewType: InboxViewType, count: number, hasNextPage: boolean, filterScope: FilterScope) =>
-    (hasNextPage ? t('word.moreThan') : '') +
-    t(`inbox.heading.title.${viewType}`, { count }) +
-    (viewType !== 'archive' && viewType !== 'bin' && filterScope !== 'ALL'
-      ? t(`inbox.heading.scope.${filterScope}`)
-      : '');
 
   const onScopeChange = (scope: FilterScope) => {
     if (!onFiltersChange || !filterState) return;
@@ -218,118 +232,131 @@ const useGroupedDialogs = ({
 
   const clockPrefix = t('word.clock_prefix');
   const formatString = `do MMMM yyyy ${clockPrefix ? `'${clockPrefix}' ` : ''}HH.mm`;
-  const allWithinSameYear = items.every((d) => new Date(d.contentUpdatedAt).getFullYear() === new Date().getFullYear());
   const useDateGrouping = !displaySearchResults;
 
-  const onToggleBulkId = (id: string) => {
-    if (bulkedIds?.includes(id)) {
-      const newBulkedIds = bulkedIds.filter((bulkedId) => bulkedId !== id);
-      setBulkedIds(newBulkedIds);
-      if (!newBulkedIds.length) {
-        setBulkMode(false);
+  const onToggleBulkId = useCallback(
+    (id: string) => {
+      if (bulkedIds?.includes(id)) {
+        const newBulkedIds = bulkedIds.filter((bulkedId) => bulkedId !== id);
+        setBulkedIds(newBulkedIds);
+        if (!newBulkedIds.length) {
+          setBulkMode(false);
+        }
+      } else {
+        setBulkedIds([...bulkedIds, id]);
       }
-    } else {
-      setBulkedIds([...bulkedIds, id]);
-    }
-  };
+    },
+    [bulkedIds, setBulkedIds, setBulkMode],
+  );
 
-  const formatDialogItem = (item: InboxItemInput, groupId: string): DialogListItemProps => {
-    const contextMenuId = 'dialog-context-menu-' + item.id;
-    const contextMenu: ContextMenuProps = {
-      id: contextMenuId,
-      placement: 'right',
-      color: item.recipient.type === 'person' ? 'person' : 'company',
-      items: [
-        {
-          id: 'select-multiple',
-          groupId: 'mark-as',
-          title: t('bulk_action.select_multiple'),
-          icon: CheckmarkIcon,
-          onClick: () => {
-            setBulkMode(true);
-            setBulkedIds([item.id]);
+  const formatDialogItem = useCallback(
+    (item: InboxItemInput, groupId: string): DialogListItemProps => {
+      const contextMenuId = 'dialog-context-menu-' + item.id;
+      const contextMenu: ContextMenuProps = {
+        id: contextMenuId,
+        placement: 'right',
+        color: item.recipient.type === 'person' ? 'person' : 'company',
+        items: [
+          {
+            id: 'select-multiple',
+            groupId: 'mark-as',
+            title: t('bulk_action.select_multiple'),
+            icon: CheckmarkIcon,
+            onClick: () => {
+              setBulkMode(true);
+              setBulkedIds([item.id]);
+            },
           },
-        },
-        ...(item ? systemLabelActions(item.id, item.label, item.unread) : []),
-        ...(item.seenByLabel
-          ? [
-              {
-                id: 'seenby-log',
-                groupId: 'logs',
-                title: item.seenByLabel,
-                icon: item.seenByLog,
-                onClick: () => {
-                  onSeenByLogModalChange({
-                    title: item.title,
-                    dialogId: item.id,
-                    items: item.seenByLog.items,
-                  });
+          ...(item ? systemLabelActions(item.id, item.label, item.unread) : []),
+          ...(item.seenByLabel
+            ? [
+                {
+                  id: 'seenby-log',
+                  groupId: 'logs',
+                  title: item.seenByLabel,
+                  icon: item.seenByLog,
+                  onClick: () => {
+                    onSeenByLogModalChange({
+                      title: item.title,
+                      dialogId: item.id,
+                      items: item.seenByLog.items,
+                    });
+                  },
                 },
-              },
-            ]
-          : []),
-        {
-          id: 'access-info',
-          groupId: 'logs',
-          title: t('dialog.access_info.menu_item'),
-          icon: InformationSquareIcon,
-          onClick: () => onAccessInfoModalChange({ dialogId: item.id, title: item.title }),
-        },
-      ].map((menuItem) => ({ ...menuItem, id: `${contextMenuId}-${menuItem.id}` })),
-      'aria-label': t('dialog.context_menu.label', { title: item.title }),
-    };
+              ]
+            : []),
+          {
+            id: 'access-info',
+            groupId: 'logs',
+            title: t('dialog.access_info.menu_item'),
+            icon: InformationSquareIcon,
+            onClick: () => onAccessInfoModalChange({ dialogId: item.id, title: item.title }),
+          },
+        ].map((menuItem) => ({ ...menuItem, id: `${contextMenuId}-${menuItem.id}` })),
+        'aria-label': t('dialog.context_menu.label', { title: item.title }),
+      };
 
-    const disabledBulkItem = bulkMode && bulkedIds.length >= MAX_COUNT_BULK_DIALOGS && !bulkedIds.includes(item.id);
+      const disabledBulkItem = bulkMode && bulkedIds.length >= MAX_COUNT_BULK_DIALOGS && !bulkedIds.includes(item.id);
 
-    return {
-      groupId,
-      title: item.title,
-      id: item.id,
-      recipientLabel: t('word.to'),
-      archivedAtLabel: item.viewType === 'archive' ? t(`status.archive`) : '',
-      trashedAtLabel: item.viewType === 'bin' ? t(`status.bin`) : '',
-      sender: item.sender,
-      summary: item.summary,
-      recipient: item.recipient,
-      color: item.recipient.type?.toLowerCase() as 'person' | 'company',
-      grouped: shouldGroup,
-      attachmentsCount: item.guiAttachmentCount,
-      seenByLog: item.seenByLog,
-      unread: item.unread,
-      unreadLabel: t('word.unread'),
-      unreadItemsLabel: t('word.unread_content'),
-      unreadItems: item.unreadItems,
-      selectable: bulkMode,
-      tabIndex: bulkMode ? 0 : undefined,
-      selected: bulkedIds?.includes(item.id),
-      controls: bulkMode ? (
-        <ItemSelect
-          checked={bulkedIds?.includes(item.id)}
-          onClick={() => onToggleBulkId(item.id)}
-          disabled={disabledBulkItem}
-        />
-      ) : (
-        <ContextMenu {...contextMenu} />
-      ),
-      status: getDialogStatus(item.status, t),
-      extendedStatusLabel: item.extendedStatus,
-      updatedAt: item.contentUpdatedAt,
-      updatedAtLabel: format(item.contentUpdatedAt, formatString),
-      dueAt: getDueAtProps(item.dueAt, item.status, t, (date) => format(date, formatString)),
-      sentCount: item.fromPartyTransmissionsCount ?? 0,
-      receivedCount: item.fromServiceOwnerTransmissionsCount ?? 0,
-      ariaLabel: item.title,
-      ...(bulkMode ? { onClick: () => onToggleBulkId(item.id) } : {}),
-      disabled: disabledBulkItem,
-      as: bulkMode
-        ? 'button'
-        : (props: LinkProps) => (
-            <Link state={{ fromView: location.pathname }} {...props} to={`/inbox/${item.id}/${location.search}`} />
-          ),
-    };
-  };
+      return {
+        groupId,
+        title: item.title,
+        id: item.id,
+        recipientLabel: t('word.to'),
+        archivedAtLabel: item.viewType === 'archive' ? t(`status.archive`) : '',
+        trashedAtLabel: item.viewType === 'bin' ? t(`status.bin`) : '',
+        sender: item.sender,
+        summary: item.summary,
+        recipient: item.recipient,
+        color: item.recipient.type?.toLowerCase() as 'person' | 'company',
+        grouped: shouldGroup,
+        attachmentsCount: item.guiAttachmentCount,
+        seenByLog: item.seenByLog,
+        unread: item.unread,
+        unreadLabel: t('word.unread'),
+        unreadItemsLabel: t('word.unread_content'),
+        unreadItems: item.unreadItems,
+        selectable: bulkMode,
+        tabIndex: bulkMode ? 0 : undefined,
+        selected: bulkedIds?.includes(item.id),
+        controls: bulkMode ? (
+          <ItemSelect
+            checked={bulkedIds?.includes(item.id)}
+            onClick={() => onToggleBulkId(item.id)}
+            disabled={disabledBulkItem}
+          />
+        ) : (
+          <ContextMenu {...contextMenu} />
+        ),
+        status: getDialogStatus(item.status, t),
+        extendedStatusLabel: item.extendedStatus,
+        updatedAt: item.contentUpdatedAt,
+        updatedAtLabel: format(item.contentUpdatedAt, formatString),
+        dueAt: getDueAtProps(item.dueAt, item.status, t, (date) => format(date, formatString)),
+        sentCount: item.fromPartyTransmissionsCount ?? 0,
+        receivedCount: item.fromServiceOwnerTransmissionsCount ?? 0,
+        ariaLabel: item.title,
+        ...(bulkMode ? { onClick: () => onToggleBulkId(item.id) } : { href: `/inbox/${item.id}/` }),
+        disabled: disabledBulkItem,
+        as: bulkMode ? 'button' : DialogListItemLink,
+      };
+    },
+    [
+      t,
+      format,
+      formatString,
+      shouldGroup,
+      bulkMode,
+      bulkedIds,
+      onToggleBulkId,
+      systemLabelActions,
+      onSeenByLogModalChange,
+      onAccessInfoModalChange,
+      setBulkMode,
+      setBulkedIds,
+    ],
+  );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: This hook does not specify all of its dependencies
   const grouped = useMemo((): UseGroupedDialogsOutput => {
     if (isLoading) {
       return {
@@ -369,14 +396,14 @@ const useGroupedDialogs = ({
       return {
         groupedDialogs,
         groups: stripTitlelessSingleGroup(groups),
-        title: getSearchTitle(viewType, items.length, hasNextPage, filterScope),
+        title: getSearchTitle(t, viewType, items.length, hasNextPage, filterScope),
       };
     }
 
     const groupedItems: GroupedItem[] = [];
     const bankruptcyDialogs = items.filter((item) => item.serviceResource === BANKRUPTCY_SERVICE_RESOURCE);
     const regularDialogs = items.filter((item) => item.serviceResource !== BANKRUPTCY_SERVICE_RESOURCE);
-    const title = getSearchTitle(viewType, regularDialogs.length, hasNextPage, filterScope);
+    const title = getSearchTitle(t, viewType, regularDialogs.length, hasNextPage, filterScope);
 
     if (bankruptcyDialogs.length > 0) {
       groupedItems.push({
@@ -395,7 +422,18 @@ const useGroupedDialogs = ({
         orderIndex: null,
       });
     } else {
-      regularDialogs.reduce((acc, item, _, list) => {
+      const currentYear = new Date().getFullYear();
+      const allWithinSameYear = items.every((item) => new Date(item.contentUpdatedAt).getFullYear() === currentYear);
+
+      const countByViewType = new Map<string, number>();
+      if (displaySearchResults) {
+        for (const item of regularDialogs) {
+          countByViewType.set(item.viewType, (countByViewType.get(item.viewType) ?? 0) + 1);
+        }
+      }
+
+      const groupsById = new Map(groupedItems.map((group) => [group.id, group]));
+      for (const item of regularDialogs) {
         const updatedAt = new Date(item.contentUpdatedAt);
         const month = format(updatedAt, 'LLLL');
         const capitalizedMonth = month.charAt(0).toUpperCase() + month.slice(1);
@@ -409,11 +447,11 @@ const useGroupedDialogs = ({
         const groupByDate = !displaySearchResults;
         const label = displaySearchResults
           ? t(`inbox.heading.search_results.${groupKey}`, {
-              count: list.filter((i) => i.viewType === groupKey).length,
+              count: countByViewType.get(groupKey) ?? 0,
             })
           : groupKey;
 
-        const existingGroup = acc.find((group) => group.id === groupKey);
+        const existingGroup = groupsById.get(groupKey);
 
         if (existingGroup) {
           existingGroup.items.push(item);
@@ -424,11 +462,11 @@ const useGroupedDialogs = ({
               ? updatedAt.getMonth()
               : updatedAt.getFullYear()
             : viewTypeIndex;
-          acc.push({ id: groupKey, title: label, description: '', items: [item], orderIndex });
+          const newGroup = { id: groupKey, title: label, description: '', items: [item], orderIndex };
+          groupsById.set(groupKey, newGroup);
+          groupedItems.push(newGroup);
         }
-
-        return acc;
-      }, groupedItems);
+      }
     }
 
     const groups = Object.fromEntries(
@@ -446,7 +484,20 @@ const useGroupedDialogs = ({
     }
 
     return { groupedDialogs, groups: stripTitlelessSingleGroup(groups), title };
-  }, [items, displaySearchResults, t, format, viewType, allWithinSameYear, isLoading, isFetchingNextPage]);
+  }, [
+    items,
+    displaySearchResults,
+    useDateGrouping,
+    collapseGroups,
+    t,
+    format,
+    formatDialogItem,
+    viewType,
+    isLoading,
+    isFetchingNextPage,
+    hasNextPage,
+    filterScope,
+  ]);
 
   return { ...grouped, description };
 };


### PR DESCRIPTION
Stable dialogs identity + full useGroupedDialogs memo deps, stable callbacks/link component so memoized rows stop remounting, cheaper grouping and sort.

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)
https://github.com/Altinn/dialogporten-frontend/issues/4311

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
