### PR TITLE
feat: return to the originating list after moving a dialog

### DIFF
--- a/packages/frontend/src/pages/DialogDetailsPage/useDialogActions.spec.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/useDialogActions.spec.tsx
@@ -1,8 +1,17 @@
 import { renderHook } from '@testing-library/react';
 import { SystemLabel } from 'bff-types-generated';
+import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageRoutes } from '../routes';
 import { useDialogActions } from './useDialogActions';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => navigateMock };
+});
 
 vi.mock('@altinn/altinn-components', () => ({
   useSnackbar: () => ({ openSnackbar: vi.fn() }),
@@ -69,5 +78,68 @@ describe('useDialogActions', () => {
     const actions = result.current('', [SystemLabel.Default], false);
 
     expect(actions).toEqual([]);
+  });
+
+  describe('navigation back to the originating list', () => {
+    const dialogId = 'abc123';
+    const search = '?party=urn%3Aaltinn%3Aperson&search=snø';
+
+    const renderOnDialogDetails = (fromView?: string) =>
+      renderHook(() => useDialogActions(), {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <MemoryRouter initialEntries={[{ pathname: `/inbox/${dialogId}`, search, state: { fromView } }]}>
+            {children}
+          </MemoryRouter>
+        ),
+      });
+
+    const clickAction = (actions: ReturnType<ReturnType<typeof useDialogActions>>, id: string) => {
+      const action = actions.find((item) => item.id === id);
+      expect(action).toBeDefined();
+      action!.onClick?.();
+    };
+
+    beforeEach(() => {
+      navigateMock.mockClear();
+    });
+
+    it.each([
+      ['archive', SystemLabel.Default],
+      ['delete', SystemLabel.Default],
+      ['mark-as-unread', SystemLabel.Default],
+    ])('navigates back to the originating view with scrollToId for "%s"', (actionId, label) => {
+      const { result } = renderOnDialogDetails(PageRoutes.sent);
+      clickAction(result.current(dialogId, [label], false), actionId);
+
+      expect(navigateMock).toHaveBeenCalledWith(PageRoutes.sent + search, { state: { scrollToId: dialogId } });
+    });
+
+    it('falls back to inbox when there is no originating view', () => {
+      const { result } = renderOnDialogDetails();
+      clickAction(result.current(dialogId, [SystemLabel.Default], false), 'archive');
+
+      expect(navigateMock).toHaveBeenCalledWith(PageRoutes.inbox + search, { state: { scrollToId: dialogId } });
+    });
+
+    it('navigates to inbox when undoing from the archive, not back to the archive', () => {
+      const { result } = renderOnDialogDetails(PageRoutes.archive);
+      clickAction(result.current(dialogId, [SystemLabel.Archive], false), 'undo');
+
+      expect(navigateMock).toHaveBeenCalledWith(PageRoutes.inbox + search, { state: { scrollToId: dialogId } });
+    });
+
+    it.each(['archive', 'delete', 'mark-as-unread'])(
+      'does not navigate for "%s" when triggered from the dialog list',
+      (actionId) => {
+        const { result } = renderHook(() => useDialogActions(), {
+          wrapper: ({ children }: { children: ReactNode }) => (
+            <MemoryRouter initialEntries={[{ pathname: PageRoutes.inbox, search }]}>{children}</MemoryRouter>
+          ),
+        });
+        clickAction(result.current(dialogId, [SystemLabel.Default], false), actionId);
+
+        expect(navigateMock).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/packages/frontend/src/pages/DialogDetailsPage/useDialogActions.tsx
+++ b/packages/frontend/src/pages/DialogDetailsPage/useDialogActions.tsx
@@ -11,15 +11,14 @@ import { updateSystemLabel } from '../../api/queries';
 import { QUERY_KEYS } from '../../constants/queryKeys';
 import { useGlobalState } from '../../useGlobalState.ts';
 import { getNavigationOrigin } from '../../utils/viewType.ts';
-import { pruneSearchQueryParams } from '../Inbox/queryParams.ts';
+import { PageRoutes } from '../routes.ts';
 
 const EXCLUSIVE_LABELS = [SystemLabel.Default, SystemLabel.Archive, SystemLabel.Bin];
 
 export const useDialogActions = () => {
   const { t } = useTranslation();
   const { openSnackbar } = useSnackbar();
-  const { state } = useLocation();
-  const { search } = useLocation();
+  const { state, search, pathname } = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [archiveLoading, setArchiveLoading] = useGlobalState<boolean>(QUERY_KEYS.SET_ARCHIVE_LABEL_LOADING, false);
@@ -61,6 +60,18 @@ export const useDialogActions = () => {
     [openSnackbar, t, queryClient],
   );
 
+  const isDialogDetailsPage = pathname.startsWith('/inbox/');
+
+  const returnToList = useCallback(
+    (dialogId: string, destination?: string) => {
+      if (!isDialogDetailsPage) {
+        return;
+      }
+      navigate((destination ?? getNavigationOrigin(state)) + search, { state: { scrollToId: dialogId } });
+    },
+    [isDialogDetailsPage, navigate, state, search],
+  );
+
   return useCallback(
     (dialogId: string, currentLabels: SystemLabel[], isUnread: boolean): MenuItemProps[] => {
       const currentLabel =
@@ -76,11 +87,8 @@ export const useDialogActions = () => {
           'aria-label': t('dialog.toolbar.mark_as_unread'),
           as: 'button',
           onClick: () => {
-            if (location.pathname.startsWith('/inbox/')) {
-              // Escape before a subscription of dialog cases a refetch and removes the label
-              const navigationOrigin = getNavigationOrigin(state);
-              navigate(navigationOrigin + pruneSearchQueryParams(search.toString()));
-            }
+            // Escape before a subscription of dialog cases a refetch and removes the label
+            returnToList(dialogId);
             void handleUpdateLabel(
               dialogId,
               SystemLabel.MarkedAsUnopened,
@@ -101,14 +109,16 @@ export const useDialogActions = () => {
           title: t('dialog.toolbar.move_undo'),
           'aria-label': t('dialog.toolbar.move_undo'),
           as: 'button',
-          onClick: () =>
-            handleUpdateLabel(
+          onClick: () => {
+            returnToList(dialogId, PageRoutes.inbox);
+            void handleUpdateLabel(
               dialogId,
               SystemLabel.Default,
               'dialog.toolbar.toast.move_to_inbox_success',
               'dialog.toolbar.toast.move_to_inbox_failed',
               setUndoLoading,
-            ),
+            );
+          },
           disabled: archiveLoading,
         });
       }
@@ -121,14 +131,16 @@ export const useDialogActions = () => {
           title: t('dialog.toolbar.move_to_archive'),
           'aria-label': t('dialog.toolbar.move_to_archive'),
           as: 'button',
-          onClick: () =>
-            handleUpdateLabel(
+          onClick: () => {
+            returnToList(dialogId);
+            void handleUpdateLabel(
               dialogId,
               SystemLabel.Archive,
               'dialog.toolbar.toast.move_to_archive_success',
               'dialog.toolbar.toast.move_to_archive_failed',
               setArchiveLoading,
-            ),
+            );
+          },
           disabled: deleteLoading,
         });
       }
@@ -141,14 +153,16 @@ export const useDialogActions = () => {
           title: t('dialog.toolbar.move_to_bin'),
           'aria-label': t('dialog.toolbar.move_to_bin'),
           as: 'button',
-          onClick: () =>
-            handleUpdateLabel(
+          onClick: () => {
+            returnToList(dialogId);
+            void handleUpdateLabel(
               dialogId,
               SystemLabel.Bin,
               'dialog.toolbar.toast.move_to_bin_success',
               'dialog.toolbar.toast.move_to_bin_failed',
               setDeleteLoading,
-            ),
+            );
+          },
           disabled: undoLoading,
         });
       }
@@ -164,9 +178,7 @@ export const useDialogActions = () => {
       setArchiveLoading,
       setDeleteLoading,
       setUndoLoading,
-      navigate,
-      state,
-      search,
+      returnToList,
     ],
   );
 };

--- a/packages/frontend/src/pages/Inbox/Inbox.tsx
+++ b/packages/frontend/src/pages/Inbox/Inbox.tsx
@@ -17,7 +17,7 @@ import {
   Typography,
 } from '@altinn/altinn-components';
 import { XMarkIcon } from '@navikt/aksel-icons';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { MAX_COUNT_BULK_DIALOGS, useBulkActions } from '../../api/hooks/useBulkActions.tsx';
@@ -68,6 +68,8 @@ export interface CurrentSeenByLog {
   items: SeenByLogItemProps[];
 }
 
+const MAX_SCROLL_TO_ITEM_ATTEMPTS = 5;
+
 export const Inbox = ({ viewType }: InboxProps) => {
   useMockError();
   const { t } = useTranslation();
@@ -88,6 +90,7 @@ export const Inbox = ({ viewType }: InboxProps) => {
   const [bulkMode, setBulkMode] = useGlobalState<boolean>(QUERY_KEYS.BULK_MODE, false);
   const [bulkedIds, setBulkedIds] = useGlobalState<string[]>(QUERY_KEYS.BULK_MODE_SELECTED_IDS, []);
   const location = useLocation();
+  const scrolledToItem = useRef<string | undefined>(undefined);
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentSeenByLogModal, setCurrentSeenByLogModal] = useState<CurrentSeenByLog | null>(null);
   const [accessInfoModal, setAccessInfoModal] = useState<{ dialogId: string; title: string } | null>(null);
@@ -246,16 +249,31 @@ export const Inbox = ({ viewType }: InboxProps) => {
 
   const isLoading = isLoadingParties || isLoadingDialogs;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: This hook does not specify all of its dependencies
+  const scrollToId: string | undefined = location?.state?.scrollToId;
+
   useEffect(() => {
-    const scrollToId = location?.state?.scrollToId;
-    const listElToScroll = document.getElementById(scrollToId);
-    if (!isLoading) {
-      if (listElToScroll) {
-        listElToScroll.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
+    if (isLoading || !scrollToId || scrolledToItem.current === scrollToId) {
+      return;
     }
-  }, [isLoading]);
+
+    let attempt = 0;
+    let frameId = 0;
+
+    const scrollToItem = () => {
+      const listElToScroll = document.getElementById(scrollToId);
+      if (listElToScroll) {
+        scrolledToItem.current = scrollToId;
+        listElToScroll.scrollIntoView({ behavior: 'instant', block: 'center' });
+        return;
+      }
+      if (attempt++ < MAX_SCROLL_TO_ITEM_ATTEMPTS) {
+        frameId = requestAnimationFrame(scrollToItem);
+      }
+    };
+
+    scrollToItem();
+    return () => cancelAnimationFrame(frameId);
+  }, [isLoading, scrollToId]);
 
   const { groupedDialogs, groups, title, description } = useGroupedDialogs({
     onSeenByLogModalChange: setCurrentSeenByLogModal,

--- a/packages/frontend/tests/stories/contextMenuBinArchive.spec.ts
+++ b/packages/frontend/tests/stories/contextMenuBinArchive.spec.ts
@@ -1,7 +1,16 @@
+import type { Page } from '@playwright/test';
 import { PageRoutes } from '../../src/pages/routes';
-import { defaultAppURL } from '../';
+import { appURLSent, appUrlWithPlaywrightId, defaultAppURL } from '../';
 import { expect, test } from '../fixtures';
 import { getSidebarMenuItem, openContextMenuForDialog } from './common';
+
+const clickDialogAction = (page: Page, name: RegExp) =>
+  page.getByRole('button', { name }).or(page.getByRole('menuitem', { name })).click();
+
+const openDialog = async (page: Page, link: ReturnType<Page['getByRole']>) => {
+  await link.click();
+  await page.waitForURL((url) => url.pathname.startsWith('/inbox/'));
+};
 
 test.describe('Move dialogs between archive and bin', () => {
   test('Move to bin and archive', async ({ page }) => {
@@ -25,5 +34,65 @@ test.describe('Move dialogs between archive and bin', () => {
     await binLink.click();
 
     await expect(page.getByRole('heading', { name: title }).first()).toBeVisible();
+  });
+});
+
+test.describe('Returning to the originating list after moving a dialog', () => {
+  test('Moving to archive from the dialog details returns to the inbox', async ({ page }) => {
+    await page.goto(defaultAppURL);
+    await page.waitForLoadState('networkidle');
+
+    const title = 'Melding om bortkjøring av snø';
+    await openDialog(page, page.getByRole('link', { name: title }).first());
+
+    await clickDialogAction(page, /flytt til arkivet/i);
+
+    await page.waitForURL((url) => url.pathname === PageRoutes.inbox);
+    await expect(page.getByText(/flyttet til arkivet/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: title })).toHaveCount(0);
+  });
+
+  test('Moving to archive from a dialog opened in Sent returns to Sent', async ({ page }) => {
+    await page.goto(appURLSent);
+    await page.waitForLoadState('networkidle');
+
+    const title = 'Melding om hull i veien';
+    await openDialog(page, page.getByRole('link', { name: title }).first());
+
+    await clickDialogAction(page, /flytt til arkivet/i);
+
+    await page.waitForURL((url) => url.pathname === PageRoutes.sent);
+    await expect(page.getByText(/flyttet til arkivet/i)).toBeVisible();
+  });
+
+  test('Moving to bin from the dialog details returns to the inbox', async ({ page }) => {
+    await page.goto(defaultAppURL);
+    await page.waitForLoadState('networkidle');
+
+    const title = 'Melding om bortkjøring av snø';
+    await openDialog(page, page.getByRole('link', { name: title }).first());
+
+    await clickDialogAction(page, /flytt til papirkurven/i);
+
+    await page.waitForURL((url) => url.pathname === PageRoutes.inbox);
+    await expect(page.getByText(/flyttet til papirkurven/i)).toBeVisible();
+    await expect(page.getByRole('link', { name: title })).toHaveCount(0);
+  });
+
+  test('Marking as unread returns to the list and scrolls back to the dialog', async ({ page }) => {
+    await page.goto(appUrlWithPlaywrightId('dialogs-bulk'));
+    await page.waitForLoadState('networkidle');
+
+    const readDialogs = page.locator('li[id^="019241f7-bulk-"][data-unread="false"]');
+    const target = readDialogs.nth(20);
+    const dialogId = await target.getAttribute('id');
+    await expect(target).not.toBeInViewport();
+
+    await openDialog(page, target.getByRole('link').first());
+
+    await clickDialogAction(page, /marker som ulest/i);
+
+    await page.waitForURL((url) => url.pathname === PageRoutes.inbox);
+    await expect(page.locator(`[id="${dialogId}"]`)).toBeInViewport();
   });
 });


### PR DESCRIPTION
- Moving a dialog to archive or bin from the dialog details page left the user sitting in the dialog, requiring an extra click to get back. Undo (move back to inbox) follows the same logic and navigates to the inbox.
- Scroll to dialog item in list view when marking a dialog as unread 


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

https://github.com/Altinn/dialogporten-frontend/issues/3499
https://github.com/Altinn/dialogporten-frontend/issues/4149

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
