### PR TITLE
fix(bff): avoid duplicate key error when creating profile concurrently

### DIFF
--- a/packages/bff/src/graphql/profile/service.ts
+++ b/packages/bff/src/graphql/profile/service.ts
@@ -19,23 +19,20 @@ export const getOrCreateProfile = async (context: Context): Promise<ProfileTable
     throw new Error('PID is required to get or create a profile');
   }
 
-  const profile = await ProfileRepository!.createQueryBuilder('profile').where('profile.pid = :pid', { pid }).getOne();
-  const token = getSessionToken(context);
-  const groups = token ? await getFavoritesFromCore(token.access_token) : [];
+  let profile = await ProfileRepository!.createQueryBuilder('profile').where('profile.pid = :pid', { pid }).getOne();
 
   if (!profile) {
-    const newProfile = new ProfileTable();
-    newProfile.pid = pid;
-    newProfile.groups = [];
+    await ProfileRepository!.createQueryBuilder().insert().into(ProfileTable).values({ pid }).orIgnore().execute();
 
-    const savedProfile = await ProfileRepository!.save(newProfile);
-    if (!savedProfile) {
+    profile = await ProfileRepository!.findOne({ where: { pid } });
+    if (!profile) {
       throw new Error('Fatal: Not able to create new profile');
     }
-    return savedProfile;
   }
 
-  profile.groups = groups;
+  const token = getSessionToken(context);
+  profile.groups = token ? await getFavoritesFromCore(token.access_token) : [];
+
   return profile;
 };
 


### PR DESCRIPTION
We've had a couple of too many `Error: duplicate key value violates unique constraint` when fetching profile. 

Insert with`ON CONFLICT DO NOTHING` and read the row back, and move the insert ahead of the external call so the window is negligible. Also assigns the fetched groups to newly created profiles, which previously got a hardcoded empty list.


## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
