### PR TITLE
fix(profile): saved search improvements

### DIFF
--- a/packages/bff/src/graphql/profile/queries.ts
+++ b/packages/bff/src/graphql/profile/queries.ts
@@ -1,7 +1,8 @@
 import { extendType } from 'nexus';
+import { getSessionToken } from '../../auth/oidc.js';
 import config from '../../config.js';
 import { getLanguageFromAltinnContext, languageCodes, updateAltinnPersistentContextValue } from './languageCookie.ts';
-import { getOrCreateProfile, getUserFromCore } from './service.ts';
+import { getFavoritesFromCore, getOrCreateProfile, getUserFromCore } from './service.ts';
 
 export const ProfileQuery = extendType({
   type: 'Query',
@@ -9,9 +10,13 @@ export const ProfileQuery = extendType({
     t.field('profile', {
       type: 'Profile',
       resolve: async (_source, _args, ctx) => {
-        const profile = await getOrCreateProfile(ctx);
-        const user = await getUserFromCore(ctx);
-        const { groups, updatedAt } = profile;
+        const token = getSessionToken(ctx);
+        const [profile, user, groups] = await Promise.all([
+          getOrCreateProfile(ctx),
+          getUserFromCore(ctx),
+          token ? getFavoritesFromCore(token.access_token) : [],
+        ]);
+        const { updatedAt } = profile;
 
         const currentCookieLang = getLanguageFromAltinnContext(ctx.request.raw.cookies?.altinnPersistentContext);
 

--- a/packages/bff/src/graphql/profile/service.ts
+++ b/packages/bff/src/graphql/profile/service.ts
@@ -11,13 +11,27 @@ const platformProfileAPI_url = platformBaseURL + '/profile/api/v1/';
 
 export type PreselectedPartyOperationType = 'set' | 'unset';
 
-export const getOrCreateProfile = async (context: Context): Promise<ProfileTable> => {
+const getPidOrThrow = (context: Context): string => {
   const pid = typeof context.session.get('pid') === 'string' ? (context.session.get('pid') as string) : '';
 
   if (!pid) {
     logger.error('No pid provided');
     throw new Error('PID is required to get or create a profile');
   }
+
+  return pid;
+};
+
+export const ensureProfile = async (context: Context): Promise<string> => {
+  const pid = getPidOrThrow(context);
+
+  await ProfileRepository!.createQueryBuilder().insert().into(ProfileTable).values({ pid }).orIgnore().execute();
+
+  return pid;
+};
+
+export const getOrCreateProfile = async (context: Context): Promise<ProfileTable> => {
+  const pid = getPidOrThrow(context);
 
   let profile = await ProfileRepository!.createQueryBuilder('profile').where('profile.pid = :pid', { pid }).getOne();
 
@@ -29,9 +43,6 @@ export const getOrCreateProfile = async (context: Context): Promise<ProfileTable
       throw new Error('Fatal: Not able to create new profile');
     }
   }
-
-  const token = getSessionToken(context);
-  profile.groups = token ? await getFavoritesFromCore(token.access_token) : [];
 
   return profile;
 };

--- a/packages/bff/src/graphql/savedSearches/mutations.ts
+++ b/packages/bff/src/graphql/savedSearches/mutations.ts
@@ -1,7 +1,7 @@
 import { logger } from '@altinn/dialogporten-node-logger';
 import { extendType, intArg, nonNull, stringArg } from 'nexus';
 import { decryptPersonUrn } from '../../party/personUrnCipher.ts';
-import { getOrCreateProfile } from '../profile/service.ts';
+import { ensureProfile } from '../profile/service.ts';
 import { Response } from '../shared/types.ts';
 import { createSavedSearch, deleteSavedSearch, updateSavedSearch } from './service.ts';
 import { SavedSearches, SavedSearchInput } from './types.ts';
@@ -62,10 +62,7 @@ export const CreateSavedSearch = extendType({
       },
       resolve: async (_, { name, data }, ctx) => {
         try {
-          const profile = await getOrCreateProfile(ctx);
-          if (!profile) {
-            throw new Error('Profile not found or could not be created');
-          }
+          const pid = await ensureProfile(ctx);
           if (!data) {
             throw new Error('Data are required to create a saved search');
           }
@@ -73,7 +70,7 @@ export const CreateSavedSearch = extendType({
             ...data,
             urn: Array.isArray(data.urn) ? data.urn.map((u: string) => decryptPersonUrn(u) as string) : data.urn,
           };
-          return await createSavedSearch({ name, data: resolvedData, profile });
+          return await createSavedSearch({ name, data: resolvedData, pid });
         } catch (error) {
           logger.error(error, 'Failed to create saved search:');
           return error;

--- a/packages/bff/src/graphql/savedSearches/service.ts
+++ b/packages/bff/src/graphql/savedSearches/service.ts
@@ -4,7 +4,7 @@ import { type ProfileTable, SavedSearch, type SavedSearchData } from '../../enti
 interface CreateSavedSearch {
   name: string;
   data: SavedSearchData;
-  profile: ProfileTable;
+  pid: string;
 }
 
 export const listSavedSearches = async (pid: string | undefined) => {
@@ -18,11 +18,11 @@ export const listSavedSearches = async (pid: string | undefined) => {
     .getMany();
 };
 
-export const createSavedSearch = async ({ name, data, profile }: CreateSavedSearch) => {
+export const createSavedSearch = async ({ name, data, pid }: CreateSavedSearch) => {
   const newSavedSearch = new SavedSearch();
   newSavedSearch.name = name;
   newSavedSearch.data = data;
-  newSavedSearch.profile = profile;
+  newSavedSearch.profile = { pid } as ProfileTable;
   return await SavedSearchRepository!.save(newSavedSearch);
 };
 

--- a/packages/bff/tests/integration/savedSearches.spec.ts
+++ b/packages/bff/tests/integration/savedSearches.spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { initRepositories } from '../../src/db.ts';
 import { Group, Party, ProfileTable, SavedSearch, type SavedSearchData } from '../../src/entities.ts';
+import { ensureProfile } from '../../src/graphql/profile/service.ts';
 import {
   createSavedSearch,
   deleteSavedSearch,
@@ -24,6 +25,9 @@ const createProfile = async (pid: string) => {
   profile.groups = [];
   return await dataSource.getRepository(ProfileTable).save(profile);
 };
+
+const contextForPid = (pid: string) =>
+  ({ session: { get: () => pid } }) as unknown as Parameters<typeof ensureProfile>[0];
 
 const searchData: SavedSearchData = {
   searchString: 'skatt',
@@ -76,9 +80,21 @@ describe('savedSearches against a real database', () => {
     ]);
   });
 
+  it('creates the profile row on demand, so a first saved search needs no existing profile', async () => {
+    const context = contextForPid('pid-new');
+
+    expect(await ensureProfile(context)).toBe('pid-new');
+    expect(await ensureProfile(context)).toBe('pid-new');
+    expect(await dataSource.getRepository(ProfileTable).find({ where: { pid: 'pid-new' } })).toHaveLength(1);
+
+    const created = await createSavedSearch({ name: 'Uten profil', data: searchData, pid: 'pid-new' });
+    expect(created.id).toBeGreaterThan(0);
+    expect(await listSavedSearches('pid-new')).toHaveLength(1);
+  });
+
   it('round-trips a saved search with its JSON data intact', async () => {
-    const profile = await createProfile('pid-1');
-    const created = await createSavedSearch({ name: 'Mine krav', data: searchData, profile });
+    await createProfile('pid-1');
+    const created = await createSavedSearch({ name: 'Mine krav', data: searchData, pid: 'pid-1' });
 
     expect(created.id).toBeGreaterThan(0);
 
@@ -90,10 +106,10 @@ describe('savedSearches against a real database', () => {
   });
 
   it('lists only searches belonging to the given profile', async () => {
-    const profileA = await createProfile('pid-a');
-    const profileB = await createProfile('pid-b');
-    await createSavedSearch({ name: 'A sin', data: searchData, profile: profileA });
-    await createSavedSearch({ name: 'B sin', data: searchData, profile: profileB });
+    await createProfile('pid-a');
+    await createProfile('pid-b');
+    await createSavedSearch({ name: 'A sin', data: searchData, pid: 'pid-a' });
+    await createSavedSearch({ name: 'B sin', data: searchData, pid: 'pid-b' });
 
     const searchesA = await listSavedSearches('pid-a');
     expect(searchesA.map((s) => s.name)).toEqual(['A sin']);
@@ -104,10 +120,10 @@ describe('savedSearches against a real database', () => {
 
   it('orders named searches alphabetically before unnamed ones', async () => {
     const profile = await createProfile('pid-1');
-    await createSavedSearch({ name: '', data: searchData, profile });
-    await createSavedSearch({ name: 'b-navn', data: searchData, profile });
+    await createSavedSearch({ name: '', data: searchData, pid: 'pid-1' });
+    await createSavedSearch({ name: 'b-navn', data: searchData, pid: 'pid-1' });
     await dataSource.getRepository(SavedSearch).insert({ data: searchData, profile });
-    await createSavedSearch({ name: 'a-navn', data: searchData, profile });
+    await createSavedSearch({ name: 'a-navn', data: searchData, pid: 'pid-1' });
 
     const searches = await listSavedSearches('pid-1');
     expect(searches.map((s) => s.name).slice(0, 2)).toEqual(['a-navn', 'b-navn']);
@@ -115,8 +131,8 @@ describe('savedSearches against a real database', () => {
   });
 
   it('updates the name of a saved search', async () => {
-    const profile = await createProfile('pid-1');
-    const created = await createSavedSearch({ name: 'Gammelt navn', data: searchData, profile });
+    await createProfile('pid-1');
+    const created = await createSavedSearch({ name: 'Gammelt navn', data: searchData, pid: 'pid-1' });
 
     const result = await updateSavedSearch(created.id, 'Nytt navn');
     expect(result.affected).toBe(1);
@@ -126,8 +142,8 @@ describe('savedSearches against a real database', () => {
   });
 
   it('deletes a saved search and reports affected rows', async () => {
-    const profile = await createProfile('pid-1');
-    const created = await createSavedSearch({ name: 'Slett meg', data: searchData, profile });
+    await createProfile('pid-1');
+    const created = await createSavedSearch({ name: 'Slett meg', data: searchData, pid: 'pid-1' });
 
     const result = await deleteSavedSearch(created.id);
     expect(result.affected).toBe(1);

--- a/packages/frontend/src/pages/Profile/useSettings.spec.tsx
+++ b/packages/frontend/src/pages/Profile/useSettings.spec.tsx
@@ -51,7 +51,7 @@ vi.mock('../Inbox/queryParams.ts', () => ({
 }));
 
 vi.mock('../SavedSearches/useSavedSearches.tsx', () => ({
-  useSavedSearches: vi.fn(() => ({ savedSearches: [] })),
+  useSavedSearchesCount: vi.fn(() => 0),
 }));
 
 vi.mock('./usePartiesWithNotificationSettings.ts', () => ({

--- a/packages/frontend/src/pages/Profile/useSettings.tsx
+++ b/packages/frontend/src/pages/Profile/useSettings.tsx
@@ -39,7 +39,7 @@ import { useFeatureFlag } from '../../featureFlags/useFeatureFlag.ts';
 import { useErrorLogger } from '../../hooks/useErrorLogger';
 import { pruneSearchQueryParams } from '../Inbox/queryParams.ts';
 import { PageRoutes } from '../routes.ts';
-import { useSavedSearches } from '../SavedSearches/useSavedSearches.tsx';
+import { useSavedSearchesCount } from '../SavedSearches/useSavedSearches.tsx';
 import { AccountAlertsChannelDetails } from './AccountAlerts/AccountAlertsChannelDetails.tsx';
 import type { Channel } from './AccountAlerts/common.ts';
 import { ServiceResourceNotificationsDetails } from './AccountAlerts/ServiceResourceNotificationsDetails.tsx';
@@ -159,10 +159,19 @@ export const useSettings = ({ options: inputOptions = {}, isLoading }: UseSettin
   } = useProfile();
   const { openSnackbar } = useSnackbar();
   const { logError } = useErrorLogger();
-  const { savedSearches } = useSavedSearches(selectedPartyIds);
   const { search: currentSearchQuery } = useLocation();
 
   const { t } = useTranslation();
+
+  const options = { ...getDefaultOptions(t), ...inputOptions };
+
+  const groupIncluded = (groupId: SettingsType): boolean => {
+    if (options.includeGroups?.length) return options.includeGroups.includes(groupId);
+    if (options.excludeGroups?.length) return !options.excludeGroups.includes(groupId);
+    return true;
+  };
+
+  const savedSearchesCount = useSavedSearchesCount(selectedPartyIds, groupIncluded(SettingsType.inboxShortcuts));
   const [searchString, setSearchString] = useState<string>('');
   const [selectedLanguage, setSelectedLanguage] = useState<string>(i18n.language);
   const { partiesWithNotificationSettings, uniqueEmailAddresses, uniquePhoneNumbers } =
@@ -251,8 +260,6 @@ export const useSettings = ({ options: inputOptions = {}, isLoading }: UseSettin
     );
   };
 
-  const options = { ...getDefaultOptions(t), ...inputOptions };
-
   const { accounts, accountGroups } = useAccounts({
     isLoading: isLoadingParties,
     parties,
@@ -273,12 +280,6 @@ export const useSettings = ({ options: inputOptions = {}, isLoading }: UseSettin
     () => new Map(partiesWithNotificationSettings.map((p) => [p.party, p])),
     [partiesWithNotificationSettings],
   );
-
-  const groupIncluded = (groupId: SettingsType): boolean => {
-    if (options.includeGroups?.length) return options.includeGroups.includes(groupId);
-    if (options.excludeGroups?.length) return !options.excludeGroups.includes(groupId);
-    return true;
-  };
 
   const settingsSearch = {
     name: 'settings-search',
@@ -716,7 +717,7 @@ export const useSettings = ({ options: inputOptions = {}, isLoading }: UseSettin
       linkIcon: true,
       icon: MagnifyingGlassIcon,
       badge: {
-        label: t('profile.saved_searches', { count: savedSearches.length }),
+        label: t('profile.saved_searches', { count: savedSearchesCount }),
       },
       summary: <p>{t('profile.settings.saved_searches_summary')}</p>,
     },

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
@@ -127,9 +127,6 @@ const savedSearchesQueryOptions = (selectedPartyIds?: string[], enabled = true) 
   enabled: enabled && !!selectedPartyIds && selectedPartyIds.length > 0,
 });
 
-/**
- * Count-only view of the user's saved searches.
- */
 export const useSavedSearchesCount = (selectedPartyIds?: string[], enabled = true): number => {
   const { data } = useAuthenticatedQuery<SavedSearchesQuery>(savedSearchesQueryOptions(selectedPartyIds, enabled));
   return data?.savedSearches?.length ?? 0;

--- a/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
+++ b/packages/frontend/src/pages/SavedSearches/useSavedSearches.tsx
@@ -119,6 +119,22 @@ export const filterSavedSearches = (
   });
 };
 
+const savedSearchesQueryOptions = (selectedPartyIds?: string[], enabled = true) => ({
+  queryKey: [QUERY_KEYS.SAVED_SEARCHES, selectedPartyIds],
+  queryFn: fetchSavedSearches,
+  retry: 3,
+  staleTime: 1000 * 60 * 20,
+  enabled: enabled && !!selectedPartyIds && selectedPartyIds.length > 0,
+});
+
+/**
+ * Count-only view of the user's saved searches.
+ */
+export const useSavedSearchesCount = (selectedPartyIds?: string[], enabled = true): number => {
+  const { data } = useAuthenticatedQuery<SavedSearchesQuery>(savedSearchesQueryOptions(selectedPartyIds, enabled));
+  return data?.savedSearches?.length ?? 0;
+};
+
 export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesOutput => {
   const [isCTALoading, setIsCTALoading] = useState<boolean>(false);
   const [openedSavedSearch, setOpenedSavedSearch] = useState<string | null>(null);
@@ -134,13 +150,9 @@ export const useSavedSearches = (selectedPartyIds?: string[]): UseSavedSearchesO
   const { openSnackbar } = useSnackbar();
   const { logError } = useErrorLogger();
 
-  const { data, isLoading, isSuccess } = useAuthenticatedQuery<SavedSearchesQuery>({
-    queryKey: [QUERY_KEYS.SAVED_SEARCHES, selectedPartyIds],
-    queryFn: fetchSavedSearches,
-    retry: 3,
-    staleTime: 1000 * 60 * 20,
-    enabled: !!selectedPartyIds && selectedPartyIds?.length > 0,
-  });
+  const { data, isLoading, isSuccess } = useAuthenticatedQuery<SavedSearchesQuery>(
+    savedSearchesQueryOptions(selectedPartyIds),
+  );
 
   const endUsersSavedSearches = (data?.savedSearches ?? []) as SavedSearchesFieldsFragment[];
   const currentPartySavedSearches = filterSavedSearches(endUsersSavedSearches, selectedPartyIds || []);


### PR DESCRIPTION
Improvements:

1. The profile resolver fetched the DB row, then the user from Altinn, then favourites (form Core) sequentially instead in parallell with `Promise.all`. 

2. Remove unneccessary fetch of profile while Saving a search:

`getOrCreateProfile` did two unrelated things: look up the profile row in our DB and fetch favourites from Core. Saving a search only needs the profile's `pid` to set the foreign key, so it was paying for a favourites call it threw away, plus a row read it didn't use.

Split into `ensureProfile`, which just guarantees the row exists (`INSERT … ON CONFLICT DO NOTHING`) and returns the pid. The row still has to exist, `saved_search.profilePid` has a foreign key to `profile.pid`, but nothing needs to be read. The stored row is identical.

3. Split saved searches count as a separate selector

## Hva er endret?
<!--- Gi en mer detaljert beskrivelse av hva endringene dine innebærer ved behov, med eventuelle marknader -->

## Related Issue(s)

- #{issue number}

### Dokumentasjon / testdekning
<!--- Oppgi om du har lagt til eller oppdatert dokumentasjonen som er relevant for endringene. Enten i Readme eller i Docosauros på `./packages/docs/docs` -->

- [ ] Dokumentasjon er oppdatert eller ikke relevant / nødvendig.
- [ ] Det er blitt lagt til nye tester / eksiterende tester er blitt utvidet, eller tester er ikke relevant.

### Skjermbilder eller GIFs (valgfritt)
<!--- Det er alltid nyttig å inkludere skjermbilder eller GIFs for å vise frem endringene visuelt, spesielt for UI-relaterte endringer. -->
